### PR TITLE
feat: add params alias across public command APIs

### DIFF
--- a/docs/async_methods/execute_async.md
+++ b/docs/async_methods/execute_async.md
@@ -6,7 +6,9 @@ to execute insert, update or delete operations.
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |
- | param | `ListParamType, ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+ | params | `ListParamType, ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example - Execute Insert
 ### Single
@@ -18,7 +20,7 @@ Execute the INSERT statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the INSERT statement multiple times, one for each object in the param list.
+Execute the INSERT statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/async_methods/execute/insert_multiple.py!}
@@ -35,7 +37,7 @@ Execute the UPDATE statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the UPDATE statement multiple times, one for each object in the param list.
+Execute the UPDATE statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/async_methods/execute/update_multiple.py!}
@@ -52,7 +54,7 @@ Execute the DELETE statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the DELETE statement multiple times, one for each object in the param list.
+Execute the DELETE statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/async_methods/execute/delete_multiple.py!}

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -7,7 +7,9 @@ the query.  The additional columns or rows are ignored.
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example
 Get the name of the first task owner in the database.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -5,10 +5,12 @@
 | name     | type        | description                                                                                   | optional     | default |
 |----------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql      | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query_async` method and map the results to a list of dataclasses.

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -5,8 +5,10 @@
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -7,9 +7,11 @@ set contains no records.
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
  | default | `Any`       | any object to return if the result set is empty                                               | :thumbsdown: |
-| param   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model   | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -6,8 +6,10 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example
 Query two tables and return the serialized results.

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -6,8 +6,10 @@ record in the result set.
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -7,9 +7,11 @@ set is empty; this method throws an exception if there is more than one element 
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
  | default | `Any`       | any object to return if the result set is empty                                               | :thumbsdown: |
-| param   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model   | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/methods/execute.md
+++ b/docs/methods/execute.md
@@ -6,7 +6,9 @@ to execute insert, update or delete operations.
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |
- | param | `ListParamType, ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+ | params | `ListParamType, ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example - Execute Insert
 ### Single
@@ -18,7 +20,7 @@ Execute the INSERT statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the INSERT statement multiple times, one for each object in the param list.
+Execute the INSERT statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/methods/execute/insert_multiple.py!}
@@ -35,7 +37,7 @@ Execute the UPDATE statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the UPDATE statement multiple times, one for each object in the param list.
+Execute the UPDATE statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/methods/execute/update_multiple.py!}
@@ -52,7 +54,7 @@ Execute the DELETE statement a single time.
 (*This script is complete, it should run "as is"*)
 
 ### Multiple
-Execute the DELETE statement multiple times, one for each object in the param list.
+Execute the DELETE statement multiple times, one for each object in the params list.
 
 ```python
 {!docs/../docs_src/methods/execute/delete_multiple.py!}

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -7,7 +7,9 @@ the query.  The additional columns or rows are ignored.
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query | :thumbsup:   | `None`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example
 Get the name of the first task owner in the database.

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -5,10 +5,12 @@
 | name     | type        | description                                                                                   | optional     | default |
 |----------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql      | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query` method and map the results to a list of dataclasses.

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -5,8 +5,10 @@
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -7,9 +7,11 @@ set contains no records.
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
  | default | `Any`       | any object to return if the result set is empty                                               | :thumbsdown: |
-| param   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model   | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -6,8 +6,10 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## Example
 Query two tables and return the serialized results.

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -6,8 +6,10 @@ record in the result set.
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
-| param | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -7,9 +7,11 @@ set is empty; this method throws an exception if there is more than one element 
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
  | default | `Any`       | any object to return if the result set is empty                                               | :thumbsdown: |
-| param   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
+| params   | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model   | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
 
+
+`param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
 ## First, Single and Default
 {!docs/.first_single_default.md!}

--- a/docs_src/async_methods/execute/delete_multiple.py
+++ b/docs_src/async_methods/execute/delete_multiple.py
@@ -5,7 +5,7 @@ import pydapper
 
 async def main():
     async with pydapper.connect_async() as commands:
-        rowcount = await commands.execute_async("delete from task where id = ?id?", param=[{"id": 2}, {"id": 3}])
+        rowcount = await commands.execute_async("delete from task where id = ?id?", params=[{"id": 2}, {"id": 3}])
 
     print(rowcount)
     # 2

--- a/docs_src/async_methods/execute/delete_single.py
+++ b/docs_src/async_methods/execute/delete_single.py
@@ -5,7 +5,7 @@ from pydapper import connect_async
 
 async def main():
     async with connect_async() as commands:
-        rowcount = await commands.execute_async("delete from task where id = ?id?", param={"id": 1})
+        rowcount = await commands.execute_async("delete from task where id = ?id?", params={"id": 1})
 
     print(rowcount)
     # 1

