### PR TITLE
🔧 Improve typing

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9.9'
+          python-version: '3.9'
 
       - name: Install poetry
         env:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -42,6 +42,9 @@ jobs:
       - name: mypy
         run: poetry run mypy --config-file mypy.ini .
 
+      - name: test annotations
+        run: poetry run mypy --config-file mypy.ini tests/annotation_tests.py
+
       - name: black
         run: poetry run isort --check .
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -268,7 +268,7 @@ class Commands(BaseCommands, ABC):
     ) -> Union["_Default", "_T"]:
         ...
 
-    def query_first_or_default(self, sql, default, model=dict, param: Any = None):
+    def query_first_or_default(self, sql, default, model=dict, param=None):
         try:
             return self.query_first(sql, model=model, param=param)
         except NoResultException:
@@ -417,7 +417,7 @@ class CommandsAsync(BaseCommands, ABC):
     ) -> AsyncGenerator["_T", None]:
         ...
 
-    async def query_async(self, sql: str, model=dict, param=None, buffered=True):
+    async def query_async(self, sql, model=dict, param=None, buffered=True):
         handler = self.SqlParamHandler(sql, param)
         if buffered:
             records = await self._buffered_query(handler, model)

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -157,36 +157,34 @@ class Commands(BaseCommands, ABC):
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
 
-    # region query
-    @overload  # specify model and unbuffered
+    @overload
     def query(
-        self, sql: str, param: ParamType = None, *, model: "_T", buffered: Literal[False]
+        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., buffered: Literal[True] = True
+    ) -> List[Dict[str, Any]]:
+        ...
+
+    @overload
+    def query(
+        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: Literal[False]
+    ) -> typing.Generator[Dict[str, Any], None, None]:
+        ...
+
+    @overload
+    def query(
+        self, sql: str, param: Optional["ParamType"] = ..., buffered: Literal[True] = True, *, model: Type["_T"]
+    ) -> List["_T"]:
+        ...
+
+    @overload
+    def query(
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: Literal[False]
     ) -> Generator["_T", None, None]:
         ...
 
-    @overload  # specify model and buffered
-    def query(
-        self, sql: str, param: ParamType = None, *, model: "_T", buffered: Literal[True]
-    ) -> List["_T", None, None]:
-        ...
-
-    @overload  # specify model with default for buffered
-    def query(
-        self,
-        sql: str,
-        param: ParamType = None,
-        *,
-        model: "_T",
-    ) -> Generator["_T", None, None]:
-        ...
-
-    @overload  # unbuffered with default model
-    def query(self, sql: str, param: ParamType = None, *, buffered: Literal[False]):
-        ...
-
-    def query(self, sql: str, model=dict, param: "ParamType" = None, buffered: bool = True):
+    def query(self, sql, model=dict, param=None, buffered=True):
         handler = self.SqlParamHandler(sql, param)
         return self._buffered_query(handler, model) if buffered else self._unbuffered_query(handler, model)
