### PR TITLE
docs: add AI development guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Agent Guide
+
+This file is for coding agents working in pydapper. Keep changes narrow, prefer the
+existing patterns, and report exactly which checks ran.
+
+## Repository Shape
+
+* `pydapper/` contains the runtime package. `main.py` exposes the public entry
+  points, `commands.py` holds the shared command behavior, and each database
+  backend has its own subpackage.
+* `tests/` mirrors the supported backends. Core tests live in top-level test
+  files and driver tests live under `tests/test_<backend>/`.
+* `tests/test_suites/commands.py` contains shared behavior exercised by
+  backend-specific tests. Reuse it when adding driver coverage.
+* `tests/databases/` contains SQL fixtures for integration tests.
+* `docs/` is the MkDocs source. Runnable docs examples live in `docs_src/` and
+  are included from markdown with `markdown_include`.
+
+## Development Setup
+
+Use Poetry as the source of truth. Do not update `poetry.lock`, add
+dependencies, or install optional extras unless the change needs them.
+
+```console
+poetry install
+poetry install --with docs
+```
+
+The package currently declares Python `>=3.10,<4.0`, and CI runs Python
+3.10-3.14. Do not introduce syntax or dependencies that break the oldest
+supported runtime without updating project metadata and CI together.
+
+## Core Commands
+
+```console
+poetry run pytest -m "core"
+poetry run pytest -m "sqlite"
+poetry run mypy pydapper
+poetry run mypy tests/type_tests.py
+poetry run black --check .
+poetry run isort --check .
+poetry run mkdocs build --strict
+```
+
+Useful Make targets:
+
+```console
+make fmt
+make mypy
+make test
+make test-cov
+make docs
+```
+
+`make test` runs the whole pytest suite. In narrow PRs, prefer marker-scoped
+tests so you do not start optional database integrations accidentally.
+
+## Driver-Specific Tests
+
+Run driver tests only when the change touches that backend, shared command
+behavior, DSN parsing, or docs that claim backend behavior. These tests may use
+Docker, testcontainers, external images, emulator startup, or cloud/client
+packages.
+
+```console
+poetry install -E psycopg2 -E psycopg -E aiopg
+poetry run pytest -m "postgresql"
+
+poetry install -E pymssql
+poetry run pytest -m "mssql"
+
+poetry install -E mysql-connector-python
+poetry run pytest -m "mysql"
+
+poetry install -E oracledb
+poetry run pytest -m "oracle"
+
+poetry install -E google-cloud-bigquery
+poetry run pytest -m "bigquery"
+```
+
+For CI-equivalent coverage output, add:
+
+```console
+--cov=. --cov-branch -v --durations=25 --cov-report=xml
+```
+
+Do not run optional integrations blindly in documentation-only or narrowly
+scoped PRs. State clearly when they were skipped.
+
+## Coding Expectations
+
+* Preserve the small DBAPI wrapper model. Avoid adding mandatory dependencies
+  for optional database support.
+* Keep sync and async behavior aligned where a backend supports both.
+* Keep parameter handling safe for each DBAPI. Do not replace structured driver
+  behavior with ad hoc SQL string formatting.
+* Keep imports Black/isort compatible. isort is configured for one import per
+  line and Black uses a 120 character line length.
+* pydapper is typed (`pydapper/py.typed`). Public API changes should include
+  type-test coverage in `tests/type_tests.py` when relevant.
+* Treat behavior changes to `connect`, `connect_async`, `using`,
+  `using_async`, command methods, DSN parsing, and parameter substitution as
+  compatibility-sensitive.
+
+## Docs Expectations
+
+* Public documentation lives in `docs/`; runnable examples live in `docs_src/`.
+* Add new docs pages to `mkdocs.yml` so they are discoverable.
+* Prefer concise examples that can run as shown. Keep README-level installation
+  and usage content out of development docs.
+* Build docs with `poetry run mkdocs build --strict` when docs dependencies are
+  already available.
+
+## Roadmap And Review
+
+The pydapper v1 roadmap is tracked in GitHub issues, especially
+[#446](https://github.com/zschumacher/pydapper/issues/446). Do not fold broad
+v1 API redesign into incidental bug fixes or documentation PRs unless the issue
+explicitly calls for it.
+
+PR titles should always use Conventional Commits format, for example
+`docs: add agent development guide` or `fix: handle param alias conflict`.
+
+In PR summaries, include:
+
+* What changed and why.
+* Which commands ran and their results.
+* Which driver-specific tests were skipped and why.
+* Any public API, type compatibility, docs, or optional-extra impact.
+
+Repo-local Codex skills are not currently needed. Prefer this file and the
+development docs unless a future workflow needs reusable, task-specific context
+that would otherwise bloat normal agent prompts.

--- a/docs/development/ai-assisted-development.md
+++ b/docs/development/ai-assisted-development.md
@@ -1,0 +1,68 @@
+# AI-assisted development
+
+This page summarizes the checks and review expectations for AI-assisted changes
+to pydapper. It is intentionally shorter than the root `AGENTS.md`; use that
+file as the operating guide for coding agents.
+
+## Scope changes narrowly
+
+Most pydapper changes affect one of these areas:
+
+* shared command behavior in `pydapper/commands.py`
+* public entry points and DSN routing in `pydapper/main.py` and
+  `pydapper/dsn_parser.py`
+* one optional database backend under `pydapper/<backend>/`
+* tests and fixtures under the matching `tests/test_<backend>/` and
+  `tests/databases/` paths
+* documentation under `docs/` with runnable snippets under `docs_src/`
+
+Keep optional database dependencies optional. Avoid changing package metadata,
+lock files, CI, or multiple backends unless the task requires it.
+
+## Preferred checks
+
+Run the smallest check set that covers the change:
+
+```console
+poetry run pytest -m "core"
+poetry run pytest -m "sqlite"
+poetry run mypy pydapper
+poetry run mypy tests/type_tests.py
+poetry run black --check .
+poetry run isort --check .
+poetry run mkdocs build --strict
+```
+
+Driver-specific checks should be explicit and justified:
+
+```console
+poetry run pytest -m "postgresql"
+poetry run pytest -m "mssql"
+poetry run pytest -m "mysql"
+poetry run pytest -m "oracle"
+poetry run pytest -m "bigquery"
+```
+
+The non-SQLite driver tests may need Poetry extras, Docker, testcontainers,
+external images, emulators, or cloud/client packages. Do not run them blindly in
+narrow PRs; say which ones were skipped and why.
+
+## Compatibility notes
+
+pydapper currently targets Python `>=3.10,<4.0`, with CI coverage for Python
+3.10-3.14. Public command methods, connection helpers, DSN parsing, parameter
+substitution, and optional extras are compatibility-sensitive. Keep type-test
+coverage current for public typing behavior.
+
+The pydapper v1 roadmap is tracked in GitHub issues, especially
+[#446](https://github.com/zschumacher/pydapper/issues/446). Keep broad v1 API
+work tied to those issues instead of mixing it into unrelated PRs.
+
+## PR handoff
+
+An AI-assisted PR should make review easy:
+
+* summarize the behavior or docs change
+* list commands run and outcomes
+* list skipped optional driver checks
+* call out public API, typing, docs, or compatibility impact

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ nav:
       - query_single_async: async_methods/query_single_async.md
       - query_single_or_default_async: async_methods/query_single_or_default_async.md
       - query_multiple_async: async_methods/query_multiple_async.md
+  - Development:
+      - AI-assisted development: development/ai-assisted-development.md
   - Release Notes: release_notes.md
 
 theme:
@@ -68,7 +70,7 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format ''
   - pymdownx.extra
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: 🔗


### PR DESCRIPTION
## Summary

* add a root `AGENTS.md` with repository shape, check selection, compatibility-sensitive areas, driver-test guidance, and PR handoff expectations
* document AI-assisted development expectations under the MkDocs development nav
* update the MkDocs Material emoji extension namespace so `mkdocs build --strict` passes with current docs dependencies

## Checks

* `poetry install --with docs`
* `poetry run mkdocs build --strict --site-dir /tmp/pydapper-ai-instrumentation-mkdocs-site`
* `git diff --check`
* `rg -n " +$" AGENTS.md docs/development/ai-assisted-development.md mkdocs.yml`

Skipped optional database driver suites because this is documentation and docs configuration only.
