### PR TITLE
v1: replace placeholder regex with SQL-aware scanner

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,11 @@ Why would I use *pydapper*?
 **Safe from SQL injection**
 : pydapper provides a consistent syntax for declaring query parameters and guarantees it is converted to the safest
   possible parameter substitution for the dbapi to deter SQL injection
+  Parameter placeholders use the form `?name?`, where `name` starts with an ASCII letter or underscore and then contains
+  only ASCII letters, numbers, or underscores. Placeholder-shaped text inside single-quoted text, double-quoted text,
+  `--` line comments, and `/* ... */` block comments is ignored; PostgreSQL dollar-quoted strings are not special-cased
+  by the placeholder scanner. Invalid forms such as `??`, `? id?`, `?first-name?`, `?table.column?`, and `?1id?` are left
+  unchanged.
 
 **You want a framework that lets you BYOC (bring your own connection)**
 : Sometimes ORM frameworks abstract *too* much from you.  *pydapper* allows you to use your own connection

--- a/pydapper/_sql_placeholders.py
+++ b/pydapper/_sql_placeholders.py
@@ -1,0 +1,133 @@
+from typing import List
+from typing import Tuple
+
+PlaceholderSpan = Tuple[int, int, str]
+
+
+def _is_placeholder_name_start(char: str) -> bool:
+    return ("A" <= char <= "Z") or ("a" <= char <= "z") or char == "_"
+
+
+def _is_placeholder_name_char(char: str) -> bool:
+    return _is_placeholder_name_start(char) or ("0" <= char <= "9")
+
+
+def _skip_quoted_sql_text(sql: str, start: int, quote: str) -> int:
+    index = start + 1
+    while index < len(sql):
+        if sql[index] == "\\" and index + 1 < len(sql):
+            index += 2
+            continue
+
+        if sql[index] == quote:
+            if index + 1 < len(sql) and sql[index + 1] == quote:
+                index += 2
+                continue
+            return index + 1
+        index += 1
+    return len(sql)
+
+
+def _skip_line_comment(sql: str, start: int) -> int:
+    index = start + 2
+    while index < len(sql) and sql[index] not in "\r\n":
+        index += 1
+    return index
+
+
+def _skip_block_comment(sql: str, start: int) -> int:
+    index = start + 2
+    while index + 1 < len(sql):
+        if sql[index] == "*" and sql[index + 1] == "/":
+            return index + 2
+        index += 1
+    return len(sql)
+
+
+def _is_malformed_placeholder_boundary(char: str) -> bool:
+    return char.isspace() or char in "',;()[]{}:=<>+*/|&~!@#%^"
+
+
+def _skip_question_mark_run(sql: str, start: int) -> int:
+    index = start
+    while index < len(sql) and sql[index] == "?":
+        index += 1
+    return index
+
+
+def _skip_malformed_placeholder(sql: str, start: int) -> int:
+    index = start
+    while index < len(sql):
+        if sql[index] == '"':
+            return index
+
+        if sql[index] == "-" and index + 1 < len(sql) and sql[index + 1] == "-":
+            return index
+
+        if sql[index] == "/" and index + 1 < len(sql) and sql[index + 1] == "*":
+            return index
+
+        if _is_malformed_placeholder_boundary(sql[index]):
+            return index
+
+        if sql[index] == "?":
+            return index + 1
+
+        index += 1
+    return len(sql)
+
+
+def scan_placeholder_spans(sql: str) -> Tuple[PlaceholderSpan, ...]:
+    spans: List[PlaceholderSpan] = []
+    index = 0
+    sql_length = len(sql)
+
+    while index < sql_length:
+        char = sql[index]
+
+        if char == "'":
+            index = _skip_quoted_sql_text(sql, index, "'")
+            continue
+
+        if char == '"':
+            index = _skip_quoted_sql_text(sql, index, '"')
+            continue
+
+        if char == "-" and index + 1 < sql_length and sql[index + 1] == "-":
+            index = _skip_line_comment(sql, index)
+            continue
+
+        if char == "/" and index + 1 < sql_length and sql[index + 1] == "*":
+            index = _skip_block_comment(sql, index)
+            continue
+
+        if char == "?":
+            name_start = index + 1
+            if name_start < sql_length and sql[name_start] == "?":
+                index = _skip_question_mark_run(sql, index)
+                continue
+
+            if name_start < sql_length and _is_placeholder_name_start(sql[name_start]):
+                name_end = name_start + 1
+                while name_end < sql_length and _is_placeholder_name_char(sql[name_end]):
+                    name_end += 1
+
+                if name_end < sql_length and sql[name_end] == "?":
+                    placeholder_end = name_end + 1
+                    if placeholder_end == sql_length or not _is_placeholder_name_char(sql[placeholder_end]):
+                        spans.append((index, placeholder_end, sql[name_start:name_end]))
+                        index = placeholder_end
+                        continue
+
+                    index = _skip_malformed_placeholder(sql, placeholder_end)
+                    continue
+
+                index = _skip_malformed_placeholder(sql, name_end)
+                continue
+
+            index += 1
+            continue
+
+        index += 1
+
+    return tuple(spans)

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1,11 +1,9 @@
-import re
 import typing
 from abc import ABC
 from abc import abstractmethod
 from contextlib import ExitStack
 from contextlib import contextmanager
 from functools import cached_property
-from re import Match
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncGenerator
@@ -23,6 +21,8 @@ from typing import cast
 from typing import overload
 
 from ._context import CoroContextManager
+from ._sql_placeholders import PlaceholderSpan
+from ._sql_placeholders import scan_placeholder_spans
 from .exceptions import MoreThanOneResultException
 from .exceptions import NoResultException
 from .utils import database_row_to_dict
