### PR TITLE
v1: define public exceptions and cardinality semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,12 +122,19 @@ explicitly calls for it.
 PR titles should always use Conventional Commits format, for example
 `docs: add agent development guide` or `fix: handle param alias conflict`.
 
-In PR summaries, include:
+PR descriptions should be self-contained. Prefer a short structured body with
+these pieces:
 
 * What changed and why.
+* A concrete example of the behavior before and after, when behavior changes.
 * Which commands ran and their results.
 * Which driver-specific tests were skipped and why.
 * Any public API, type compatibility, docs, or optional-extra impact.
+
+Keep examples small and reviewable. For API changes, show import paths or call
+patterns. For bug fixes, show the edge case that now works. For docs-only
+changes, name the docs page or generated site area instead of inventing a
+runtime example.
 
 Repo-local Codex skills are not currently needed. Prefer this file and the
 development docs unless a future workflow needs reusable, task-specific context

--- a/docs/.first_single_default.md
+++ b/docs/.first_single_default.md
@@ -1,4 +1,5 @@
-Be careful to use the right method.  `first` and `single` methods are very different.
+Be careful to use the right method. `first` and `single` methods are very different.
+For default methods, callable defaults are called only when no row is returned.
 
 | method              | no item             | one item | many items                   | 
 |---------------------|---------------------|----------|------------------------------|

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -11,6 +11,11 @@ the query.  The additional columns or rows are ignored.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+## Cardinality
+- 0 rows: raises `NoResultException`.
+- 1+ rows: returns the first column of the first row.
+- SQL `NULL` in the first column is returned as Python `None`.
+
 ## Example
 Get the name of the first task owner in the database.
 

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -12,6 +12,10 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+## Cardinality
+- 0 rows with `buffered=True`: returns an empty list.
+- 0 rows with `buffered=False`: returns an async generator that yields no rows.
+
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query_async` method and map the results to a list of dataclasses.
 ```python

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -11,6 +11,11 @@ the query.  The additional columns or rows are ignored.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+## Cardinality
+- 0 rows: raises `NoResultException`.
+- 1+ rows: returns the first column of the first row.
+- SQL `NULL` in the first column is returned as Python `None`.
+
 ## Example
 Get the name of the first task owner in the database.
 

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -12,6 +12,10 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+## Cardinality
+- 0 rows with `buffered=True`: returns an empty list.
+- 0 rows with `buffered=False`: returns a generator that yields no rows.
+
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query` method and map the results to a list of dataclasses.
 ```python

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -195,7 +195,7 @@ class Commands(BaseCommands, ABC):
             headers = get_col_names(cursor)
             while True:
                 row = cursor.fetchone()
-                if not row:
+                if row is None:
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
 
@@ -369,7 +369,7 @@ class Commands(BaseCommands, ABC):
             handler.execute(cursor)
             headers = get_col_names(cursor)
             row = cursor.fetchone()
-            if not row:
+            if row is None:
                 raise NoResultException("Query returned no results")
         return serialize_dict_row(model, database_row_to_dict(headers, row))
 
@@ -601,7 +601,7 @@ class Commands(BaseCommands, ABC):
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             first_row = cursor.fetchone()
-        if not first_row:
+        if first_row is None:
             raise NoResultException("Query returned no results")
         return first_row[0]
 
@@ -653,7 +653,7 @@ class CommandsAsync(BaseCommands, ABC):
             headers = get_col_names(cursor)
             while True:
                 row = await cursor.fetchone()
-                if not row:
+                if row is None:
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
 
@@ -830,7 +830,7 @@ class CommandsAsync(BaseCommands, ABC):
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             row = await cursor.fetchone()
-            if not row:
+            if row is None:
                 raise NoResultException("Query returned no results")
         return serialize_dict_row(model, database_row_to_dict(headers, row))
 
@@ -1068,6 +1068,6 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             first_row = await cursor.fetchone()
-        if not first_row:
+        if first_row is None:
             raise NoResultException("Query returned no results")
         return first_row[0]

--- a/pydapper/exceptions.py
+++ b/pydapper/exceptions.py
@@ -8,3 +8,15 @@ class NoResultException(PyDapperException):
 
 class MoreThanOneResultException(PyDapperException):
     pass