+
     # endregion
 
     def query_multiple(

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -524,7 +524,7 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_async(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T":
         ...
 
-    def query_single_async(self, sql, model=dict, param=None):
+    async def query_single_async(self, sql, model=dict, param=None):
         handler = self.SqlParamHandler(sql, param)
 
         async with self.cursor() as cursor:

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -10,9 +10,7 @@ from typing import Callable
 from typing import Dict
 from typing import Generator
 from typing import List
-from typing import Literal
 from typing import Optional
-from typing import Protocol
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -37,6 +35,7 @@ if TYPE_CHECKING:
     from .types import ConnectionType
     from .types import CursorType
     from .types import ListParamType
+    from .types import Literal
     from .types import ParamType
 
     _T = TypeVar("_T")
@@ -158,25 +157,30 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: Literal[True] = True
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[True]" = True,
     ) -> List[Dict[str, Any]]:
         ...
 
     @overload
     def query(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: Literal[False]
+        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: "Literal[False]"
     ) -> typing.Generator[Dict[str, Any], None, None]:
         ...
 
     @overload
     def query(
-        self, sql: str, param: Optional["ParamType"] = ..., buffered: Literal[True] = True, *, model: Type["_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., buffered: "Literal[True]" = True, *, model: Type["_T"]
     ) -> List["_T"]:
         ...
 
     @overload
     def query(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: Literal[False]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: "Literal[False]"
     ) -> Generator["_T", None, None]:
         ...
 
@@ -395,25 +399,30 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_async(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: Literal[True] = True
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[True]" = True,
     ) -> List[Dict[str, Any]]:
         ...
 
     @overload
     async def query_async(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: Literal[False]
+        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: "Literal[False]"
     ) -> AsyncGenerator[Dict[str, Any], None]:
         ...
 
     @overload
     async def query_async(
-        self, sql: str, param: Optional["ParamType"] = ..., buffered: Literal[True] = True, *, model: Type["_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., buffered: "Literal[True]" = True, *, model: Type["_T"]
     ) -> List["_T"]:
         ...
 
     @overload
     async def query_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: Literal[False]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: "Literal[False]"
     ) -> AsyncGenerator["_T", None]:
         ...
 

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -32,10 +32,10 @@ class MySqlConnectorPythonCommands(Commands):
 
     def query_first(
         self,
-        sql: str,
-        model: Any = dict,
-        param: "ParamType" = None,
-    ) -> Any:
+        sql,
+        model=dict,
+        param=None,
+    ):
         """
         the mysql connector throws an exception if you only read one row from a cursor.  Unfortunately, we have to
         fetchall to make the lib happy.

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -1,9 +1,11 @@
 import sys
 
 if sys.version_info < (3, 8):
+    from typing_extensions import Literal
     from typing_extensions import Protocol
 else:
     from typing import Protocol
+    from typing import Literal
 
 from abc import abstractmethod
 from typing import Any

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -1,5 +1,4 @@
 import importlib
-import typing
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -28,12 +27,12 @@ def database_row_to_dict(col_names: List[str], row: Tuple[Any]) -> Dict[str, Any
     return dict(zip(col_names, row))
 
 
-@typing.overload
+@overload
 def serialize_dict_row(model: Type[Dict], row: Dict[str, Any]) -> Dict[str, Any]:
     ...
 
 
-@typing.overload
+@overload
 def serialize_dict_row(model: Type["_T"], row: Dict[str, Any]) -> "_T":
     ...
 

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -1,8 +1,16 @@
 import importlib
+import typing
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import overload
+
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
 
 
 def safe_getattr(obj: Any, key: str) -> Any:
@@ -20,7 +28,17 @@ def database_row_to_dict(col_names: List[str], row: Tuple[Any]) -> Dict[str, Any
     return dict(zip(col_names, row))
 
 
-def serialize_dict_row(model: Any, row: Dict[str, Any]):
+@typing.overload
+def serialize_dict_row(model: Type[dict], row: Dict[str, Any]) -> dict:
+    ...
+
+
+@typing.overload
+def serialize_dict_row(model: Type["_T"], row: Dict[str, Any]) -> "_T":
+    ...
+
+
+def serialize_dict_row(model, row):
     if model == dict:
         return row
     return model(**row)

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -29,7 +29,7 @@ def database_row_to_dict(col_names: List[str], row: Tuple[Any]) -> Dict[str, Any
 
 
 @typing.overload
-def serialize_dict_row(model: Type[dict], row: Dict[str, Any]) -> dict:
+def serialize_dict_row(model: Type[Dict], row: Dict[str, Any]) -> Dict[str, Any]:
     ...
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,8 @@ exclude_lines = [
     "raise NotImplementedError",
     "Protocol",
     "except ImportError",
-    "@abstractmethod"
+    "@abstractmethod",
+    "@overload"
 ]
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/annotation_tests.py
+++ b/tests/annotation_tests.py
@@ -1,0 +1,38 @@
+import datetime
+from dataclasses import dataclass
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import List
+
+from typing_extensions import assert_type
+from typing_extensions import reveal_type
+
+import pydapper
+
+
+class Task:
+    id: int
+    description: str
+    due_date: datetime.date
+    owner_id: int
+
+
+def command_annotations():
+    with pydapper.connect() as commands:
+        assert_type(
+            commands.query("select * from task", buffered=True),
+            List[Dict[str, Any]],
+        )
+        assert_type(
+            commands.query("select * from task", buffered=False),
+            Generator[Dict[str, Any], None, None],
+        )
+        assert_type(
+            commands.query("select * from task", model=Task, buffered=False),
+            Generator[Task, None, None],
+        )
+        assert_type(
+            commands.query("select * from task", model=Task, param=None, buffered=True),
+            List[Task],
+        )

--- a/tests/annotation_tests.py
+++ b/tests/annotation_tests.py
@@ -1,16 +1,20 @@
 import datetime
 from dataclasses import dataclass
 from typing import Any
+from typing import AsyncGenerator
 from typing import Dict
 from typing import Generator
 from typing import List
+from typing import Union
 
 from typing_extensions import assert_type
-from typing_extensions import reveal_type
 
 import pydapper
 
+"""This file tests some of the more complex type annotations on the Commands and AsyncCommands classes"""
 
+
+@dataclass
 class Task:
     id: int
     description: str
@@ -18,21 +22,97 @@ class Task:
     owner_id: int
 
 
-def command_annotations():
-    with pydapper.connect() as commands:
-        assert_type(
-            commands.query("select * from task", buffered=True),
-            List[Dict[str, Any]],
-        )
-        assert_type(
-            commands.query("select * from task", buffered=False),
-            Generator[Dict[str, Any], None, None],
-        )
-        assert_type(
-            commands.query("select * from task", model=Task, buffered=False),
-            Generator[Task, None, None],
-        )
-        assert_type(
-            commands.query("select * from task", model=Task, param=None, buffered=True),
-            List[Task],
-        )
+def default_callable() -> str:
+    return "sup"
+
+
+class Commands:
+    @staticmethod
+    def query(query: str) -> None:
+        with pydapper.connect() as commands:
+            assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
+            assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
+            assert_type(commands.query(query, model=Task, buffered=True), List[Task])
+            assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
+
+    @staticmethod
+    def query_first(query: str) -> None:
+        with pydapper.connect() as commands:
+            assert_type(commands.query_first(query), Dict[str, Any])
+            assert_type(commands.query_first(query, model=Task), Task)
+
+    @staticmethod
+    def query_first_or_default(query: str) -> None:
+        with pydapper.connect() as commands:
+            # passing a callable, the return type of the callable is part of the return type
+            assert_type(commands.query_first_or_default(query, default_callable, model=Task), Union[str, Task])
+            assert_type(commands.query_first_or_default(query, default_callable), Union[str, Dict[str, Any]])
+            # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(commands.query_first_or_default(query, "hello", model=Task), Union[str, Task])
+            assert_type(commands.query_first_or_default(query, "hello"), Union[str, Dict[str, Any]])
+
+    @staticmethod
+    def query_single(query: str) -> None:
+        with pydapper.connect() as commands:
+            assert_type(commands.query_single(query), Dict[str, Any])
+            assert_type(commands.query_single(query, model=Task), Task)
+
+    @staticmethod
+    def query_single_or_default(query: str) -> None:
+        with pydapper.connect() as commands:
+            # passing a callable, the return type of the callable is part of the return type
+            assert_type(commands.query_single_or_default(query, default_callable, model=Task), Union[str, Task])
+            assert_type(commands.query_single_or_default(query, default_callable), Union[str, Dict[str, Any]])
+            # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(commands.query_single_or_default(query, "hello", model=Task), Union[str, Task])
+            assert_type(commands.query_single_or_default(query, "hello"), Union[str, Dict[str, Any]])
+
+
+class CommandsAsync:
+    @staticmethod
+    async def query(query: str):
+        async with pydapper.connect_async() as commands:
+            assert_type(await commands.query_async(query, buffered=True), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, buffered=False), AsyncGenerator[Dict[str, Any], None])
+            assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
+            assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
+
+    @staticmethod
+    async def query_first(query: str) -> None:
+        async with pydapper.connect_async() as commands:
+            assert_type(await commands.query_first_async(query), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, model=Task), Task)
+
+    @staticmethod
+    async def query_first_or_default(query: str) -> None:
+        async with pydapper.connect_async() as commands:
+            # passing a callable, the return type of the callable is part of the return type
+            assert_type(
+                await commands.query_first_or_default_async(query, default_callable, model=Task), Union[str, Task]
+            )
+            assert_type(
+                await commands.query_first_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
+            )
+            # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(await commands.query_first_or_default_async(query, "hello", model=Task), Union[str, Task])
+            assert_type(await commands.query_first_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
+
+    @staticmethod
+    async def query_single(query: str) -> None:
+        async with pydapper.connect_async() as commands:
+            assert_type(await commands.query_single_async(query), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, model=Task), Task)
+
+    @staticmethod
+    async def query_single_or_default(query: str) -> None:
+        async with pydapper.connect_async() as commands:
+            # passing a callable, the return type of the callable is part of the return type
+            assert_type(
+                await commands.query_single_or_default_async(query, default_callable, model=Task), Union[str, Task]
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
+            )
+            # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(await commands.query_single_or_default_async(query, "hello", model=Task), Union[str, Task])
+            assert_type(await commands.query_single_or_default_async(query, "hello"), Union[str, Dict[str, Any]])

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,6 +1,8 @@
+import typing
 from types import SimpleNamespace
 
 import pytest
+import typing_extensions
 
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.exceptions import NoResultException


### PR DESCRIPTION
## Overview
I naively implemented typing.  It was time to give it some much needed attention.  Now IDEs and mypy will correctly interpret types for all methods on `Commands` and `CommandsAsync` except for `query_multiple` and `query_multiple_async`.  I have a TODO to explore variadic typevars (`TypeVarTuple`) for this in the future.

## Changes
- Leverage `TypeVar` to provide a better typing experience on `Commands` and `CommandsAsync`
- Add an annotations test to CI for validating some of the more complex type annotations are outputting what I would expect