### PR TITLE
✨ add support for `psycopg3` async

### DIFF
--- a/docs/database_support/postgresql.md
+++ b/docs/database_support/postgresql.md
@@ -1,11 +1,11 @@
 # [PostgreSQL](https://www.postgresql.org)
 Supported drivers:
 
-| dbapi                                               | default      | driver                | connection class                 |
-|-----------------------------------------------------|--------------|-----------------------|----------------------------------|
-| [psycopg2](https://www.psycopg.org/docs/usage.html) | :thumbsup:   | `postgresql+psycopg2` | `psycopg2.extensions.connection` |
-| [psycopg3](https://www.psycopg.org/psycopg3/docs/)  | :thumbsdown: | `postgresql+psycopg`  | `psycopg.Connection`             |
-| [aiopg](https://aiopg.readthedocs.io/en/stable/)    | :thumbsdown: | `postgresql+aiopg`    | `aiopg.connection.Connection`    |
+| dbapi                                               | default      | driver                | connection class                                     |
+|-----------------------------------------------------|--------------|-----------------------|------------------------------------------------------|
+| [psycopg2](https://www.psycopg.org/docs/usage.html) | :thumbsup:   | `postgresql+psycopg2` | `psycopg2.extensions.connection`                     |
+| [psycopg3](https://www.psycopg.org/psycopg3/docs/)  | :thumbsdown: | `postgresql+psycopg`  | `psycopg.Connection` \| `psycopg.AsyncConnection`    |
+| [aiopg](https://aiopg.readthedocs.io/en/stable/)    | :thumbsdown: | `postgresql+aiopg`    | `aiopg.connection.Connection`                        |
 
 ## psycopg2
 `psycopg2` is the default dbapi driver for PostgreSQL in *pydapper*.
@@ -89,10 +89,17 @@ Use *pydapper* with a `psycopg2` connection pool.
     ```
 
 ### Example - `connect`
-Please see the [psycopg docs](https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html#with-connection) for a full description of the
+Please see the [psycopg docs](https://www.psycopg.org/psycopg3/docs/basic/usage.html#with-connection) for a full description of the
 context manager behavior.  
 ```python
 {!docs/../docs_src/connections/psycopg3_connect.py!}
+```
+
+### Example - `connect_async`
+Please see the [psycopg docs](https://www.psycopg.org/psycopg3/docs/advanced/async.html#async-with) for a full description of the
+context manager behavior.
+```python
+{!docs/../docs_src/connections/psycopg3_connect_async.py!}
 ```
 
 </details>
@@ -112,6 +119,13 @@ Use *pydapper* with a `psycopg` connection pool. Package that handles [connectio
 
 ```python
 {!docs/../docs_src/connections/psycopg3_using.py!}
+```
+
+### Example - `using_async`
+Use *pydapper* with a `psycopg` [async connection pools]((https://www.psycopg.org/psycopg3/docs/api/pool.html#the-asyncconnectionpool-class)). 
+
+```python
+{!docs/../docs_src/connections/psycopg3_using_async.py!}
 ```
 
 ## aiopg

--- a/docs_src/connections/psycopg3_connect_async.py
+++ b/docs_src/connections/psycopg3_connect_async.py
@@ -1,0 +1,19 @@
+import asyncio
+
+import pydapper
+
+
+async def main():
+    async with pydapper.connect_async("postgresql+psycopg://pydapper:pydapper@localhost/pydapper") as commands:
+        print(type(commands))
+        # <class 'pydapper.postgresql.psycopg3.Psycopg3CommandsAsync'>
+
+        print(type(commands.connection))
+        # <class 'psycopg.AsyncConnection'>
+
+        async with commands.cursor() as raw_cursor:
+            print(type(raw_cursor))
+            # <class 'psycopg.AsyncCursor'>
+
+
+asyncio.run(main())

--- a/docs_src/connections/psycopg3_using.py
+++ b/docs_src/connections/psycopg3_using.py
@@ -2,13 +2,13 @@ from psycopg_pool import ConnectionPool
 
 import pydapper
 
-my_pool = ConnectionPool("postgresql://pydapper:pydapper@localhost/pydapper", min_size=1, max_size=10)
+pool = ConnectionPool("postgresql://pydapper:pydapper@localhost/pydapper", min_size=1, max_size=10, open=True)
 
-commands = pydapper.using(my_pool.getconn())
+commands = pydapper.using(pool.getconn())
 print(type(commands))
 # <class 'pydapper.postgresql.psycopg3.Psycopg3Commands'>
 
 print(type(commands.connection))
 # <class 'psycopg.Connection'>
 
-my_pool.putconn(commands.connection)
+pool.putconn(commands.connection)

--- a/docs_src/connections/psycopg3_using_async.py
+++ b/docs_src/connections/psycopg3_using_async.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from psycopg_pool import AsyncConnectionPool
+
+import pydapper
+
+
+async def main():
+    async with AsyncConnectionPool(
+        "postgresql://pydapper:pydapper@localhost/pydapper", min_size=1, max_size=10, open=False
+    ) as pool:
+        conn = await pool.getconn()
+        async with pydapper.using_async(conn) as commands:
+            print(type(commands))
+            # <class 'pydapper.postgresql.psycopg3.Psycopg3CommandsAsync'>
+
+            print(type(commands.connection))
+            # <class 'psycopg.AsyncConnection'>
+
+            pool.putconn(commands.connection)
+
+
+asyncio.run(main())

--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -11,4 +11,5 @@ from .oracle import CxOracleCommands as _CxOracleCommands
 from .postgresql import AiopgCommands as _AioPgCommand
 from .postgresql import Psycopg2Commands as _Psycopg2Commands
 from .postgresql import Psycopg3Commands as _Psycopg3Commands
+from .postgresql import Psycopg3CommandsAsync as _Psycopg3CommandsAsync
 from .sqlite import Sqlite3Commands as _Sqlite3Commands

--- a/pydapper/postgresql/__init__.py
+++ b/pydapper/postgresql/__init__.py
@@ -1,3 +1,4 @@
 from .aiopg import AiopgCommands
 from .psycopg2 import Psycopg2Commands
 from .psycopg3 import Psycopg3Commands
+from .psycopg3 import Psycopg3CommandsAsync

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -1,12 +1,15 @@
 from typing import TYPE_CHECKING
 
 from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
 
 from ..main import register
+from ..main import register_async
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
+    from ..types import AsyncCursorType
 
 
 @register("psycopg")
@@ -15,6 +18,27 @@ class Psycopg3Commands(Commands):
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         psycopg = import_dbapi_module("psycopg")
         conn = psycopg.connect(
+            dbname=parsed_dsn.dbname,
+            user=parsed_dsn.username,
+            password=parsed_dsn.password,
+            host=parsed_dsn.host,
+            port=parsed_dsn.port if parsed_dsn.port else "5432",
+            **connect_kwargs,
+        )
+        return cls(conn)
+
+
+@register_async("psycopg")
+class Psycopg3CommandsAsync(CommandsAsync):
+    # https://www.psycopg.org/psycopg3/docs/api/connections.html#psycopg.AsyncConnection.cursor
+    # AsyncConnection.cursor() function is not an async function (it never performs I/O) so we don't need CoroContextManager
+    def cursor(self, *args, **kwargs) -> "AsyncCursorType":
+        return self.connection.cursor(*args, **kwargs)
+
+    @classmethod
+    async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync":
+        psycopg = import_dbapi_module("psycopg")
+        conn = await psycopg.AsyncConnection.connect(
             dbname=parsed_dsn.dbname,
             user=parsed_dsn.username,
             password=parsed_dsn.password,

--- a/tests/test_postgresql/test_psycopg3_async.py
+++ b/tests/test_postgresql/test_psycopg3_async.py
@@ -1,0 +1,88 @@
+import datetime
+
+import pytest
+import pytest_asyncio
+
+from pydapper import connect_async
+from pydapper import using_async
+from pydapper.commands import CommandsAsync
+from pydapper.postgresql.psycopg3 import Psycopg3CommandsAsync
+from tests.test_suites.commands import ExecuteAsyncTestSuite
+from tests.test_suites.commands import ExecuteScalarAsyncTestSuite
+from tests.test_suites.commands import QueryAsyncTestSuite
+from tests.test_suites.commands import QueryFirstAsyncTestSuite
+from tests.test_suites.commands import QueryFirstOrDefaultAsyncTestSuite
+from tests.test_suites.commands import QueryMultipleAsyncTestSuite
+from tests.test_suites.commands import QuerySingleAsyncTestSuite
+from tests.test_suites.commands import QuerySingleOrDefaultAsyncTestSuite
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest_asyncio.fixture(scope="function")
+async def commands(server, database_name) -> Psycopg3CommandsAsync:
+    import psycopg
+
+    conn = await psycopg.AsyncConnection.connect(f"postgresql://pydapper:pydapper@{server}:5433/{database_name}")
+    async with Psycopg3CommandsAsync(conn) as commands:
+        yield commands
+        await commands.connection.rollback()
+
+
+@pytest.mark.asyncio
+async def test_using_async(server, database_name):
+    import psycopg
+
+    conn = await psycopg.AsyncConnection.connect(f"postgresql://pydapper:pydapper@{server}:5433/{database_name}")
+    async with using_async(conn) as commands:
+        assert isinstance(commands, Psycopg3CommandsAsync)
+
+
+@pytest.mark.asyncio
+async def test_connect_async(server, database_name):
+    async with connect_async(f"postgresql+psycopg://pydapper:pydapper@{server}:5433/{database_name}") as commands:
+        assert isinstance(commands, Psycopg3CommandsAsync)
+
+
+class TestExecute(ExecuteAsyncTestSuite):
+    @pytest.mark.asyncio
+    async def test_multiple(self, commands: CommandsAsync):
+        assert (
+            await commands.execute_async(
+                "INSERT INTO task (id, description, due_date, owner_id) "
+                "VALUES (?id?, ?description?, ?due_date?, ?owner_id?)",
+                [
+                    {"id": 4, "description": "new task", "due_date": datetime.date(2022, 1, 1), "owner_id": 1},
+                    {"id": 5, "description": "another new task", "due_date": datetime.date(2022, 1, 1), "owner_id": 1},
+                ],
+            )
+            == 2
+        )
+
+
+class TestQueryAsync(QueryAsyncTestSuite):
+    ...
+
+
+class TestQueryMultipleAsync(QueryMultipleAsyncTestSuite):
+    ...
+
+
+class TestQueryFirstAsync(QueryFirstAsyncTestSuite):
+    ...
+
+
+class TestQueryFirstOrDefaultAsync(QueryFirstOrDefaultAsyncTestSuite):
+    ...
+
+
+class TestQuerySingleAsync(QuerySingleAsyncTestSuite):
+    ...
+
+
+class TestQuerySingleOrDefaultAsync(QuerySingleOrDefaultAsyncTestSuite):
+    ...
+
+
+class TestExecuteScalarAsync(ExecuteScalarAsyncTestSuite):
+    ...

--- a/tests/test_suites/commands.py
+++ b/tests/test_suites/commands.py
@@ -36,7 +36,7 @@ class ExecuteAsyncTestSuite:
     async def test_single(self, commands: CommandsAsync, owner_table_name):
         assert (
             await commands.execute_async(
-                "UPDATE {owner_table_name} SET name = ?new_name? WHERE id = ?id?", {"new_name": "Zachary", "id": "1"}
+                f"UPDATE {owner_table_name} SET name = ?new_name? WHERE id = ?id?", {"new_name": "Zachary", "id": "1"}
             )
             == 1
         )


### PR DESCRIPTION
We have an architecture problem here `aiopg` implements `cursor` as coroutine but `psycopg` does not. I don't know how you want to handle this decision but that's why the `fmt` check fails because of the base class difference. 

Let me know what you decide so I can implement, I don't want to do any major changes before you see it because it affects both `CommandsAsync` and `AsynConnectionType` public API.

Tests pass only because I am overriding the `cursor` method in `Psycopg3CommandsAsync`, but the typecheck fails as it should.