+
+
+class MissingParameterException(PyDapperException):
+    pass
+
+
+class UnsupportedFeatureError(PyDapperException):
+    pass
+
+
+class RowMappingException(PyDapperException):
+    pass

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -48,7 +48,7 @@ class MySqlConnectorPythonCommands(Commands):
             handler.execute(cursor)
             headers = get_col_names(cursor)
             row = cursor.fetchone()
-            if not row:
+            if row is None:
                 raise NoResultException("Query returned no results")
             cursor.fetchall()
         return serialize_dict_row(model, database_row_to_dict(headers, row))

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2,8 +2,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.exceptions import NoResultException
+from pydapper.exceptions import PyDapperException
+from pydapper.exceptions import RowMappingException
+from pydapper.exceptions import UnsupportedFeatureError
 from tests.mocks import MockAsyncCommands
 from tests.mocks import MockAsyncConnection
 from tests.mocks import MockAsyncCursor
@@ -13,6 +17,11 @@ from tests.mocks import MockCursor
 from tests.mocks import MockParamHandler
 
 pytestmark = pytest.mark.core
+
+
+class FalsyRow(tuple):
+    def __bool__(self):
+        return False
 
 
 @pytest.fixture
@@ -245,6 +254,21 @@ ASYNC_ALIAS_CONFLICT_CALLS = [
 ]
 
 
+class TestPublicExceptions:
+    @pytest.mark.parametrize(
+        "exception_type",
+        [
+            NoResultException,
+            MoreThanOneResultException,
+            MissingParameterException,
+            UnsupportedFeatureError,
+            RowMappingException,
+        ],
+    )
+    def test_public_exceptions_subclass_pydapper_exception(self, exception_type):
+        assert issubclass(exception_type, PyDapperException)
+
+
 class TestParamHandler:
     def test__init__validation(self):
         with pytest.raises(ValueError):
@@ -314,6 +338,14 @@ class TestCommands:
     @pytest.fixture
     def set_fetchone_to_return_none(self, monkeypatch):
         monkeypatch.setattr(MockCursor, "fetchone", lambda self_: None)
+
+    @pytest.fixture
+    def set_fetchone_to_return_null_first_column(self, monkeypatch):
+        monkeypatch.setattr(MockCursor, "fetchone", lambda self_: FalsyRow((None,)))
+
+    @pytest.fixture
+    def set_fetchone_to_return_falsy_row(self, monkeypatch):
+        monkeypatch.setattr(MockCursor, "fetchone", lambda self_: FalsyRow((None, "nullable")))
 
     @pytest.fixture
     def set_fetchall_return_one(self, faker, monkeypatch):
@@ -399,11 +431,32 @@ class TestCommands:
 
         assert captured_handler_params == [params]
 
+    def test_mysql_query_first_treats_only_none_as_no_result(self, connection, set_fetchone_to_return_falsy_row):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(connection) as commands:
+            data = commands.query_first("select id, name from some_table")
+
+        assert data == {"id": None, "name": "nullable"}
+
     def test_query(self, connection):
         with MockCommands(connection) as commands:
             data = commands.query("select id, name from some_table", model=SimpleNamespace)
         assert len(data) == 2
         assert all(isinstance(row, SimpleNamespace) for row in data)
+
+    def test_query_returns_empty_list_on_no_results(self, connection, set_fetchall_return_empty):
+        with MockCommands(connection) as commands:
+            data = commands.query("select id, name from some_table")
+        assert data == []
+
+    def test_query_unbuffered_yields_no_rows_on_no_results(self, connection, set_fetchone_to_return_none):
+        with MockCommands(connection) as commands:
+            generator = commands.query("select id, name from some_table", buffered=False)
+            assert list(generator) == []
 
     def test_query_multiple(self, connection):
         with MockCommands(connection) as commands:
@@ -450,6 +503,33 @@ class TestCommands:
             data = commands.query_first_or_default("select * from some_table", default=default)
         assert data is default
 
+    def test_query_first_or_default_calls_callable_default_on_no_result(self, connection, set_fetchone_to_return_none):
+        sentinel = object()
+        calls = []
+
+        def default():
+            calls.append(None)
+            return sentinel
+
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=default)
+
+        assert data is sentinel
+        assert calls == [None]
+
+    def test_query_first_or_default_returns_first_row(self, connection):
+        calls = []
+
+        def default():
+            calls.append(None)
+            return object()
+
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=default)
+
+        assert data["id"] == 1
+        assert calls == []
+
     def test_query_single(self, connection, set_fetchall_return_one):
         with MockCommands(connection) as commands:
             record = commands.query_single("select * from some_table")