--- a/docs_src/async_methods/execute/insert_multiple.py
+++ b/docs_src/async_methods/execute/insert_multiple.py
@@ -8,7 +8,7 @@ async def main():
     async with connect_async() as commands:
         rowcount = await commands.execute_async(
             "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
-            param=[
+            params=[
                 {"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
                 {"description": "With multiple inserts!", "due_date": datetime.date.today(), "owner_id": 1},
             ],

--- a/docs_src/async_methods/execute/insert_single.py
+++ b/docs_src/async_methods/execute/insert_single.py
@@ -8,7 +8,7 @@ async def main():
     async with connect_async() as commands:
         rowcount = await commands.execute_async(
             "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
-            param={"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
+            params={"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
         )
 
     print(rowcount)

--- a/docs_src/async_methods/execute/update_multiple.py
+++ b/docs_src/async_methods/execute/update_multiple.py
@@ -7,7 +7,7 @@ async def main():
     async with connect_async() as commands:
         rowcount = await commands.execute_async(
             "update task set description = ?desc? where id = ?id?",
-            param=[{"desc": "A single update!", "id": 1}, {"desc": "No wait, multiple updates!", "id": 2}],
+            params=[{"desc": "A single update!", "id": 1}, {"desc": "No wait, multiple updates!", "id": 2}],
         )
 
     print(rowcount)

--- a/docs_src/async_methods/execute/update_single.py
+++ b/docs_src/async_methods/execute/update_single.py
@@ -6,7 +6,7 @@ from pydapper import connect_async
 async def main():
     async with connect_async() as commands:
         rowcount = await commands.execute_async(
-            "update task set description = ?desc? where id = ?id?", param={"desc": "A single update!", "id": 1}
+            "update task set description = ?desc? where id = ?id?", params={"desc": "A single update!", "id": 1}
         )
 
     print(rowcount)

--- a/docs_src/methods/execute/delete_multiple.py
+++ b/docs_src/methods/execute/delete_multiple.py
@@ -1,7 +1,7 @@
 from pydapper import connect
 
 with connect() as commands:
-    rowcount = commands.execute("delete from task where id = ?id?", param=[{"id": 2}, {"id": 3}])
+    rowcount = commands.execute("delete from task where id = ?id?", params=[{"id": 2}, {"id": 3}])
 
 print(rowcount)
 # 2

--- a/docs_src/methods/execute/delete_single.py
+++ b/docs_src/methods/execute/delete_single.py
@@ -1,7 +1,7 @@
 from pydapper import connect
 
 with connect() as commands:
-    rowcount = commands.execute("delete from task where id = ?id?", param={"id": 1})
+    rowcount = commands.execute("delete from task where id = ?id?", params={"id": 1})
 
 print(rowcount)
 # 1

--- a/docs_src/methods/execute/insert_multiple.py
+++ b/docs_src/methods/execute/insert_multiple.py
@@ -5,7 +5,7 @@ from pydapper import connect
 with connect() as commands:
     rowcount = commands.execute(
         "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
-        param=[
+        params=[
             {"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
             {"description": "With multiple inserts!", "due_date": datetime.date.today(), "owner_id": 1},
         ],

--- a/docs_src/methods/execute/insert_single.py
+++ b/docs_src/methods/execute/insert_single.py
@@ -5,7 +5,7 @@ from pydapper import connect
 with connect() as commands:
     rowcount = commands.execute(
         "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
-        param={"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
+        params={"description": "An insert example", "due_date": datetime.date.today(), "owner_id": 1},
     )
 
 print(rowcount)

--- a/docs_src/methods/execute/update_multiple.py
+++ b/docs_src/methods/execute/update_multiple.py
@@ -3,7 +3,7 @@ from pydapper import connect
 with connect() as commands:
     rowcount = commands.execute(
         "update task set description = ?desc? where id = ?id?",
-        param=[{"desc": "A single update!", "id": 1}, {"desc": "No wait, multiple updates!", "id": 2}],
+        params=[{"desc": "A single update!", "id": 1}, {"desc": "No wait, multiple updates!", "id": 2}],
     )
 
 print(rowcount)

--- a/docs_src/methods/execute/update_single.py
+++ b/docs_src/methods/execute/update_single.py
@@ -2,7 +2,7 @@ from pydapper import connect
 
 with connect() as commands:
     rowcount = commands.execute(
-        "update task set description = ?desc? where id = ?id?", param={"desc": "A single update!", "id": 1}
+        "update task set description = ?desc? where id = ?id?", params={"desc": "A single update!", "id": 1}
     )
 
 print(rowcount)

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -43,6 +43,27 @@ if TYPE_CHECKING:
     _Default = TypeVar("_Default")
 
 
+class _ParamAliasUnset:
+    def __repr__(self) -> str:
+        return "None"
+
+
+_PARAM_ALIAS_UNSET = _ParamAliasUnset()
+
+
+def _resolve_param_aliases(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
+    if param is not _PARAM_ALIAS_UNSET and params is not _PARAM_ALIAS_UNSET:
+        raise ValueError("Pass either 'params' or 'param', not both.")
+
+    if params is not _PARAM_ALIAS_UNSET:
+        return params
+
+    if param is not _PARAM_ALIAS_UNSET:
+        return param
+
+    return None
+
+
 class BaseSqlParamHandler(ABC):
     _PARAM_REGEX = "\\?(.*?)\\?"
 
@@ -112,6 +133,10 @@ class DefaultSqlParamHandler(BaseSqlParamHandler):
 class BaseCommands(ABC):
     SqlParamHandler: Type[BaseSqlParamHandler] = DefaultSqlParamHandler
 
+    @staticmethod
+    def _resolve_params(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
+        return _resolve_param_aliases(param, params)
+
 
 class Commands(BaseCommands, ABC):
     def __init__(self, connection: "ConnectionType"):
@@ -142,8 +167,15 @@ class Commands(BaseCommands, ABC):
     def cursor(self, *args, **kwargs) -> "CursorType":
         return self.connection.cursor(*args, **kwargs)
 
-    def execute(self, sql: str, param: Union["ParamType", "ListParamType"] = None) -> int:
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    def execute(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...
+
+    @overload
+    def execute(self, sql: str, *, param: Union["ParamType", "ListParamType"] = None) -> int: ...
+
+    def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
             rowcount = handler.execute(cursor)
         return rowcount
@@ -179,7 +211,32 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: "Literal[False]"
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        *,
+        buffered: "Literal[True]" = True,
+        params: Optional["ParamType"],
+    ) -> List[Dict[str, Any]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[False]",
+    ) -> typing.Generator[Dict[str, Any], None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        *,
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
     ) -> typing.Generator[Dict[str, Any], None, None]: ...
 
     @overload
@@ -196,25 +253,63 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
     ) -> Generator["_T", None, None]: ...
 
-    def query(self, sql, model=dict, param=None, buffered=True):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> Generator["_T", None, None]: ...
+
+    def query(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         return self._buffered_query(handler, model) if buffered else self._unbuffered_query(handler, model)
 
     # endregion
 
+    @overload
     def query_multiple(
         self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, param: Optional["ParamType"] = None
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    def query_multiple(
+        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
+    ) -> Tuple[List[Any], ...]: ...
+
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
+        resolved_params = self._resolve_params(param, params)
+
         if models is None:
             models = tuple(dict for _ in queries)
 
@@ -224,7 +319,7 @@ class Commands(BaseCommands, ABC):
         results = list()
         with self._cursor_context_proxy() as cursor:
             for query, model in zip(queries, models):
-                handler = self.SqlParamHandler(query, param)
+                handler = self.SqlParamHandler(query, resolved_params)
                 handler.execute(cursor)
                 headers = get_col_names(cursor)
                 data = cursor.fetchall()
@@ -238,15 +333,37 @@ class Commands(BaseCommands, ABC):
         return tuple(results)
 
     @overload
-    def query_first(self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ...) -> Dict[str, Any]: ...
+    def query_first(
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    def query_first(self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]) -> Dict[str, Any]: ...
 
     @overload
     def query_first(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> "_T": ...
 
-    def query_first(self, sql, model=dict, param=None):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    def query_first(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    def query_first(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
@@ -258,12 +375,40 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query_first_or_default(
-        self, sql: str, default: Callable[[], "_Default"], model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
     def query_first_or_default(
-        self, sql: str, default: "_Default", model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -280,30 +425,71 @@ class Commands(BaseCommands, ABC):
     def query_first_or_default(
         self,
         sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
-    def query_first_or_default(self, sql, default, model=dict, param=None):
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    def query_first_or_default(self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
         try:
-            return self.query_first(sql, model=model, param=param)
+            return self.query_first(sql, model=model, param=resolved_params)
         except NoResultException:
             return default() if callable(default) else default
 
     @overload
     def query_single(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Dict[str, Any]: ...
 
     @overload
+    def query_single(self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]) -> Dict[str, Any]: ...
+
+    @overload
     def query_single(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> "_T": ...
 
-    def query_single(self, sql, model=dict, param=None):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    def query_single(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    def query_single(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
@@ -320,12 +506,40 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query_single_or_default(
-        self, sql: str, default: Callable[[], "_Default"], model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
     def query_single_or_default(
-        self, sql: str, default: "_Default", model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -342,24 +556,48 @@ class Commands(BaseCommands, ABC):
     def query_single_or_default(
         self,
         sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
-    def query_single_or_default(self, sql, default, model=dict, param=None):
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    def query_single_or_default(self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
         try:
-            return self.query_single(sql, model=model, param=param)
+            return self.query_single(sql, model=model, param=resolved_params)
         except NoResultException:
             return default() if callable(default) else default
 
-    def execute_scalar(
-        self,
-        sql: str,
-        param: "ParamType" = None,
-    ) -> Any:
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    def execute_scalar(self, sql: str, params: "ParamType" = None) -> Any: ...
+
+    @overload
+    def execute_scalar(self, sql: str, *, param: "ParamType" = None) -> Any: ...
+
+    def execute_scalar(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             first_row = cursor.fetchone()
@@ -386,8 +624,15 @@ class CommandsAsync(BaseCommands, ABC):
     def cursor(self, *args, **kwargs) -> "CoroContextManager[AsyncCursorType]":
         return CoroContextManager(self.connection.cursor(*args, **kwargs))
 
-    async def execute_async(self, sql: str, param: Union["ParamType", "ListParamType"] = None) -> int:
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    async def execute_async(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...
+
+    @overload
+    async def execute_async(self, sql: str, *, param: Union["ParamType", "ListParamType"] = None) -> int: ...
+
+    async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
             return await handler.execute_async(cursor)
 
@@ -424,7 +669,32 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_async(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ..., *, buffered: "Literal[False]"
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        *,
+        buffered: "Literal[True]" = True,
+        params: Optional["ParamType"],
+    ) -> List[Dict[str, Any]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[False]",
+    ) -> AsyncGenerator[Dict[str, Any], None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        *,
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
     ) -> AsyncGenerator[Dict[str, Any], None]: ...
 
     @overload
@@ -441,26 +711,64 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
     ) -> AsyncGenerator["_T", None]: ...
 
-    async def query_async(self, sql, model=dict, param=None, buffered=True):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> AsyncGenerator["_T", None]: ...
+
+    async def query_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         if buffered:
             records = await self._buffered_query(handler, model)
             return records
         return self._unbuffered_query(handler, model)
 
+    @overload
     async def query_multiple_async(
         self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, param: Optional["ParamType"] = None
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    async def query_multiple_async(
+        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
+    ) -> Tuple[List[Any], ...]: ...
+
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
+        resolved_params = self._resolve_params(param, params)
+
         if models is None:
             models = cast(Tuple[dict], tuple(dict for _ in queries))
 
@@ -470,7 +778,7 @@ class CommandsAsync(BaseCommands, ABC):
         results = list()
         async with self.cursor() as cursor:
             for query, model in zip(queries, models):
-                handler = self.SqlParamHandler(query, param)
+                handler = self.SqlParamHandler(query, resolved_params)
                 await handler.execute_async(cursor)
                 headers = get_col_names(cursor)
                 data = await cursor.fetchall()
@@ -485,16 +793,38 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_first_async(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Dict[str, Any]: ...
 
     @overload
     async def query_first_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
+        self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> "_T": ...
 
-    async def query_first_async(self, sql, model=dict, param=None):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    async def query_first_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
@@ -506,12 +836,40 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_first_or_default_async(
-        self, sql: str, default: Callable[[], "_Default"], model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
     async def query_first_or_default_async(
-        self, sql: str, default: "_Default", model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -528,30 +886,75 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_or_default_async(
         self,
         sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
-    async def query_first_or_default_async(self, sql, default, model=dict, param=None):
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    async def query_first_or_default_async(
+        self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET
+    ):
+        resolved_params = self._resolve_params(param, params)
         try:
-            return await self.query_first_async(sql, model=model, param=param)
+            return await self.query_first_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return default() if callable(default) else default
 
     @overload
     async def query_single_async(
-        self, sql: str, model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Dict[str, Any]: ...
 
     @overload
     async def query_single_async(
-        self, sql: str, param: Optional["ParamType"] = ..., *, model: Union[Type["_T"], Callable[..., "_T"]]
+        self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]
+    ) -> Dict[str, Any]: ...
+
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> "_T": ...
 
-    async def query_single_async(self, sql, model=dict, param=None):
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    async def query_single_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
@@ -568,12 +971,40 @@ class CommandsAsync(BaseCommands, ABC):
 
     @overload
     async def query_single_or_default_async(
-        self, sql: str, default: Callable[[], "_Default"], model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
     async def query_single_or_default_async(
-        self, sql: str, default: "_Default", model: Type[Dict] = dict, param: Optional["ParamType"] = ...
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", Dict[str, Any]]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Type[Dict] = dict,
+        *,
+        params: Optional["ParamType"],
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -590,24 +1021,50 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_or_default_async(
         self,
         sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
         default: "_Default",
         param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
     ) -> Union["_Default", "_T"]: ...
 
-    async def query_single_or_default_async(self, sql, default, model=dict, param=None):
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    async def query_single_or_default_async(
+        self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET
+    ):
+        resolved_params = self._resolve_params(param, params)
         try:
-            return await self.query_single_async(sql, model=model, param=param)
+            return await self.query_single_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return default() if callable(default) else default
 
-    async def execute_scalar_async(
-        self,
-        sql: str,
-        param: "ParamType" = None,
-    ) -> Any:
-        handler = self.SqlParamHandler(sql, param)
+    @overload
+    async def execute_scalar_async(self, sql: str, params: "ParamType" = None) -> Any: ...
+
+    @overload
+    async def execute_scalar_async(self, sql: str, *, param: "ParamType" = None) -> Any: ...
+
+    async def execute_scalar_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             first_row = await cursor.fetchone()

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -1,11 +1,10 @@
 from typing import TYPE_CHECKING
-from typing import Any
 
 from pydapper import register
+from pydapper.commands import _PARAM_ALIAS_UNSET
 from pydapper.commands import Commands
 
 from ..exceptions import NoResultException
-from ..types import ParamType
 from ..utils import database_row_to_dict
 from ..utils import get_col_names
 from ..utils import import_dbapi_module
@@ -34,13 +33,16 @@ class MySqlConnectorPythonCommands(Commands):
         self,
         sql,
         model=dict,
-        param=None,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
     ):
         """
         the mysql connector throws an exception if you only read one row from a cursor.  Unfortunately, we have to
         fetchall to make the lib happy.
         """
-        handler = self.SqlParamHandler(sql, param)
+        resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
 
         with self.cursor() as cursor:
             handler.execute(cursor)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -15,6 +15,236 @@ from tests.mocks import MockParamHandler
 pytestmark = pytest.mark.core
 
 
+@pytest.fixture
+def captured_handler_params(monkeypatch):
+    captured = []
+    original_init = MockParamHandler.__init__
+
+    def capture_init(self, sql, param=None):
+        captured.append(param)
+        original_init(self, sql, param)
+
+    monkeypatch.setattr(MockParamHandler, "__init__", capture_init)
+    return captured
+
+
+SYNC_PARAMS_CALLS = [
+    pytest.param(
+        lambda commands, params: commands.execute("insert into some_table (id) values (?id?)", params=params),
+        1,
+        id="execute",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query("select id, name from some_table where id = ?id?", params=params),
+        1,
+        id="query",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_multiple(
+            (
+                "select id, name from some_table where id = ?id?",
+                "select id, name from another_table where id = ?id?",
+            ),
+            params=params,
+        ),
+        2,
+        id="query_multiple",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first("select id, name from some_table where id = ?id?", params=params),
+        1,
+        id="query_first",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_or_default(
+            "select id, name from some_table where id = ?id?", None, params=params
+        ),
+        1,
+        id="query_first_or_default",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single(
+            "select id, name from some_table where id = ?id?", params=params
+        ),
+        1,
+        id="query_single",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_or_default(
+            "select id, name from some_table where id = ?id?", None, params=params
+        ),
+        1,
+        id="query_single_or_default",
+    ),
+    pytest.param(
+        lambda commands, params: commands.execute_scalar("select id from some_table where id = ?id?", params=params),
+        1,
+        id="execute_scalar",
+    ),
+]
+
+SYNC_ALIAS_CONFLICT_CALLS = [
+    pytest.param(
+        lambda commands, params: commands.execute(
+            "insert into some_table (id) values (?id?)", param=params, params=params
+        ),
+        id="execute",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_multiple(
+            ("select id, name from some_table where id = ?id?",), param=params, params=params
+        ),
+        id="query_multiple",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query_first",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_or_default(
+            "select id, name from some_table where id = ?id?", None, param=params, params=params
+        ),
+        id="query_first_or_default",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query_single",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_or_default(
+            "select id, name from some_table where id = ?id?", None, param=params, params=params
+        ),
+        id="query_single_or_default",
+    ),
+    pytest.param(
+        lambda commands, params: commands.execute_scalar(
+            "select id from some_table where id = ?id?", param=params, params=params
+        ),
+        id="execute_scalar",
+    ),
+]
+
+ASYNC_PARAMS_CALLS = [
+    pytest.param(
+        lambda commands, params: commands.execute_async("insert into some_table (id) values (?id?)", params=params),
+        1,
+        id="execute_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_async("select id, name from some_table where id = ?id?", params=params),
+        1,
+        id="query_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_multiple_async(
+            (
+                "select id, name from some_table where id = ?id?",
+                "select id, name from another_table where id = ?id?",
+            ),
+            params=params,
+        ),
+        2,
+        id="query_multiple_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_async(
+            "select id, name from some_table where id = ?id?", params=params
+        ),
+        1,
+        id="query_first_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_or_default_async(
+            "select id, name from some_table where id = ?id?", None, params=params
+        ),
+        1,
+        id="query_first_or_default_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_async(
+            "select id, name from some_table where id = ?id?", params=params
+        ),
+        1,
+        id="query_single_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_or_default_async(
+            "select id, name from some_table where id = ?id?", None, params=params
+        ),
+        1,
+        id="query_single_or_default_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.execute_scalar_async(
+            "select id from some_table where id = ?id?", params=params
+        ),
+        1,
+        id="execute_scalar_async",
+    ),
+]
+
+ASYNC_ALIAS_CONFLICT_CALLS = [
+    pytest.param(
+        lambda commands, params: commands.execute_async(
+            "insert into some_table (id) values (?id?)", param=params, params=params
+        ),
+        id="execute_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_async(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_multiple_async(
+            ("select id, name from some_table where id = ?id?",), param=params, params=params
+        ),
+        id="query_multiple_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_async(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query_first_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_first_or_default_async(
+            "select id, name from some_table where id = ?id?", None, param=params, params=params
+        ),
+        id="query_first_or_default_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_async(
+            "select id, name from some_table where id = ?id?", param=params, params=params
+        ),
+        id="query_single_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.query_single_or_default_async(
+            "select id, name from some_table where id = ?id?", None, param=params, params=params
+        ),
+        id="query_single_or_default_async",
+    ),
+    pytest.param(
+        lambda commands, params: commands.execute_scalar_async(
+            "select id from some_table where id = ?id?", param=params, params=params
+        ),
+        id="execute_scalar_async",
+    ),
+]
+
+
 class TestParamHandler:
     def test__init__validation(self):
         with pytest.raises(ValueError):
@@ -23,6 +253,11 @@ class TestParamHandler:
     def test_get_param_placeholder(self):
         handler = MockParamHandler("sup", None)
         assert handler.get_param_placeholder("sup") == "%s"
+
+    def test_param_alias_unset_repr_matches_legacy_default_display(self):
+        from pydapper.commands import _PARAM_ALIAS_UNSET
+
+        assert repr(_PARAM_ALIAS_UNSET) == "None"
 
     def test_ordered_param_names(self):
         handler = MockParamHandler("?sup? ?hello? ?world? ?foo? ?bar?", None)
@@ -110,6 +345,59 @@ class TestCommands:
                 "insert into some_table (id, name), (?id?, ?name?)", param={"id": 1, "name": "Zach"}
             )
         assert affected_rows == 1
+
+    @pytest.mark.parametrize("call, expected_handler_count", SYNC_PARAMS_CALLS)
+    def test_public_methods_accept_params(
+        self, connection, captured_handler_params, set_fetchall_return_one, call, expected_handler_count
+    ):
+        params = {"id": 1}
+
+        with MockCommands(connection) as commands:
+            call(commands, params)
+
+        assert captured_handler_params == [params] * expected_handler_count
+
+    @pytest.mark.parametrize("call", SYNC_ALIAS_CONFLICT_CALLS)
+    def test_public_methods_reject_param_and_params(self, connection, call):
+        params = {"id": 1}
+
+        with MockCommands(connection) as commands, pytest.raises(ValueError, match="Pass either 'params' or 'param'"):
+            call(commands, params)
+
+    def test_or_default_methods_preserve_param_only_overrides(self, connection):
+        class ParamOnlyOverrideCommands(MockCommands):
+            def query_first(self, sql, model=dict, param=None):
+                assert param == {"id": 1}
+                raise NoResultException
+
+            def query_single(self, sql, model=dict, param=None):
+                assert param == {"id": 1}
+                raise NoResultException
+
+        default = object()
+
+        with ParamOnlyOverrideCommands(connection) as commands:
+            assert (
+                commands.query_first_or_default("select * from some_table where id = ?id?", default, params={"id": 1})
+                is default
+            )
+            assert (
+                commands.query_single_or_default("select * from some_table where id = ?id?", default, params={"id": 1})
+                is default
+            )
+
+    def test_mysql_query_first_accepts_params(self, connection, captured_handler_params):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        params = {"id": 1}
+
+        with MockMySqlConnectorPythonCommands(connection) as commands:
+            commands.query_first("select id, name from some_table where id = ?id?", params=params)
+
+        assert captured_handler_params == [params]
 
     def test_query(self, connection):
         with MockCommands(connection) as commands:
@@ -242,6 +530,54 @@ class TestCommandsAsync:
                 "insert into some_table (id, name), (?id?, ?name?)", param={"id": 1, "name": "Zach"}
             )
         assert affected_rows == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call, expected_handler_count", ASYNC_PARAMS_CALLS)
+    async def test_public_methods_accept_params(
+        self, connection, captured_handler_params, set_fetchall_return_one, call, expected_handler_count
+    ):
+        params = {"id": 1}
+
+        async with MockAsyncCommands(connection) as commands:
+            await call(commands, params)
+
+        assert captured_handler_params == [params] * expected_handler_count
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call", ASYNC_ALIAS_CONFLICT_CALLS)
+    async def test_public_methods_reject_param_and_params(self, connection, call):
+        params = {"id": 1}
+
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'params' or 'param'"):
+                await call(commands, params)
+
+    @pytest.mark.asyncio
+    async def test_or_default_methods_preserve_param_only_overrides(self, connection):
+        class ParamOnlyOverrideCommands(MockAsyncCommands):
+            async def query_first_async(self, sql, model=dict, param=None):
+                assert param == {"id": 1}
+                raise NoResultException
+
+            async def query_single_async(self, sql, model=dict, param=None):
+                assert param == {"id": 1}
+                raise NoResultException
+
+        default = object()
+
+        async with ParamOnlyOverrideCommands(connection) as commands:
+            assert (
+                await commands.query_first_or_default_async(
+                    "select * from some_table where id = ?id?", default, params={"id": 1}
+                )
+                is default
+            )
+            assert (
+                await commands.query_single_or_default_async(
+                    "select * from some_table where id = ?id?", default, params={"id": 1}
+                )
+                is default
+            )
 
     @pytest.mark.asyncio
     async def test_query(self, connection):

--- a/tests/test_oracle/test_oracledb.py
+++ b/tests/test_oracle/test_oracledb.py
@@ -100,6 +100,10 @@ class TestQueryMultiple(QueryMultipleTestSuite):
 
 class TestQueryFirst(QueryFirstTestSuite):
     def test_param(self, commands, task_table_name):
+        task = commands.query_first(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
+        assert task["ID"] == 1
+
+    def test_param_alias(self, commands, task_table_name):
         task = commands.query_first(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
         assert task["ID"] == 1
 
@@ -113,7 +117,7 @@ class TestQuerySingle(QuerySingleTestSuite):
         assert task["ID"] == 1
 
     def test_param(self, commands, task_table_name):
-        task = commands.query_single(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
+        task = commands.query_single(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
         assert task["ID"] == 1
 
 

--- a/tests/test_suites/commands.py
+++ b/tests/test_suites/commands.py
@@ -65,7 +65,7 @@ class QueryTestSuite:
     def test_param(self, commands: Commands, task_table_name):
         data = commands.query(
             f"select * from {task_table_name} where due_date = ?due_date?",
-            param={"due_date": datetime.date(2021, 12, 31)},
+            params={"due_date": datetime.date(2021, 12, 31)},
         )
         assert len(data) == 2
         assert all(isinstance(record, dict) for record in data)
@@ -92,7 +92,7 @@ class QueryAsyncTestSuite:
     async def test_param(self, commands: CommandsAsync, task_table_name):
         data = await commands.query_async(
             f"select * from {task_table_name} where due_date = ?due_date?",
-            param={"due_date": datetime.date(2021, 12, 31)},
+            params={"due_date": datetime.date(2021, 12, 31)},
         )
         assert len(data) == 2
         assert all(isinstance(record, dict) for record in data)
@@ -120,7 +120,7 @@ class QueryMultipleTestSuite:
                 f"select * from {owner_table_name} where id = ?id?",
                 f"select * from {task_table_name} where due_date = ?due_date?",
             ),
-            param={"id": 1, "due_date": datetime.date(2021, 12, 31)},
+            params={"id": 1, "due_date": datetime.date(2021, 12, 31)},
         )
         assert len(owner) == 1
         assert len(task) == 2
@@ -172,7 +172,7 @@ class QueryMultipleAsyncTestSuite:
                 f"select * from {owner_table_name} where id = ?id?",
                 f"select * from {task_table_name} where due_date = ?due_date?",
             ),
-            param={"id": 1, "due_date": datetime.date(2021, 12, 31)},
+            params={"id": 1, "due_date": datetime.date(2021, 12, 31)},
         )
         assert len(owner) == 1
         assert len(task) == 2
@@ -213,6 +213,10 @@ class QueryFirstTestSuite:
         assert isinstance(task, dict)
 
     def test_param(self, commands: Commands, task_table_name):
+        task = commands.query_first(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
+        assert task["id"] == 1
+
+    def test_param_alias(self, commands: Commands, task_table_name):
         task = commands.query_first(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
         assert task["id"] == 1
 
@@ -225,6 +229,11 @@ class QueryFirstAsyncTestSuite:
 
     @pytest.mark.asyncio
     async def test_param(self, commands: CommandsAsync, task_table_name):
+        task = await commands.query_first_async(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
+        assert task["id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_param_alias(self, commands: CommandsAsync, task_table_name):
         task = await commands.query_first_async(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
         assert task["id"] == 1
 
@@ -238,7 +247,7 @@ class QueryFirstOrDefaultTestSuite:
     def test_param(self, commands: Commands, task_table_name):
         sentinel = object()
         task = commands.query_first_or_default(
-            f"select * from {task_table_name} where id = ?id?", param={"id": 1000}, default=sentinel
+            f"select * from {task_table_name} where id = ?id?", params={"id": 1000}, default=sentinel
         )
         assert task is sentinel
 
@@ -256,7 +265,7 @@ class QueryFirstOrDefaultAsyncTestSuite:
     async def test_param(self, commands: CommandsAsync, task_table_name):
         sentinel = object()
         task = await commands.query_first_or_default_async(
-            f"select * from {task_table_name} where id = ?id?", param={"id": 1000}, default=sentinel
+            f"select * from {task_table_name} where id = ?id?", params={"id": 1000}, default=sentinel
         )
         assert task is sentinel
 
@@ -267,7 +276,7 @@ class QuerySingleTestSuite:
         assert task["id"] == 1
 
     def test_param(self, commands: Commands, task_table_name):
-        task = commands.query_single(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
+        task = commands.query_single(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
         assert task["id"] == 1
 
 
@@ -279,7 +288,7 @@ class QuerySingleAsyncTestSuite:
 
     @pytest.mark.asyncio
     async def test_param(self, commands: CommandsAsync, task_table_name):
-        task = await commands.query_single_async(f"select id from {task_table_name} where id = ?id?", param={"id": 1})
+        task = await commands.query_single_async(f"select id from {task_table_name} where id = ?id?", params={"id": 1})
         assert task["id"] == 1
 
 
@@ -292,7 +301,7 @@ class QuerySingleOrDefaultTestSuite:
     def test_param(self, commands: Commands, task_table_name):
         sentinel = object()
         task = commands.query_single_or_default(
-            f"select * from {task_table_name} where id = ?id?", param={"id": 1000}, default=sentinel
+            f"select * from {task_table_name} where id = ?id?", params={"id": 1000}, default=sentinel
         )
         assert task is sentinel
 
@@ -310,7 +319,7 @@ class QuerySingleOrDefaultAsyncTestSuite:
     async def test_param(self, commands: CommandsAsync, task_table_name):
         sentinel = object()
         task = await commands.query_single_or_default_async(
-            f"select * from {task_table_name} where id = ?id?", param={"id": 1000}, default=sentinel
+            f"select * from {task_table_name} where id = ?id?", params={"id": 1000}, default=sentinel
         )
         assert task is sentinel
 
@@ -322,7 +331,7 @@ class ExecuteScalarTestSuite:
 
     def test_param(self, commands: Commands, task_table_name):
         first_task_description = commands.execute_scalar(
-            f"select description from {task_table_name} where id = ?id?", param={"id": 1}
+            f"select description from {task_table_name} where id = ?id?", params={"id": 1}
         )
         assert first_task_description == "Set up a test database"
 
@@ -336,6 +345,6 @@ class ExecuteScalarAsyncTestSuite:
     @pytest.mark.asyncio
     async def test_param(self, commands: CommandsAsync, task_table_name):
         first_task_description = await commands.execute_scalar_async(
-            f"select description from {task_table_name} where id = ?id?", param={"id": 1}
+            f"select description from {task_table_name} where id = ?id?", params={"id": 1}
         )
         assert first_task_description == "Set up a test database"

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -5,6 +5,7 @@ from typing import AsyncGenerator
 from typing import Dict
 from typing import Generator
 from typing import List
+from typing import Tuple
 from typing import Union
 
 import pytest
@@ -31,7 +32,21 @@ def default_callable() -> str:
 
 class Commands:
     @staticmethod
+    def execute(query: str) -> None:
+        params = {"id": 1}
+
+        with pydapper.connect() as commands:
+            assert_type(commands.execute(query, param=params), int)
+            assert_type(commands.execute(query, params=params), int)
+            assert_type(commands.execute_scalar(query, param=params), Any)
+            assert_type(commands.execute_scalar(query, params=params), Any)
+            assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
+            assert_type(commands.query_multiple((query,), params=params), Tuple[List[Any], ...])
+
+    @staticmethod
     def query(query: str) -> None:
+        params = {"id": 1}
+
         with pydapper.connect() as commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
@@ -42,15 +57,25 @@ class Commands:
                 Generator[Task, None, None],
             )
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
+            assert_type(commands.query(query, param=params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=params, model=Task), List[Task])
 
     @staticmethod
     def query_first(query: str) -> None:
+        params = {"id": 1}
+
         with pydapper.connect() as commands:
             assert_type(commands.query_first(query), Dict[str, Any])
             assert_type(commands.query_first(query, model=Task), Task)
+            assert_type(commands.query_first(query, param=params), Dict[str, Any])
+            assert_type(commands.query_first(query, params=params), Dict[str, Any])
+            assert_type(commands.query_first(query, params=params, model=Task), Task)
 
     @staticmethod
     def query_first_or_default(query: str) -> None:
+        params = {"id": 1}
+
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(commands.query_first_or_default(query, default_callable, model=Task), Union[str, Task])
@@ -58,15 +83,24 @@ class Commands:
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(commands.query_first_or_default(query, "hello", model=Task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, "hello"), Union[str, Dict[str, Any]])
+            assert_type(commands.query_first_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
+            assert_type(commands.query_first_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
 
     @staticmethod
     def query_single(query: str) -> None:
+        params = {"id": 1}
+
         with pydapper.connect() as commands:
             assert_type(commands.query_single(query), Dict[str, Any])
             assert_type(commands.query_single(query, model=Task), Task)
+            assert_type(commands.query_single(query, param=params), Dict[str, Any])
+            assert_type(commands.query_single(query, params=params), Dict[str, Any])
+            assert_type(commands.query_single(query, params=params, model=Task), Task)
 
     @staticmethod
     def query_single_or_default(query: str) -> None:
+        params = {"id": 1}
+
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(commands.query_single_or_default(query, default_callable, model=Task), Union[str, Task])
@@ -74,25 +108,51 @@ class Commands:
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(commands.query_single_or_default(query, "hello", model=Task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, "hello"), Union[str, Dict[str, Any]])
+            assert_type(commands.query_single_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
+            assert_type(commands.query_single_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
 
 
 class CommandsAsync:
     @staticmethod
+    async def execute(query: str) -> None:
+        params = {"id": 1}
+
+        async with pydapper.connect_async() as commands:
+            assert_type(await commands.execute_async(query, param=params), int)
+            assert_type(await commands.execute_async(query, params=params), int)
+            assert_type(await commands.execute_scalar_async(query, param=params), Any)
+            assert_type(await commands.execute_scalar_async(query, params=params), Any)
+            assert_type(await commands.query_multiple_async((query,), param=params), Tuple[List[Any], ...])
+            assert_type(await commands.query_multiple_async((query,), params=params), Tuple[List[Any], ...])
+
+    @staticmethod
     async def query(query: str):
+        params = {"id": 1}
+
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_async(query, buffered=True), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, buffered=False), AsyncGenerator[Dict[str, Any], None])
             assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
+            assert_type(await commands.query_async(query, param=params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=params, model=Task), List[Task])
 
     @staticmethod
     async def query_first(query: str) -> None:
+        params = {"id": 1}
+
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_first_async(query), Dict[str, Any])
             assert_type(await commands.query_first_async(query, model=Task), Task)
+            assert_type(await commands.query_first_async(query, param=params), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, params=params), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, params=params, model=Task), Task)
 
     @staticmethod
     async def query_first_or_default(query: str) -> None:
+        params = {"id": 1}
+
         async with pydapper.connect_async() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(
@@ -104,15 +164,28 @@ class CommandsAsync:
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(await commands.query_first_or_default_async(query, "hello", model=Task), Union[str, Task])
             assert_type(await commands.query_first_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
+            assert_type(
+                await commands.query_first_or_default_async(query, "hello", param=params), Union[str, Dict[str, Any]]
+            )
+            assert_type(
+                await commands.query_first_or_default_async(query, "hello", params=params), Union[str, Dict[str, Any]]
+            )
 
     @staticmethod
     async def query_single(query: str) -> None:
+        params = {"id": 1}
+
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_single_async(query), Dict[str, Any])
             assert_type(await commands.query_single_async(query, model=Task), Task)
+            assert_type(await commands.query_single_async(query, param=params), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, params=params), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, params=params, model=Task), Task)
 
     @staticmethod
     async def query_single_or_default(query: str) -> None:
+        params = {"id": 1}
+
         async with pydapper.connect_async() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(
@@ -124,3 +197,9 @@ class CommandsAsync:
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(await commands.query_single_or_default_async(query, "hello", model=Task), Union[str, Task])
             assert_type(await commands.query_single_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
+            assert_type(
+                await commands.query_single_or_default_async(query, "hello", param=params), Union[str, Dict[str, Any]]
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, "hello", params=params), Union[str, Dict[str, Any]]
+            )


### PR DESCRIPTION
## Summary
- add `params=` support across public sync and async command APIs while preserving `param=`
- reject calls that supply both aliases
- update typing overloads, type tests, docs, and examples to prefer `params=`
- keep compatibility for existing `param`-only subclass overrides in default methods

Closes #455.

## Validation
- `poetry run pytest tests/test_commands_interface.py tests/type_tests.py tests/test_sqlite/test_sqlite3.py`
- `poetry run pytest -m core`
- `poetry run mypy pydapper tests/type_tests.py`
- `poetry run mypy -c $'import pydapper\nfrom typing import Dict\nparams: Dict[str, int] = {"id": 1}\nwith pydapper.connect() as c:\n    c.query("select ?id?", param=params, params=params)'` fails as expected because both aliases are supplied
- `poetry run black --check pydapper tests`
- `poetry run isort --check .`
- `git diff --check`

## Not run
- optional external database suites beyond SQLite
- `poetry run mkdocs build --strict --site-dir /tmp/pydapper-mkdocs-site`: `mkdocs` is not installed in the current Poetry environment
