### PR TITLE
Fix sqlite not opening in subdirectories

### DIFF
--- a/pydapper/sqlite/sqlite3.py
+++ b/pydapper/sqlite/sqlite3.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from sqlite3 import Cursor
 from typing import TYPE_CHECKING
@@ -18,5 +19,9 @@ class Sqlite3Commands(Commands):
 
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
-        conn = sqlite3.connect(parsed_dsn.host, **connect_kwargs)
+        db_path = parsed_dsn.host or ''
+        if parsed_dsn.database:
+            db_path = os.path.join(db_path, parsed_dsn.database)
+
+        conn = sqlite3.connect(db_path, **connect_kwargs)
         return cls(conn)  # type: ignore

--- a/tests/test_sqlite/conftest.py
+++ b/tests/test_sqlite/conftest.py
@@ -15,6 +15,7 @@ def sqlite_setup(database_name, setup_sql_dir):
         conn.executescript(sql)
     yield
     os.remove(db_name)
+    os.remove(os.path.join(setup_sql_dir, db_name))
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_sqlite/test_sqlite3.py
+++ b/tests/test_sqlite/test_sqlite3.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 
 import pytest
@@ -17,8 +18,19 @@ from tests.test_suites.commands import QueryTestSuite
 pytestmark = pytest.mark.sqlite
 
 
+def test_using_subfolder(database_name, setup_sql_dir):
+    with using(sqlite3.connect(f"{setup_sql_dir}{os.path.sep}{database_name}.db")) as commands:
+        assert isinstance(commands, Sqlite3Commands)
+
+
 def test_using(database_name):
     with using(sqlite3.connect(f"{database_name}.db")) as commands:
+        assert isinstance(commands, Sqlite3Commands)
+
+
+@pytest.mark.parametrize("driver", ["sqlite", "sqlite+sqlite3"])
+def test_connect_subfolder(driver, database_name, setup_sql_dir):
+    with connect(f"{driver}://{setup_sql_dir}{os.path.sep}{database_name}.db") as commands:
         assert isinstance(commands, Sqlite3Commands)
 
 


### PR DESCRIPTION
Closes #343 

testing caveats:
- I decided to test by using `sql_setup_folder` to build a subdirectory.
-  I have seen that the behaviour is different between absolute and relative paths. However, I'm not enough of a pytest expert to figure out how to test with both. If you can give me a pointer on how I would test both, I would gladly add some more test parameters.
-  I'm also only testing the connection to the sqlite connection, and not running the test suite. The assumption being that if we can connect, we can do everything else that has been tested