@@ -471,6 +551,37 @@ class TestCommands:
             record = commands.query_single_or_default("select * from some_table", default=default)
         assert record is default
 
+    def test_query_single_or_default_calls_callable_default_on_no_result(self, connection, set_fetchall_return_empty):
+        sentinel = object()
+        calls = []
+
+        def default():
+            calls.append(None)
+            return sentinel
+
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default("select * from some_table", default=default)
+
+        assert record is sentinel
+        assert calls == [None]
+
+    def test_query_single_or_default_returns_single_row(self, connection, set_fetchall_return_one):
+        calls = []
+
+        def default():
+            calls.append(None)
+            return object()
+
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default("select * from some_table", default=default)
+
+        assert record["id"] == 1
+        assert calls == []
+
+    def test_query_single_or_default_raises_on_many_results(self, connection):
+        with MockCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single_or_default("select * from some_table", default=None)
+
     def test_execute_scalar(self, connection):
         with MockCommands(connection) as commands:
             id_ = commands.execute_scalar("select id, name from some_table")
@@ -479,6 +590,12 @@ class TestCommands:
     def test_execute_scalar_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
             commands.execute_scalar("select * from some_table")
+
+    def test_execute_scalar_returns_none_for_null_first_column(
+        self, connection, set_fetchone_to_return_null_first_column
+    ):
+        with MockCommands(connection) as commands:
+            assert commands.execute_scalar("select nullable_column from some_table") is None
 
 
 class TestCommandsAsync:
@@ -490,6 +607,13 @@ class TestCommandsAsync:
     def set_fetchone_to_return_none(self, mocker):
         async def fetchone(s):
             return None
+
+        mocker.patch("tests.mocks.MockAsyncCursor.fetchone", fetchone)
+
+    @pytest.fixture
+    def set_fetchone_to_return_null_first_column(self, mocker):
+        async def fetchone(s):
+            return FalsyRow((None,))
 
         mocker.patch("tests.mocks.MockAsyncCursor.fetchone", fetchone)
 
@@ -587,6 +711,18 @@ class TestCommandsAsync:
         assert all(isinstance(row, SimpleNamespace) for row in data)
 
     @pytest.mark.asyncio
