### PR TITLE
:sparkles: Add callable that returns a model as a supported model type

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -149,7 +149,7 @@ class Commands(BaseCommands, ABC):
             rowcount = handler.execute(cursor)
         return rowcount
 
-    def _buffered_query(self, handler: BaseSqlParamHandler, model: Type["_T"]) -> List["_T"]:
+    def _buffered_query(self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]) -> List["_T"]:
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
@@ -183,12 +183,22 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query(
-        self, sql: str, param: Optional["ParamType"] = ..., buffered: "Literal[True]" = True, *, model: Type["_T"]
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
+        *,
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> List["_T"]: ...
 
     @overload
     def query(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: "Literal[False]"
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Type["_T"] | Callable[..., "_T"],
+        buffered: "Literal[False]",
     ) -> Generator["_T", None, None]: ...
 
     def query(self, sql, model=dict, param=None, buffered=True):
@@ -230,7 +240,9 @@ class Commands(BaseCommands, ABC):
     def query_first(self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ...) -> Dict[str, Any]: ...
 
     @overload
-    def query_first(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T": ...
+    def query_first(
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+    ) -> "_T": ...
 
     def query_first(self, sql, model=dict, param=None):
         handler = self.SqlParamHandler(sql, param)
@@ -260,7 +272,7 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -270,7 +282,7 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     def query_first_or_default(self, sql, default, model=dict, param=None):
@@ -285,7 +297,9 @@ class Commands(BaseCommands, ABC):
     ) -> Dict[str, Any]: ...
 
     @overload
-    def query_single(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T": ...
+    def query_single(
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+    ) -> "_T": ...
 
     def query_single(self, sql, model=dict, param=None):
         handler = self.SqlParamHandler(sql, param)
@@ -320,7 +334,7 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -330,7 +344,7 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     def query_single_or_default(self, sql, default, model=dict, param=None):
@@ -376,14 +390,18 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             return await handler.execute_async(cursor)
 
-    async def _buffered_query(self, handler: BaseSqlParamHandler, model: Type["_T"]) -> List["_T"]:
+    async def _buffered_query(
+        self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]
+    ) -> List["_T"]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             data = await cursor.fetchall()
             return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
 
-    async def _unbuffered_query(self, handler: BaseSqlParamHandler, model: Type["_T"]) -> AsyncGenerator["_T", None]:
+    async def _unbuffered_query(
+        self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]
+    ) -> AsyncGenerator["_T", None]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
@@ -410,12 +428,22 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_async(
-        self, sql: str, param: Optional["ParamType"] = ..., buffered: "Literal[True]" = True, *, model: Type["_T"]
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
+        *,
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> List["_T"]: ...
 
     @overload
     async def query_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: "Literal[False]"
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Type["_T"] | Callable[..., "_T"],
+        buffered: "Literal[False]",
     ) -> AsyncGenerator["_T", None]: ...
 
     async def query_async(self, sql, model=dict, param=None, buffered=True):
@@ -460,7 +488,9 @@ class CommandsAsync(BaseCommands, ABC):
     ) -> Dict[str, Any]: ...
 
     @overload
-    async def query_first_async(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T": ...
+    async def query_first_async(
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+    ) -> "_T": ...
 
     async def query_first_async(self, sql, model=dict, param=None):
         handler = self.SqlParamHandler(sql, param)
@@ -490,7 +520,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -500,7 +530,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     async def query_first_or_default_async(self, sql, default, model=dict, param=None):
@@ -515,7 +545,9 @@ class CommandsAsync(BaseCommands, ABC):
     ) -> Dict[str, Any]: ...
 
     @overload
-    async def query_single_async(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T": ...
+    async def query_single_async(
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+    ) -> "_T": ...
 
     async def query_single_async(self, sql, model=dict, param=None):
         handler = self.SqlParamHandler(sql, param)
@@ -550,7 +582,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -560,7 +592,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"],
+        model: Type["_T"] | Callable[..., "_T"],
     ) -> Union["_Default", "_T"]: ...
 
     async def query_single_or_default_async(self, sql, default, model=dict, param=None):

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -149,7 +149,9 @@ class Commands(BaseCommands, ABC):
             rowcount = handler.execute(cursor)
         return rowcount
 
