### PR TITLE
🔧 Remove python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     services:
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -10,6 +10,7 @@ from typing import Callable
 from typing import Dict
 from typing import Generator
 from typing import List
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 from typing import Type
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     from .types import ConnectionType
     from .types import CursorType
     from .types import ListParamType
-    from .types import Literal
     from .types import ParamType
 
     _T = TypeVar("_T")

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -1,18 +1,10 @@
-import sys
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-    from typing_extensions import Protocol
-else:
-    from typing import Protocol
-    from typing import Literal
-
 from abc import abstractmethod
 from typing import Any
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
 from typing import Optional
+from typing import Protocol
 from typing import Union
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -30,7 +29,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.8,<3.12"
 dsnparse = "^0.1.15"
 psycopg2-binary = { version = "^2.9.2", optional = true }
 pymssql = { version = "^2.2.6", optional = true }
@@ -132,4 +131,3 @@ exclude_lines = [
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-


### PR DESCRIPTION
Python 3.7 will stop getting security updates in June of this year.  I need to remove support for it moving forward so that I can add bigquery support, which requires a version of numpy that will not install on 3.7