+    async def test_query_returns_empty_list_on_no_results(self, connection, set_fetchall_return_empty):
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_async("select id, name from some_table")
+        assert data == []
+
+    @pytest.mark.asyncio
+    async def test_query_unbuffered_yields_no_rows_on_no_results(self, connection, set_fetchone_to_return_none):
+        async with MockAsyncCommands(connection) as commands:
+            generator = await commands.query_async("select id, name from some_table", buffered=False)
+            assert [row async for row in generator] == []
+
+    @pytest.mark.asyncio
     async def test_query_multiple(self, connection):
         async with MockAsyncCommands(connection) as commands:
             data1, data2 = await commands.query_multiple_async(
@@ -640,6 +776,37 @@ class TestCommandsAsync:
         assert data is default
 
     @pytest.mark.asyncio
+    async def test_query_first_or_default_calls_callable_default_on_no_result(
+        self, connection, set_fetchone_to_return_none
+    ):
+        sentinel = object()
+        calls = []
+
+        def default():
+            calls.append(None)
+            return sentinel
+
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async("select * from some_table", default=default)
+
+        assert data is sentinel
+        assert calls == [None]
+
+    @pytest.mark.asyncio
+    async def test_query_first_or_default_returns_first_row(self, connection):
+        calls = []
+
+        def default():
+            calls.append(None)
+            return object()
+
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async("select * from some_table", default=default)
+
+        assert data["id"] == 1
+        assert calls == []
+
+    @pytest.mark.asyncio
     async def test_query_single(self, connection, set_fetchall_return_one):
         async with MockAsyncCommands(connection) as commands:
             record = await commands.query_single_async("select * from some_table")
@@ -667,6 +834,43 @@ class TestCommandsAsync:
         assert record is default
 
     @pytest.mark.asyncio
+    async def test_query_single_or_default_calls_callable_default_on_no_result(
+        self, connection, set_fetchall_return_empty
+    ):
+        sentinel = object()
+        calls = []
+
+        def default():
+            calls.append(None)
+            return sentinel
+
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async("select * from some_table", default=default)
+
+        assert record is sentinel
+        assert calls == [None]
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_returns_single_row(self, connection, set_fetchall_return_one):
+        calls = []
+
+        def default():
+            calls.append(None)
+            return object()
+
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async("select * from some_table", default=default)
+
+        assert record["id"] == 1
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_raises_on_many_results(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(MoreThanOneResultException):
+                await commands.query_single_or_default_async("select * from some_table", default=None)
+
+    @pytest.mark.asyncio
     async def test_execute_scalar(self, connection):
         async with MockAsyncCommands(connection) as commands:
             id_ = await commands.execute_scalar_async("select id, name from some_table")
@@ -677,3 +881,10 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(NoResultException):
                 await commands.execute_scalar_async("select * from some_table")
+
+    @pytest.mark.asyncio
+    async def test_execute_scalar_returns_none_for_null_first_column(
+        self, connection, set_fetchone_to_return_null_first_column
+    ):
+        async with MockAsyncCommands(connection) as commands:
+            assert await commands.execute_scalar_async("select nullable_column from some_table") is None

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -12,6 +12,12 @@ import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper.exceptions import MissingParameterException
+from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import NoResultException
+from pydapper.exceptions import PyDapperException
+from pydapper.exceptions import RowMappingException
+from pydapper.exceptions import UnsupportedFeatureError
 
 """This file tests some of the more complex type annotations on the Commands and AsyncCommands classes"""
 
@@ -28,6 +34,15 @@ class Task:
 
 def default_callable() -> str:
     return "sup"
+
+
+def public_exceptions() -> None:
+    assert_type(PyDapperException(), PyDapperException)
+    assert_type(NoResultException(), NoResultException)
+    assert_type(MoreThanOneResultException(), MoreThanOneResultException)
+    assert_type(MissingParameterException(), MissingParameterException)
+    assert_type(UnsupportedFeatureError(), UnsupportedFeatureError)
+    assert_type(RowMappingException(), RowMappingException)
 
 
 class Commands:


### PR DESCRIPTION
Closes #456.

## Summary
- Defines the v1 public exception names under `pydapper.exceptions`.
- Freezes and tests sync/async cardinality behavior for `query`, `query_first`, `query_first_or_default`, `query_single`, `query_single_or_default`, and `execute_scalar`.
- Distinguishes no row (`fetchone() is None`) from a returned row whose first column is SQL `NULL`.
- Documents the stable query/scalar cardinality behavior.
- Adds lightweight `AGENTS.md` guidance for future PR summaries.

## Examples

Public exception imports now work from the required v1 module path:

```python
from pydapper.exceptions import PyDapperException
from pydapper.exceptions import NoResultException
from pydapper.exceptions import MoreThanOneResultException
from pydapper.exceptions import MissingParameterException
from pydapper.exceptions import UnsupportedFeatureError
from pydapper.exceptions import RowMappingException
```

Empty result sets keep the documented query/cardinality contract:

```python
commands.query("select * from task where id = -1") == []
list(commands.query("select * from task where id = -1", buffered=False)) == []

with pytest.raises(NoResultException):
    commands.query_first("select * from task where id = -1")

commands.query_first_or_default(
    "select * from task where id = -1",
    default=lambda: sentinel,
) is sentinel
```

Scalar calls now explicitly distinguish SQL `NULL` from no row:

```python
commands.execute_scalar("select null") is None

with pytest.raises(NoResultException):
    commands.execute_scalar("select id from task where id = -1")
```

## Review Notes
- Ran two adversarial review passes before opening the PR.
- Addressed the MySQL `query_first()` override so it also treats only `None` as no row.
- Strengthened tests with falsy row objects so regressions to truthiness checks are caught.
- Added callable-default tests to ensure defaults are not called when a row exists.

## Tests
- `poetry run pytest tests/test_commands_interface.py tests/type_tests.py -m core`
- `poetry run pytest -m core`
- `poetry run mypy pydapper`
- `poetry run mypy tests/type_tests.py`

## Not Run
- Optional live backend test markers (`postgresql`, `mysql`, `mssql`, `oracle`, `bigquery`) were not run because they require optional integrations/containers. The MySQL-specific cardinality fix is covered by command-interface mock coverage in this PR.
- `poetry run mkdocs build --strict` was not run; docs changes are limited to short cardinality text and the agent guide.