-    def _buffered_query(self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]) -> List["_T"]:
+    def _buffered_query(
+        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
+    ) -> List["_T"]:
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
@@ -188,7 +190,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> List["_T"]: ...
 
     @overload
@@ -197,7 +199,7 @@ class Commands(BaseCommands, ABC):
         sql: str,
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
     ) -> Generator["_T", None, None]: ...
 
@@ -241,7 +243,7 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query_first(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> "_T": ...
 
     def query_first(self, sql, model=dict, param=None):
@@ -272,7 +274,7 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -282,7 +284,7 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     def query_first_or_default(self, sql, default, model=dict, param=None):
@@ -298,7 +300,7 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query_single(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> "_T": ...
 
     def query_single(self, sql, model=dict, param=None):
@@ -334,7 +336,7 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -344,7 +346,7 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     def query_single_or_default(self, sql, default, model=dict, param=None):
@@ -391,7 +393,7 @@ class CommandsAsync(BaseCommands, ABC):
             return await handler.execute_async(cursor)
 
     async def _buffered_query(
-        self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]
+        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> List["_T"]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
@@ -400,7 +402,7 @@ class CommandsAsync(BaseCommands, ABC):
             return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
 
     async def _unbuffered_query(
-        self, handler: BaseSqlParamHandler, model: Type["_T"] | Callable[..., "_T"]
+        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> AsyncGenerator["_T", None]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
@@ -433,7 +435,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> List["_T"]: ...
 
     @overload
@@ -442,7 +444,7 @@ class CommandsAsync(BaseCommands, ABC):
         sql: str,
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
     ) -> AsyncGenerator["_T", None]: ...
 
@@ -489,7 +491,7 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_first_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> "_T": ...
 
     async def query_first_async(self, sql, model=dict, param=None):
@@ -520,7 +522,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -530,7 +532,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     async def query_first_or_default_async(self, sql, default, model=dict, param=None):
@@ -546,7 +548,7 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_single_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"] | Callable[..., "_T"]
+        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
     ) -> "_T": ...
 
     async def query_single_async(self, sql, model=dict, param=None):
@@ -582,7 +584,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -592,7 +594,7 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
-        model: Type["_T"] | Callable[..., "_T"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
     async def query_single_or_default_async(self, sql, default, model=dict, param=None):

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -1,6 +1,7 @@
 import importlib
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -32,7 +33,7 @@ def serialize_dict_row(model: Type[Dict], row: Dict[str, Any]) -> Dict[str, Any]
 
 
 @overload
-def serialize_dict_row(model: Type["_T"], row: Dict[str, Any]) -> "_T": ...
+def serialize_dict_row(model: Type["_T"] | Callable[..., "_T"], row: Dict[str, Any]) -> "_T": ...
 
 
 def serialize_dict_row(model, row):

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -7,6 +7,7 @@ from typing import List
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
+from typing import Union
 from typing import overload
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ def serialize_dict_row(model: Type[Dict], row: Dict[str, Any]) -> Dict[str, Any]
 
 
 @overload
-def serialize_dict_row(model: Type["_T"] | Callable[..., "_T"], row: Dict[str, Any]) -> "_T": ...
+def serialize_dict_row(model: Union[Type["_T"], Callable[..., "_T"]], row: Dict[str, Any]) -> "_T": ...
 
 
 def serialize_dict_row(model, row):

--- a/tests/annotation_tests.py
+++ b/tests/annotation_tests.py
@@ -36,7 +36,10 @@ class Commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
             assert_type(commands.query(query, model=Task, buffered=True), List[Task])
+            assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
+            assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False), Generator[Task, None, None])
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
+
 
     @staticmethod
     def query_first(query: str) -> None:

--- a/tests/annotation_tests.py
+++ b/tests/annotation_tests.py
@@ -37,9 +37,11 @@ class Commands:
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
             assert_type(commands.query(query, model=Task, buffered=True), List[Task])
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
-            assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False), Generator[Task, None, None])
+            assert_type(
+                commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False),
+                Generator[Task, None, None],
+            )
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
-
 
     @staticmethod
     def query_first(query: str) -> None:


### PR DESCRIPTION
This PR fully implements the idea from #330 - rather than using overloads, we can simply union the model type and still infer the return type from the return type of the function when a callable is passed