@@ -64,13 +64,20 @@ def _resolve_param_aliases(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
     return None
 
 
-class BaseSqlParamHandler(ABC):
-    _PARAM_REGEX = "\\?(.*?)\\?"
+def _is_empty_executemany_params(param: Any) -> bool:
+    return isinstance(param, list) and not param
 
+
+def _raise_if_list_params_for_read(param: Any) -> None:
+    if isinstance(param, list):
+        raise ValueError("Top-level list params are only supported by execute and execute_async.")
+
+
+class BaseSqlParamHandler(ABC):
     def __init__(self, sql: str, param: Union["ParamType", "ListParamType"] = None):
         self._sql = sql
         self._param = param
-        if isinstance(self._param, list):
+        if isinstance(self._param, list) and self._param:
             all_params_are_same_type = all(isinstance(param, type(self._param[0])) for param in self._param[1:])
             if not all_params_are_same_type:
                 raise ValueError(f"All objects in params must be of type {type(self._param[0])}")
@@ -80,34 +87,40 @@ class BaseSqlParamHandler(ABC):
 
     @cached_property
     def ordered_param_names(self) -> Tuple[str, ...]:
-        matches = re.findall(BaseSqlParamHandler._PARAM_REGEX, self._sql)
-        matches = cast(List[str], matches)
-        return tuple(matches)
+        return tuple(name for _, _, name in self._placeholder_spans)
+
+    @cached_property
+    def _placeholder_spans(self) -> Tuple[PlaceholderSpan, ...]:
+        return scan_placeholder_spans(self._sql)
 
     @cached_property
     def ordered_param_values(self) -> Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple]:
-        if self._param:
-            if isinstance(self._param, list):
-                return [tuple(safe_getattr(p, name) for name in self.ordered_param_names) for p in self._param]
+        if isinstance(self._param, list):
+            return [tuple(safe_getattr(p, name) for name in self.ordered_param_names) for p in self._param]
 
+        if self._param:
             return tuple(safe_getattr(self._param, name) for name in self.ordered_param_names)
         return tuple()
 
     @cached_property
     def prepared_sql(self) -> str:
-        if self._param and len(self.ordered_param_names) > 0:
-            pattern = re.compile("|".join(re.escape(f"?{name}?") for name in self.ordered_param_names))
+        if self._param and self._placeholder_spans:
+            prepared_sql_parts = []
+            current_index = 0
 
-            def sub_param_with_placeholder(m: Match) -> str:
-                matched_placeholder = m.group(0)
-                matched_param_name = matched_placeholder.strip("?")
-                return self.get_param_placeholder(matched_param_name)
+            for start, end, name in self._placeholder_spans:
+                prepared_sql_parts.append(self._sql[current_index:start])
+                prepared_sql_parts.append(self.get_param_placeholder(name))
+                current_index = end
 
-            return pattern.sub(sub_param_with_placeholder, self._sql)  # type: ignore
+            prepared_sql_parts.append(self._sql[current_index:])
+            return "".join(prepared_sql_parts)
         return self._sql
 
     def execute(self, cursor: "CursorType") -> int:
         if isinstance(self.ordered_param_values, list):
+            if not self.ordered_param_values:
+                return 0
             cursor.executemany(self.prepared_sql, self.ordered_param_values)
         elif self.ordered_param_values:
             cursor.execute(self.prepared_sql, self.ordered_param_values)
@@ -118,9 +131,13 @@ class BaseSqlParamHandler(ABC):
 
     async def execute_async(self, cursor: "AsyncCursorType") -> int:
         if isinstance(self.ordered_param_values, list):
+            if not self.ordered_param_values:
+                return 0
             await cursor.executemany(self.prepared_sql, self.ordered_param_values)
-        else:
+        elif self.ordered_param_values:
             await cursor.execute(self.prepared_sql, self.ordered_param_values)
+        else:
+            await cursor.execute(self.prepared_sql)
 
         return cursor.rowcount
 
@@ -175,6 +192,9 @@ class Commands(BaseCommands, ABC):
 
     def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        if _is_empty_executemany_params(resolved_params):
+            return 0
+
         handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
             rowcount = handler.execute(cursor)
@@ -281,6 +301,7 @@ class Commands(BaseCommands, ABC):
 
     def query(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         return self._buffered_query(handler, model) if buffered else self._unbuffered_query(handler, model)
 
@@ -309,6 +330,7 @@ class Commands(BaseCommands, ABC):
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
 
         if models is None:
             models = tuple(dict for _ in queries)
@@ -363,6 +385,7 @@ class Commands(BaseCommands, ABC):
 
     def query_first(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
@@ -489,6 +512,7 @@ class Commands(BaseCommands, ABC):
 
     def query_single(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
@@ -590,13 +614,14 @@ class Commands(BaseCommands, ABC):
             return default() if callable(default) else default
 
     @overload
-    def execute_scalar(self, sql: str, params: "ParamType" = None) -> Any: ...
+    def execute_scalar(self, sql: str, params: Optional["ParamType"] = None) -> Any: ...
 
     @overload
-    def execute_scalar(self, sql: str, *, param: "ParamType" = None) -> Any: ...
+    def execute_scalar(self, sql: str, *, param: Optional["ParamType"] = None) -> Any: ...
 
     def execute_scalar(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
@@ -632,6 +657,9 @@ class CommandsAsync(BaseCommands, ABC):
 
     async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        if _is_empty_executemany_params(resolved_params):
+            return 0
+
         handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
             return await handler.execute_async(cursor)
@@ -739,6 +767,7 @@ class CommandsAsync(BaseCommands, ABC):
 
     async def query_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         if buffered:
             records = await self._buffered_query(handler, model)
@@ -768,6 +797,7 @@ class CommandsAsync(BaseCommands, ABC):
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
 
         if models is None:
             models = cast(Tuple[dict], tuple(dict for _ in queries))
@@ -824,6 +854,7 @@ class CommandsAsync(BaseCommands, ABC):
 
     async def query_first_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
@@ -832,7 +863,7 @@ class CommandsAsync(BaseCommands, ABC):
             row = await cursor.fetchone()
             if row is None:
                 raise NoResultException("Query returned no results")
-        return serialize_dict_row(model, database_row_to_dict(headers, row))
+            return serialize_dict_row(model, database_row_to_dict(headers, row))
 
     @overload
     async def query_first_or_default_async(
@@ -954,6 +985,7 @@ class CommandsAsync(BaseCommands, ABC):
 
     async def query_single_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
@@ -1057,13 +1089,14 @@ class CommandsAsync(BaseCommands, ABC):
             return default() if callable(default) else default
 
     @overload
-    async def execute_scalar_async(self, sql: str, params: "ParamType" = None) -> Any: ...
+    async def execute_scalar_async(self, sql: str, params: Optional["ParamType"] = None) -> Any: ...
 
     @overload
-    async def execute_scalar_async(self, sql: str, *, param: "ParamType" = None) -> Any: ...
+    async def execute_scalar_async(self, sql: str, *, param: Optional["ParamType"] = None) -> Any: ...
 
     async def execute_scalar_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from pydapper import register
 from pydapper.commands import _PARAM_ALIAS_UNSET
 from pydapper.commands import Commands
+from pydapper.commands import _raise_if_list_params_for_read
 
 from ..exceptions import NoResultException
 from ..utils import database_row_to_dict
@@ -42,6 +43,7 @@ class MySqlConnectorPythonCommands(Commands):
         fetchall to make the lib happy.
         """
         resolved_params = self._resolve_params(param, params)
+        _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self.cursor() as cursor:

--- a/pydapper/postgresql/aiopg.py
+++ b/pydapper/postgresql/aiopg.py
@@ -21,8 +21,11 @@ class AiopgCommands(CommandsAsync):
                 for param_values in self.ordered_param_values:
                     await cursor.execute(self.prepared_sql, param_values)
                     rowcount += cursor.rowcount
-            else:
+            elif self.ordered_param_values:
                 await cursor.execute(self.prepared_sql, self.ordered_param_values)
+                rowcount = cursor.rowcount
+            else:
+                await cursor.execute(self.prepared_sql)
                 rowcount = cursor.rowcount
 
             return rowcount

--- a/tests/test_adapter_units.py
+++ b/tests/test_adapter_units.py
@@ -1,0 +1,346 @@
+import importlib
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from pydapper.bigquery import google_bigquery_client as bigquery_module
+from pydapper.mssql import pymssql as mssql_module
+from pydapper.mysql import mysql_connector_python as mysql_module
+from pydapper.oracle import oracledb as oracle_module
+from pydapper.postgresql import aiopg as aiopg_module
+from pydapper.postgresql import psycopg2 as psycopg2_module
+from pydapper.postgresql import psycopg3 as psycopg3_module
+
+sqlite_module = importlib.import_module("pydapper.sqlite.sqlite3")
+
+pytestmark = pytest.mark.core
+
+
+class RecordingDbApi:
+    def __init__(self):
+        self.connection = object()
+        self.calls = []
+
+    def connect(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.connection
+
+
+class RecordingAsyncDbApi:
+    def __init__(self):
+        self.connection = object()
+        self.calls = []
+
+    async def connect(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.connection
+
+
+def parsed_dsn(**overrides):
+    values = {
+        "host": "db-host",
+        "hostloc": "db-host:1543",
+        "port": 1543,
+        "user": "user",
+        "username": "user",
+        "password": "password",
+        "database": "app",
+        "dbname": "app",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def patch_dbapi_import(monkeypatch, module, expected_name, dbapi):
+    calls = []
+
+    def import_dbapi_module(name):
+        calls.append(name)
+        assert name == expected_name
+        return dbapi
+
+    monkeypatch.setattr(module, "import_dbapi_module", import_dbapi_module)
+    return calls
+
+
+def test_bigquery_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, bigquery_module, "google.cloud.bigquery.dbapi", dbapi)
+    client = object()
+
+    commands = bigquery_module.GoogleBigqueryClientCommands.connect(parsed_dsn(), client=client)
+
+    assert isinstance(commands, bigquery_module.GoogleBigqueryClientCommands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [{"client": client}]
+    assert import_calls == ["google.cloud.bigquery.dbapi"]
+
+
+@pytest.mark.parametrize(
+    "param, expected_placeholder",
+    [
+        (SimpleNamespace(value=Decimal("1.0")), "%d"),
+        ([SimpleNamespace(value="text")], "%s"),
+        (SimpleNamespace(value=object()), "%s"),
+    ],
+)
+def test_pymssql_param_handler_uses_parameter_type_for_placeholder(param, expected_placeholder):
+    handler = mssql_module.PymssqlCommands.SqlParamHandler("select ?value?", param)
+
+    assert handler.get_param_placeholder("value") == expected_placeholder
+
+
+def test_pymssql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, mssql_module, "pymssql", dbapi)
+
+    commands = mssql_module.PymssqlCommands.connect(parsed_dsn(), login_timeout=3)
+
+    assert isinstance(commands, mssql_module.PymssqlCommands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "server": "db-host",
+            "port": 1543,
+            "user": "user",
+            "password": "password",
+            "database": "app",
+            "login_timeout": 3,
+        }
+    ]
+    assert import_calls == ["pymssql"]
+
+
+def test_mysql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    commands = mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), charset="utf8mb4")
+
+    assert isinstance(commands, mysql_module.MySqlConnectorPythonCommands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "host": "db-host",
+            "port": 1543,
+            "user": "user",
+            "password": "password",
+            "database": "app",
+            "charset": "utf8mb4",
+        }
+    ]
+    assert import_calls == ["mysql.connector"]
+
+
+def test_oracledb_param_handler_uses_named_placeholder():
+    handler = oracle_module.OracledbCommands.SqlParamHandler("select ?value?", {"value": 1})
+
+    assert handler.get_param_placeholder("value") == ":value"
+
+
+def test_oracledb_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, oracle_module, "oracledb", dbapi)
+
+    commands = oracle_module.OracledbCommands.connect(parsed_dsn(), mode="thin")
+
+    assert isinstance(commands, oracle_module.OracledbCommands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "user": "user",
+            "password": "password",
+            "dsn": "db-host:1543/app",
+            "mode": "thin",
+        }
+    ]
+    assert import_calls == ["oracledb"]
+
+
+@pytest.mark.asyncio
+async def test_aiopg_param_handler_emulates_executemany():
+    class TrackingCursor:
+        def __init__(self):
+            self.calls = []
+            self.rowcount = 0
+
+        async def execute(self, sql, parameters=None):
+            self.calls.append((sql, parameters))
+            self.rowcount = 1
+
+    cursor = TrackingCursor()
+    handler = aiopg_module.AiopgCommands.SqlParamHandler(
+        "insert into task (id) values (?id?)",
+        [{"id": 1}, {"id": 2}],
+    )
+
+    assert await handler.execute_async(cursor) == 2
+    assert cursor.calls == [
+        ("insert into task (id) values (%s)", (1,)),
+        ("insert into task (id) values (%s)", (2,)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aiopg_param_handler_executes_with_parameter_values():
+    class TrackingCursor:
+        rowcount = 5
+
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, sql, parameters=None):
+            self.calls.append((sql, parameters))
+
+    cursor = TrackingCursor()
+    handler = aiopg_module.AiopgCommands.SqlParamHandler("select ?id?", {"id": 1})
+
+    assert await handler.execute_async(cursor) == 5
+    assert cursor.calls == [("select %s", (1,))]
+
+
+@pytest.mark.asyncio
+async def test_aiopg_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingAsyncDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, aiopg_module, "aiopg", dbapi)
+
+    commands = await aiopg_module.AiopgCommands.connect_async(parsed_dsn(port=None), application_name="pydapper")
+
+    assert isinstance(commands, aiopg_module.AiopgCommands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "dbname": "app",
+            "user": "user",
+            "password": "password",
+            "host": "db-host",
+            "port": "5432",
+            "application_name": "pydapper",
+        }
+    ]
+    assert import_calls == ["aiopg"]
+
+
+def test_psycopg2_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, psycopg2_module, "psycopg2", dbapi)
+
+    commands = psycopg2_module.Psycopg2Commands.connect(parsed_dsn(port=None), application_name="pydapper")
+
+    assert isinstance(commands, psycopg2_module.Psycopg2Commands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "dbname": "app",
+            "user": "user",
+            "password": "password",
+            "host": "db-host",
+            "port": "5432",
+            "application_name": "pydapper",
+        }
+    ]
+    assert import_calls == ["psycopg2"]
+
+
+def test_psycopg3_connect_imports_dbapi_and_wraps_connection(monkeypatch):
+    dbapi = RecordingDbApi()
+    import_calls = patch_dbapi_import(monkeypatch, psycopg3_module, "psycopg", dbapi)
+
+    commands = psycopg3_module.Psycopg3Commands.connect(parsed_dsn(port=None), application_name="pydapper")
+
+    assert isinstance(commands, psycopg3_module.Psycopg3Commands)
+    assert commands.connection is dbapi.connection
+    assert dbapi.calls == [
+        {
+            "dbname": "app",
+            "user": "user",
+            "password": "password",
+            "host": "db-host",
+            "port": "5432",
+            "application_name": "pydapper",
+        }
+    ]
+    assert import_calls == ["psycopg"]
+
+
+@pytest.mark.asyncio
+async def test_psycopg3_connect_async_imports_dbapi_and_wraps_connection(monkeypatch):
+    connection = object()
+    dbapi_calls = []
+
+    async def connect(**kwargs):
+        dbapi_calls.append(kwargs)
+        return connection
+
+    dbapi = SimpleNamespace(AsyncConnection=SimpleNamespace(connect=connect))
+    import_calls = patch_dbapi_import(monkeypatch, psycopg3_module, "psycopg", dbapi)
+
+    commands = await psycopg3_module.Psycopg3CommandsAsync.connect_async(
+        parsed_dsn(port=None),
+        application_name="pydapper",
+    )
+
+    assert isinstance(commands, psycopg3_module.Psycopg3CommandsAsync)
+    assert commands.connection is connection
+    assert dbapi_calls == [
+        {
+            "dbname": "app",
+            "user": "user",
+            "password": "password",
+            "host": "db-host",
+            "port": "5432",
+            "application_name": "pydapper",
+        }
+    ]
+    assert import_calls == ["psycopg"]
+
+
+@pytest.mark.asyncio
+async def test_psycopg3_async_cursor_wraps_sync_cursor_return_value():
+    class Connection:
+        def __init__(self):
+            self.cursor_result = object()
+            self.calls = []
+
+        def cursor(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self.cursor_result
+
+    connection = Connection()
+    commands = psycopg3_module.Psycopg3CommandsAsync(connection)
+
+    async with commands.cursor("cursor-name", row_factory=dict) as cursor:
+        assert cursor is connection.cursor_result
+
+    assert connection.calls == [(("cursor-name",), {"row_factory": dict})]
+
+
+def test_sqlite_param_handler_uses_question_mark_placeholder():
+    handler = sqlite_module.Sqlite3Commands.SqlParamHandler("select ?value?", {"value": 1})
+
+    assert handler.get_param_placeholder("value") == "?"
+
+
+@pytest.mark.parametrize(
+    "dsn, expected_path",
+    [
+        (parsed_dsn(host="/tmp", database="app.db"), "/tmp/app.db"),
+        (parsed_dsn(host="/tmp/app.db", database=""), "/tmp/app.db"),
+    ],
+)
+def test_sqlite_connect_wraps_connection(monkeypatch, dsn, expected_path):
+    connection = object()
+    calls = []
+
+    def connect(db_path, **kwargs):
+        calls.append((db_path, kwargs))
+        return connection
+
+    monkeypatch.setattr(sqlite_module.sqlite3, "connect", connect)
+
+    commands = sqlite_module.Sqlite3Commands.connect(dsn, isolation_level=None)
+
+    assert isinstance(commands, sqlite_module.Sqlite3Commands)
+    assert commands.connection is connection
+    assert calls == [(expected_path, {"isolation_level": None})]

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -254,6 +254,78 @@ ASYNC_ALIAS_CONFLICT_CALLS = [
 ]
 
 
+SYNC_READ_LIST_PARAMS_CALLS = [
+    pytest.param(
+        lambda commands: commands.query("select id, name from some_table where id = ?id?", params=[]),
+        id="query",
+    ),
+    pytest.param(
+        lambda commands: commands.query_multiple(("select id, name from some_table where id = ?id?",), params=[]),
+        id="query_multiple",
+    ),
+    pytest.param(
+        lambda commands: commands.query_first("select id, name from some_table where id = ?id?", params=[]),
+        id="query_first",
+    ),
+    pytest.param(
+        lambda commands: commands.query_first_or_default(
+            "select id, name from some_table where id = ?id?", None, params=[]
+        ),
+        id="query_first_or_default",
+    ),
+    pytest.param(
+        lambda commands: commands.query_single("select id, name from some_table where id = ?id?", params=[]),
+        id="query_single",
+    ),
+    pytest.param(
+        lambda commands: commands.query_single_or_default(
+            "select id, name from some_table where id = ?id?", None, params=[]
+        ),
+        id="query_single_or_default",
+    ),
+    pytest.param(
+        lambda commands: commands.execute_scalar("select id from some_table where id = ?id?", params=[]),
+        id="execute_scalar",
+    ),
+]
+
+
+ASYNC_READ_LIST_PARAMS_CALLS = [
+    pytest.param(
+        lambda commands: commands.query_async("select id, name from some_table where id = ?id?", params=[]),
+        id="query_async",
+    ),
+    pytest.param(
+        lambda commands: commands.query_multiple_async(("select id, name from some_table where id = ?id?",), params=[]),
+        id="query_multiple_async",
+    ),
+    pytest.param(
+        lambda commands: commands.query_first_async("select id, name from some_table where id = ?id?", params=[]),
+        id="query_first_async",
+    ),
+    pytest.param(
+        lambda commands: commands.query_first_or_default_async(
+            "select id, name from some_table where id = ?id?", None, params=[]
+        ),
+        id="query_first_or_default_async",
+    ),
+    pytest.param(
+        lambda commands: commands.query_single_async("select id, name from some_table where id = ?id?", params=[]),
+        id="query_single_async",
+    ),
+    pytest.param(
+        lambda commands: commands.query_single_or_default_async(
+            "select id, name from some_table where id = ?id?", None, params=[]
+        ),
+        id="query_single_or_default_async",
+    ),
+    pytest.param(
+        lambda commands: commands.execute_scalar_async("select id from some_table where id = ?id?", params=[]),
+        id="execute_scalar_async",
+    ),
+]
+
+
 class TestPublicExceptions:
     @pytest.mark.parametrize(
         "exception_type",
@@ -273,6 +345,12 @@ class TestParamHandler:
     def test__init__validation(self):
         with pytest.raises(ValueError):
             MockParamHandler("sup", param=[SimpleNamespace(), dict()])
+
+    def test_default_param_handler_get_param_placeholder(self):
+        from pydapper.commands import DefaultSqlParamHandler
+
+        handler = DefaultSqlParamHandler("sup", None)
+        assert handler.get_param_placeholder("sup") == "%s"
 
     def test_get_param_placeholder(self):
         handler = MockParamHandler("sup", None)
@@ -294,6 +372,16 @@ class TestParamHandler:
         )
         assert handler.ordered_param_values == ("dude", "world", "hello", "bar", "foo")
 
+    def test_ordered_param_values_empty_top_level_list_is_executemany_input(self):
+        handler = MockParamHandler("insert into table (id) values (?id?)", [])
+        assert handler.ordered_param_values == []
+
+    def test_list_inside_mapping_is_single_parameter_value(self):
+        handler = MockParamHandler("select * from table where id in ?ids?", {"ids": []})
+        assert handler.ordered_param_names == ("ids",)
+        assert handler.ordered_param_values == ([],)
+        assert handler.prepared_sql == "select * from table where id in %s"
+
     def test_prepared_sql(self):
         handler = MockParamHandler("select * from table where id = ?id? and name = ?name?", {"id": 1, "name": "Zach"})
         assert handler.prepared_sql == "select * from table where id = %s and name = %s"
@@ -301,6 +389,181 @@ class TestParamHandler:
     def test_prepared_sql_no_matching_param(self):
         handler = MockParamHandler("select * from table", {"id": 1, "name": "Zach"})
         assert handler.prepared_sql == "select * from table"
+
+    @pytest.mark.parametrize("param", [None, {}, []])
+    def test_prepared_sql_with_falsey_params_preserves_original_sql(self, param):
+        handler = MockParamHandler("select * from table where id = ?id?", param)
+        assert handler.prepared_sql == "select * from table where id = ?id?"
+
+    def test_prepared_sql_ignores_placeholders_inside_quoted_text(self):
+        sql = """select '?ignored?', 'it''s ?still_ignored?', "?quoted?", "a "" ?still_quoted? "" b", ?active?"""
+        handler = MockParamHandler(sql, {"active": 1})
+
+        assert handler.ordered_param_names == ("active",)
+        assert (
+            handler.prepared_sql
+            == """select '?ignored?', 'it''s ?still_ignored?', "?quoted?", "a "" ?still_quoted? "" b", %s"""
+        )
+
+    def test_prepared_sql_ignores_placeholders_inside_backslash_escaped_quoted_text(self):
+        sql = r"select 'it\'s ?ignored?' as value, ?id?"
+        handler = MockParamHandler(sql, {"id": 1})
+
+        assert handler.ordered_param_names == ("id",)
+        assert handler.prepared_sql == r"select 'it\'s ?ignored?' as value, %s"
+
+    def test_prepared_sql_ignores_unclosed_quoted_text_at_eof(self):
+        sql = "select '?ignored? as value, ?also_ignored?"
+        handler = MockParamHandler(sql, {"also_ignored": 1})
+
+        assert handler.ordered_param_names == ()
+        assert handler.prepared_sql == sql
+
+    def test_prepared_sql_ignores_placeholders_inside_comments(self):
+        sql = "select ?active? -- ?ignored?\n, ?next? /* ?block_ignored? */ ?after_block? -- ?eof_ignored?"
+        handler = MockParamHandler(sql, {"active": 1, "next": 2, "after_block": 3})
+
+        assert handler.ordered_param_names == ("active", "next", "after_block")
+        assert handler.prepared_sql == "select %s -- ?ignored?\n, %s /* ?block_ignored? */ %s -- ?eof_ignored?"
+
+    def test_prepared_sql_ignores_unclosed_block_comment_at_eof(self):
+        sql = "select ?active? /* ?ignored?"
+        handler = MockParamHandler(sql, {"active": 1})
+
+        assert handler.ordered_param_names == ("active",)
+        assert handler.prepared_sql == "select %s /* ?ignored?"
+
+    def test_active_and_ignored_placeholders_with_same_name_are_distinct(self):
+        sql = "select '?id?' as literal, ?id? as id -- ?id?\n, ?id? as next_id"
+        handler = MockParamHandler(sql, {"id": 1})
+
+        assert handler.ordered_param_names == ("id", "id")
+        assert handler.ordered_param_values == (1, 1)
+        assert handler.prepared_sql == "select '?id?' as literal, %s as id -- ?id?\n, %s as next_id"
+
+    def test_duplicate_placeholders_bind_in_occurrence_order(self):
+        handler = MockParamHandler(
+            "select * from table where id = ?id? or parent_id = ?id?",
+            {"id": 1},
+        )
+
+        assert handler.ordered_param_names == ("id", "id")
+        assert handler.ordered_param_values == (1, 1)
+        assert handler.prepared_sql == "select * from table where id = %s or parent_id = %s"
+
+    def test_placeholder_names_allow_uppercase_and_digits_after_first_character(self):
+        handler = MockParamHandler("select * from table where id = ?TaskID1?", {"TaskID1": 1})
+
+        assert handler.ordered_param_names == ("TaskID1",)
+        assert handler.ordered_param_values == (1,)
+        assert handler.prepared_sql == "select * from table where id = %s"
+
+    def test_invalid_placeholder_forms_are_ignored(self):
+        sql = "select ??, ??id?, ? id?, ?first-name?, ?first-?id?, ?bad?valid?, ?table.column?, ?1id?, ?_valid?"
+        handler = MockParamHandler(sql, {"_valid": 1})
+
+        assert handler.ordered_param_names == ("_valid",)
+        assert (
+            handler.prepared_sql
+            == "select ??, ??id?, ? id?, ?first-name?, ?first-?id?, ?bad?valid?, ?table.column?, ?1id?, %s"
+        )
+
+    def test_invalid_placeholder_does_not_swallow_later_valid_placeholder(self):
+        sql = "select ? as native_param, ?bad, ?id?"
+        handler = MockParamHandler(sql, {"id": 1})
+
+        assert handler.ordered_param_names == ("id",)
+        assert handler.prepared_sql == "select ? as native_param, ?bad, %s"
+
+    def test_postgresql_question_mark_operators_do_not_swallow_placeholders(self):
+        sql = "select * from table where data ? 'key' and tags ?| ?keys? and id = ?id?"
+        handler = MockParamHandler(sql, {"keys": ["urgent"], "id": 1})
+
+        assert handler.ordered_param_names == ("keys", "id")
+        assert handler.prepared_sql == "select * from table where data ? 'key' and tags ?| %s and id = %s"
+
+    def test_unspaced_question_mark_operator_does_not_swallow_later_placeholder(self):
+        sql = "select * from table where data?key_col::text=?expected?"
+        handler = MockParamHandler(sql, {"expected": "value"})
+
+        assert handler.ordered_param_names == ("expected",)
+        assert handler.prepared_sql == "select * from table where data?key_col::text=%s"
+
+    def test_malformed_placeholder_recovery_respects_comments_and_quotes(self):
+        sql = "select ?bad -- ?comment? ?id?\n, '?ignored? ?id?', ?next?"
+        handler = MockParamHandler(sql, {"next": 1})
+
+        assert handler.ordered_param_names == ("next",)
+        assert handler.prepared_sql == "select ?bad -- ?comment? ?id?\n, '?ignored? ?id?', %s"
+
+    @pytest.mark.parametrize(
+        "sql, expected_prepared_sql",
+        [
+            ('select ?bad"?ignored?", ?id?', 'select ?bad"?ignored?", %s'),
+            ("select ?bad-- ?ignored?\n, ?id?", "select ?bad-- ?ignored?\n, %s"),
+            ("select ?bad/* ?ignored? */, ?id?", "select ?bad/* ?ignored? */, %s"),
+        ],
+    )
+    def test_malformed_placeholder_recovery_stops_at_sql_boundaries(self, sql, expected_prepared_sql):
+        handler = MockParamHandler(sql, {"id": 1})
+
+        assert handler.ordered_param_names == ("id",)
+        assert handler.prepared_sql == expected_prepared_sql
+
+    def test_malformed_placeholder_at_eof_is_ignored(self):
+        handler = MockParamHandler("select ?bad", {"bad": 1})
+
+        assert handler.ordered_param_names == ()
+        assert handler.prepared_sql == "select ?bad"
+
+    def test_get_param_placeholder_runs_once_per_active_occurrence(self):
+        class TrackingParamHandler(MockParamHandler):
+            def __init__(self, sql, param=None):
+                self.placeholder_calls = []
+                super().__init__(sql, param)
+
+            def get_param_placeholder(self, param_name):
+                self.placeholder_calls.append(param_name)
+                return f"${len(self.placeholder_calls)}"
+
+        handler = TrackingParamHandler("?id?, '?name?', ?name?, ?id? -- ?name?", {"id": 1, "name": "Zach"})
+
+        assert handler.prepared_sql == "$1, '?name?', $2, $3 -- ?name?"
+        assert handler.placeholder_calls == ["id", "name", "id"]
+
+    def test_execute_with_empty_top_level_list_returns_zero_without_cursor_calls(self):
+        class NoCallCursor:
+            rowcount = 123
+
+            def execute(self, *args, **kwargs):
+                raise AssertionError("execute should not be called")
+
+            def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        handler = MockParamHandler("insert into table (id) values (?id?)", [])
+
+        assert handler.execute(NoCallCursor()) == 0
+
+    def test_execute_with_no_params_executes_once(self):
+        class TrackingCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, sql, parameters=None):
+                self.calls.append(("execute", sql, parameters))
+                self.rowcount = 1
+
+            def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        cursor = TrackingCursor()
+        handler = MockParamHandler("insert into table default values", None)
+
+        assert handler.execute(cursor) == 1
+        assert cursor.calls == [("execute", "insert into table default values", None)]
 
     @pytest.mark.parametrize(
         "sql, param, expected",
@@ -328,6 +591,61 @@ class TestParamHandler:
         handler = MockParamHandler(sql, param)
         async with MockAsyncCursor() as cursor:
             assert await handler.execute_async(cursor) == expected
+
+    @pytest.mark.asyncio
+    async def test_execute_async_with_empty_top_level_list_returns_zero_without_cursor_calls(self):
+        class NoCallCursor:
+            rowcount = 123
+
+            async def execute(self, *args, **kwargs):
+                raise AssertionError("execute should not be called")
+
+            async def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        handler = MockParamHandler("insert into table (id) values (?id?)", [])
+
+        assert await handler.execute_async(NoCallCursor()) == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_async_with_no_params_executes_once(self):
+        class TrackingCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.calls = []
+
+            async def execute(self, sql, parameters=None):
+                self.calls.append(("execute", sql, parameters))
+                self.rowcount = 1
+
+            async def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        cursor = TrackingCursor()
+        handler = MockParamHandler("insert into table default values", None)
+
+        assert await handler.execute_async(cursor) == 1
+        assert cursor.calls == [("execute", "insert into table default values", None)]
+
+    @pytest.mark.asyncio
+    async def test_aiopg_param_handler_executes_no_param_sql_without_empty_tuple(self):
+        from pydapper.postgresql.aiopg import AiopgCommands
+
+        class TrackingCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.calls = []
+
+            async def execute(self, sql, parameters=None):
+                self.calls.append((sql, parameters))
+
+        cursor = TrackingCursor()
+        handler = AiopgCommands.SqlParamHandler("select 1", None)
+
+        assert await handler.execute_async(cursor) == 1
+        assert cursor.calls == [("select 1", None)]
 
 
 class TestCommands:
@@ -368,8 +686,44 @@ class TestCommands:
             pass
         assert commands.connection.closed
 
+    def test_context_manager_methods_allow_plain_connection(self):
+        class PlainConnection:
+            pass
+
+        commands = MockCommands(PlainConnection())
+
+        assert commands.__enter__() is commands
+        assert commands.__exit__(None, None, None) is None
+
     def test_cursor(self, connection):
         assert isinstance(MockCommands(connection).cursor(), MockCursor)
+
+    def test_cursor_context_proxy_supports_cursor_without_context_manager(self):
+        class PlainCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                return (1, "Zach"), (2, "Bob")
+
+        class PlainCursorConnection:
+            def __init__(self):
+                self.cursor_instance = PlainCursor()
+                self.cursor_calls = 0
+
+            def cursor(self, *args, **kwargs):
+                self.cursor_calls += 1
+                return self.cursor_instance
+
+        connection = PlainCursorConnection()
+
+        records = MockCommands(connection).query("select id, name from some_table")
+
+        assert records == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
+        assert connection.cursor_calls == 2
 
     def test_execute(self, connection):
         with MockCommands(connection) as commands:
@@ -377,6 +731,57 @@ class TestCommands:
                 "insert into some_table (id, name), (?id?, ?name?)", param={"id": 1, "name": "Zach"}
             )
         assert affected_rows == 1
+
+    def test_execute_sends_prepared_sql_and_ordered_values_to_cursor(self):
+        class RecordingCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.calls = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def execute(self, sql, parameters=None):
+                self.calls.append((sql, parameters))
+
+            def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        class RecordingConnection(MockConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = RecordingCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        connection = RecordingConnection()
+
+        with MockCommands(connection) as commands:
+            affected_rows = commands.execute(
+                "update task set note = '?ignored?' where id = ?id? -- ?id?",
+                params={"id": 1},
+            )
+
+        assert affected_rows == 1
+        assert connection.cursor_instance.calls == [("update task set note = '?ignored?' where id = %s -- ?id?", (1,))]
+
+    def test_execute_with_empty_top_level_list_params_returns_zero_without_opening_cursor(self):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands:
+            assert commands.execute("insert into some_table (id) values (?id?)", params=[]) == 0
+
+    @pytest.mark.parametrize("call", SYNC_READ_LIST_PARAMS_CALLS)
+    def test_read_methods_reject_top_level_list_params(self, connection, call):
+        with MockCommands(connection) as commands, pytest.raises(ValueError):
+            call(commands)
 
     @pytest.mark.parametrize("call, expected_handler_count", SYNC_PARAMS_CALLS)
     def test_public_methods_accept_params(
@@ -442,6 +847,24 @@ class TestCommands:
 
         assert data == {"id": None, "name": "nullable"}
 
+    def test_mysql_query_first_raises_on_none_result(self, connection, set_fetchone_to_return_none):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(NoResultException):
+            commands.query_first("select id, name from some_table")
+
+    def test_mysql_query_first_rejects_top_level_list_params(self, connection):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(ValueError):
+            commands.query_first("select id, name from some_table where id = ?id?", params=[])
+
     def test_query(self, connection):
         with MockCommands(connection) as commands:
             data = commands.query("select id, name from some_table", model=SimpleNamespace)
@@ -457,6 +880,27 @@ class TestCommands:
         with MockCommands(connection) as commands:
             generator = commands.query("select id, name from some_table", buffered=False)
             assert list(generator) == []
+
+    def test_query_unbuffered_yields_rows_until_none(self):
+        class OneRowCursor(MockCursor):
+            def __init__(self):
+                super().__init__()
+                self.rows = [(1, "Zach"), None]
+
+            def fetchone(self):
+                return self.rows.pop(0)
+
+        class OneRowConnection(MockConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = OneRowCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        with MockCommands(OneRowConnection()) as commands:
+            generator = commands.query("select id, name from some_table", buffered=False)
+            assert list(generator) == [{"id": 1, "name": "Zach"}]
 
     def test_query_multiple(self, connection):
         with MockCommands(connection) as commands:
@@ -656,6 +1100,61 @@ class TestCommandsAsync:
         assert affected_rows == 1
 
     @pytest.mark.asyncio
+    async def test_execute_async_sends_prepared_sql_and_ordered_values_to_cursor(self):
+        class RecordingCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            async def execute(self, sql, parameters=None):
+                self.calls.append((sql, parameters))
+
+            async def executemany(self, *args, **kwargs):
+                raise AssertionError("executemany should not be called")
+
+        class RecordingConnection(MockAsyncConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = RecordingCursor()
+
+            async def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        connection = RecordingConnection()
+
+        async with MockAsyncCommands(connection) as commands:
+            affected_rows = await commands.execute_async(
+                "update task set note = '?ignored?' where id = ?id? -- ?id?",
+                params={"id": 1},
+            )
+
+        assert affected_rows == 1
+        assert connection.cursor_instance.calls == [("update task set note = '?ignored?' where id = %s -- ?id?", (1,))]
+
+    @pytest.mark.asyncio
+    async def test_execute_async_with_empty_top_level_list_params_returns_zero_without_opening_cursor(self):
+        class NoCursorConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        async with MockAsyncCommands(NoCursorConnection()) as commands:
+            assert await commands.execute_async("insert into some_table (id) values (?id?)", params=[]) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call", ASYNC_READ_LIST_PARAMS_CALLS)
+    async def test_read_methods_reject_top_level_list_params(self, connection, call):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError):
+                await call(commands)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("call, expected_handler_count", ASYNC_PARAMS_CALLS)
     async def test_public_methods_accept_params(
         self, connection, captured_handler_params, set_fetchall_return_one, call, expected_handler_count
@@ -723,6 +1222,30 @@ class TestCommandsAsync:
             assert [row async for row in generator] == []
 
     @pytest.mark.asyncio
+    async def test_query_unbuffered_yields_rows_until_none(self):
+        class OneRowAsyncCursor(MockAsyncCursor):
+            def __init__(self):
+                super().__init__()
+                self.rows = [(1, "Zach"), None]
+
+            async def fetchone(self):
+                return self.rows.pop(0)
+
+        class OneRowAsyncConnection(MockAsyncConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = OneRowAsyncCursor()
+
+            async def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        async with MockAsyncCommands(OneRowAsyncConnection()) as commands:
+            generator = await commands.query_async("select id, name from some_table", buffered=False)
+            records = [record async for record in generator]
+
+        assert records == [{"id": 1, "name": "Zach"}]
+
+    @pytest.mark.asyncio
     async def test_query_multiple(self, connection):
         async with MockAsyncCommands(connection) as commands:
             data1, data2 = await commands.query_multiple_async(
@@ -761,6 +1284,18 @@ class TestCommandsAsync:
         assert isinstance(record, SimpleNamespace)
         assert record.id
         assert record.name
+
+    @pytest.mark.asyncio
+    async def test_query_first_treats_falsy_row_as_result(self, connection, mocker):
+        async def fetchone(s):
+            return FalsyRow((None, "nullable"))
+
+        mocker.patch("tests.mocks.MockAsyncCursor.fetchone", fetchone)
+
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_first_async("select id, name from some_table")
+
+        assert record == {"id": None, "name": "nullable"}
 
     @pytest.mark.asyncio
     async def test_query_first_raises_on_no_result(self, connection, set_fetchone_to_return_none):

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -49,10 +49,13 @@ class Commands:
     @staticmethod
     def execute(query: str) -> None:
         params = {"id": 1}
+        batch_params = [{"id": 1}, {"id": 2}]
 
         with pydapper.connect() as commands:
             assert_type(commands.execute(query, param=params), int)
             assert_type(commands.execute(query, params=params), int)
+            assert_type(commands.execute(query, params=[]), int)
+            assert_type(commands.execute(query, params=batch_params), int)
             assert_type(commands.execute_scalar(query, param=params), Any)
             assert_type(commands.execute_scalar(query, params=params), Any)
             assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
@@ -131,10 +134,13 @@ class CommandsAsync:
     @staticmethod
     async def execute(query: str) -> None:
         params = {"id": 1}
+        batch_params = [{"id": 1}, {"id": 2}]
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.execute_async(query, param=params), int)
             assert_type(await commands.execute_async(query, params=params), int)
+            assert_type(await commands.execute_async(query, params=[]), int)
+            assert_type(await commands.execute_async(query, params=batch_params), int)
             assert_type(await commands.execute_scalar_async(query, param=params), Any)
             assert_type(await commands.execute_scalar_async(query, params=params), Any)
             assert_type(await commands.query_multiple_async((query,), param=params), Tuple[List[Any], ...])


### PR DESCRIPTION
## Summary
- replace regex placeholder matching with a small SQL-aware scanner for v1 placeholder grammar
- ignore placeholder-shaped text in single/double quoted text and -- / /* */ comments
- rebuild prepared SQL from scanner spans and call get_param_placeholder(name) per active occurrence
- treat top-level execute params=[] as zero-record multi-exec, while read APIs reject top-level list params
- document the v1 placeholder grammar and scanner limits

## Tests
- /Users/zachschumacher/src/pydapper/.venv/bin/python -m pytest tests/test_commands_interface.py -q
- /Users/zachschumacher/src/pydapper/.venv/bin/python -m pytest -m core -q
- /Users/zachschumacher/src/pydapper/.venv/bin/python -m mypy tests/type_tests.py
- /Users/zachschumacher/src/pydapper/.venv/bin/python -m black --check pydapper/commands.py pydapper/mysql/mysql_connector_python.py pydapper/postgresql/aiopg.py tests/test_commands_interface.py tests/type_tests.py
- /Users/zachschumacher/src/pydapper/.venv/bin/python -m isort --check-only pydapper/commands.py pydapper/mysql/mysql_connector_python.py pydapper/postgresql/aiopg.py tests/test_commands_interface.py tests/type_tests.py
- git diff --check

Closes #457