### PR TITLE
fix: harden parameter shapes and executemany behavior

### DIFF
--- a/docs/.parameter_shapes_execute.md
+++ b/docs/.parameter_shapes_execute.md
@@ -1,0 +1,13 @@
+## Parameter Shapes
+
+`params=None`, `param=None`, or omitting both names means there is no parameter object. If the SQL contains pydapper
+placeholders such as `?id?`, every referenced placeholder must be supplied or pydapper raises
+`MissingParameterException` before calling the DBAPI.
+
+For one execution, pass one parameter record: a mapping, mapping subclass, mutable mapping, or object/dataclass with
+attributes matching the placeholder names. Falsey values such as `0`, `False`, `""`, and `[]` are bound normally.
+
+For multiple executions, pass a top-level `list` to `execute` or `execute_async`. Each list item is one parameter record.
+An empty top-level list runs zero commands and returns `0`. A list inside one parameter record, such as
+`{"ids": []}` or `{"ids": [1, 2, 3]}`, is one value, not executemany input. List expansion for `IN` clauses is reserved
+for future support.

--- a/docs/.parameter_shapes_read.md
+++ b/docs/.parameter_shapes_read.md
@@ -1,0 +1,11 @@
+## Parameter Shapes
+
+`params` accepts one parameter record: a mapping, mapping subclass, mutable mapping, or object/dataclass with attributes
+matching the placeholder names. Top-level list params are only for `execute` and `execute_async`; read and scalar methods
+raise `InvalidParameterShapeException` for top-level lists before opening a cursor.
+
+`params=None`, `param=None`, or omitting both names means there is no parameter object. If the SQL contains pydapper
+placeholders such as `?id?`, every referenced placeholder must be supplied or pydapper raises
+`MissingParameterException` before calling the DBAPI. An empty mapping is a real parameter record with no keys. A list
+inside one parameter record, such as `{"ids": []}` or `{"ids": [1, 2, 3]}`, is one value and is reserved for future `IN`
+list expansion support.

--- a/docs/async_methods/execute_async.md
+++ b/docs/async_methods/execute_async.md
@@ -10,6 +10,8 @@ to execute insert, update or delete operations.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_execute.md!}
+
 ## Example - Execute Insert
 ### Single
 Execute the INSERT statement a single time.

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -11,6 +11,8 @@ the query.  The additional columns or rows are ignored.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Cardinality
 - 0 rows: raises `NoResultException`.
 - 1+ rows: returns the first column of the first row.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -12,6 +12,8 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Cardinality
 - 0 rows with `buffered=True`: returns an empty list.
 - 0 rows with `buffered=False`: returns an async generator that yields no rows.

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -10,6 +10,8 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -13,6 +13,8 @@ set contains no records.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -11,6 +11,8 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -11,6 +11,8 @@ record in the result set.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -13,6 +13,8 @@ set is empty; this method throws an exception if there is more than one element 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/execute.md
+++ b/docs/methods/execute.md
@@ -10,6 +10,8 @@ to execute insert, update or delete operations.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_execute.md!}
+
 ## Example - Execute Insert
 ### Single
 Execute the INSERT statement a single time.

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -11,6 +11,8 @@ the query.  The additional columns or rows are ignored.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Cardinality
 - 0 rows: raises `NoResultException`.
 - 1+ rows: returns the first column of the first row.

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -12,6 +12,8 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Cardinality
 - 0 rows with `buffered=True`: returns an empty list.
 - 0 rows with `buffered=False`: returns a generator that yields no rows.

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -10,6 +10,8 @@
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -13,6 +13,8 @@ set contains no records.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -11,6 +11,8 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -11,6 +11,8 @@ record in the result set.
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -13,6 +13,8 @@ set is empty; this method throws an exception if there is more than one element 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
+{!docs/.parameter_shapes_read.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1,8 +1,10 @@
 import typing
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Mapping
 from contextlib import ExitStack
 from contextlib import contextmanager
+from dataclasses import is_dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import Any
@@ -23,11 +25,12 @@ from typing import overload
 from ._context import CoroContextManager
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
+from .exceptions import InvalidParameterShapeException
+from .exceptions import MissingParameterException
 from .exceptions import MoreThanOneResultException
 from .exceptions import NoResultException
 from .utils import database_row_to_dict
 from .utils import get_col_names
-from .utils import safe_getattr
 from .utils import serialize_dict_row
 
 if TYPE_CHECKING:
@@ -70,20 +73,87 @@ def _is_empty_executemany_params(param: Any) -> bool:
 
 def _raise_if_list_params_for_read(param: Any) -> None:
     if isinstance(param, list):
-        raise ValueError("Top-level list params are only supported by execute and execute_async.")
+        raise InvalidParameterShapeException("Top-level list params are only supported by execute and execute_async.")
+
+
+_INVALID_ATTRIBUTE_PARAM_TYPES = (
+    str,
+    bytes,
+    bytearray,
+    list,
+    tuple,
+    set,
+    frozenset,
+    range,
+    memoryview,
+)
+
+
+def _is_attribute_param_record(param: Any) -> bool:
+    if isinstance(param, type):
+        return False
+    if is_dataclass(param):
+        return True
+    if isinstance(param, _INVALID_ATTRIBUTE_PARAM_TYPES):
+        return False
+    return hasattr(param, "__dict__") or hasattr(type(param), "__slots__")
+
+
+def _is_param_record(param: Any) -> bool:
+    return isinstance(param, Mapping) or _is_attribute_param_record(param)
+
+
+def _raise_invalid_param_record(param: Any, location: str) -> None:
+    raise InvalidParameterShapeException(
+        f"{location} must be a mapping or an object with attributes matching SQL placeholders; "
+        f"got {type(param).__name__}."
+    )
+
+
+def _get_param_value(param: Any, param_name: str) -> Any:
+    if isinstance(param, Mapping):
+        try:
+            return param[param_name]
+        except KeyError:
+            raise MissingParameterException(f"Missing SQL parameter {param_name!r}.") from None
+
+    try:
+        return getattr(param, param_name)
+    except AttributeError:
+        raise MissingParameterException(f"Missing SQL parameter {param_name!r}.") from None
 
 
 class BaseSqlParamHandler(ABC):
     def __init__(self, sql: str, param: Union["ParamType", "ListParamType"] = None):
         self._sql = sql
         self._param = param
-        if isinstance(self._param, list) and self._param:
-            all_params_are_same_type = all(isinstance(param, type(self._param[0])) for param in self._param[1:])
-            if not all_params_are_same_type:
-                raise ValueError(f"All objects in params must be of type {type(self._param[0])}")
+        self._validate_param_shape()
 
     @abstractmethod
     def get_param_placeholder(self, param_name: str) -> str: ...
+
+    def get_param_value(self, param: Any, param_name: str) -> Any:
+        return _get_param_value(param, param_name)
+
+    def _validate_param_shape(self) -> None:
+        if isinstance(self._param, list):
+            for index, param in enumerate(self._param):
+                self._validate_param_record(param, f"params[{index}]")
+            return
+
+        if self._param is None:
+            if self.ordered_param_names:
+                raise MissingParameterException(f"Missing SQL parameter {self.ordered_param_names[0]!r}.")
+            return
+
+        self._validate_param_record(self._param, "params")
+
+    def _validate_param_record(self, param: Any, location: str) -> None:
+        if not _is_param_record(param):
+            _raise_invalid_param_record(param, location)
+
+        for param_name in self.ordered_param_names:
+            self.get_param_value(param, param_name)
 
     @cached_property
     def ordered_param_names(self) -> Tuple[str, ...]:
@@ -96,15 +166,18 @@ class BaseSqlParamHandler(ABC):
     @cached_property
     def ordered_param_values(self) -> Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple]:
         if isinstance(self._param, list):
-            return [tuple(safe_getattr(p, name) for name in self.ordered_param_names) for p in self._param]
+            return [self._ordered_param_values_for_record(param) for param in self._param]
 
-        if self._param:
-            return tuple(safe_getattr(self._param, name) for name in self.ordered_param_names)
+        if self._param is not None:
+            return self._ordered_param_values_for_record(self._param)
         return tuple()
+
+    def _ordered_param_values_for_record(self, param: Any) -> Tuple[Any, ...]:
+        return tuple(self.get_param_value(param, name) for name in self.ordered_param_names)
 
     @cached_property
     def prepared_sql(self) -> str:
-        if self._param and self._placeholder_spans:
+        if self._placeholder_spans:
             prepared_sql_parts = []
             current_index = 0
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -127,7 +127,9 @@ class BaseSqlParamHandler(ABC):
     def __init__(self, sql: str, param: Union["ParamType", "ListParamType"] = None):
         self._sql = sql
         self._param = param
-        self._validate_param_shape()
+        self.ordered_param_values: Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple] = (
+            self._resolve_ordered_param_values()
+        )
 
     @abstractmethod
     def get_param_placeholder(self, param_name: str) -> str: ...
@@ -135,25 +137,19 @@ class BaseSqlParamHandler(ABC):
     def get_param_value(self, param: Any, param_name: str) -> Any:
         return _get_param_value(param, param_name)
 
-    def _validate_param_shape(self) -> None:
+    def _resolve_ordered_param_values(self) -> Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple]:
         if isinstance(self._param, list):
-            for index, param in enumerate(self._param):
-                self._validate_param_record(param, f"params[{index}]")
-            return
+            return [
+                self._ordered_param_values_for_record(param, f"params[{index}]")
+                for index, param in enumerate(self._param)
+            ]
 
         if self._param is None:
             if self.ordered_param_names:
                 raise MissingParameterException(f"Missing SQL parameter {self.ordered_param_names[0]!r}.")
-            return
+            return tuple()
 
-        self._validate_param_record(self._param, "params")
-
-    def _validate_param_record(self, param: Any, location: str) -> None:
-        if not _is_param_record(param):
-            _raise_invalid_param_record(param, location)
-
-        for param_name in self.ordered_param_names:
-            self.get_param_value(param, param_name)
+        return self._ordered_param_values_for_record(self._param, "params")
 
     @cached_property
     def ordered_param_names(self) -> Tuple[str, ...]:
@@ -163,16 +159,10 @@ class BaseSqlParamHandler(ABC):
     def _placeholder_spans(self) -> Tuple[PlaceholderSpan, ...]:
         return scan_placeholder_spans(self._sql)
 
-    @cached_property
-    def ordered_param_values(self) -> Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple]:
-        if isinstance(self._param, list):
-            return [self._ordered_param_values_for_record(param) for param in self._param]
+    def _ordered_param_values_for_record(self, param: Any, location: str) -> Tuple[Any, ...]:
+        if not _is_param_record(param):
+            _raise_invalid_param_record(param, location)
 
-        if self._param is not None:
-            return self._ordered_param_values_for_record(self._param)
-        return tuple()
-
-    def _ordered_param_values_for_record(self, param: Any) -> Tuple[Any, ...]:
         return tuple(self.get_param_value(param, name) for name in self.ordered_param_names)
 
     @cached_property

--- a/pydapper/exceptions.py
+++ b/pydapper/exceptions.py
@@ -14,6 +14,10 @@ class MissingParameterException(PyDapperException):
     pass
 
 
+class InvalidParameterShapeException(PyDapperException):
+    pass
+
+
 class UnsupportedFeatureError(PyDapperException):
     pass
 

--- a/pydapper/mssql/pymssql.py
+++ b/pydapper/mssql/pymssql.py
@@ -6,7 +6,6 @@ from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
 from ..utils import import_dbapi_module
-from ..utils import safe_getattr
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
@@ -23,7 +22,9 @@ class PymssqlCommands(Commands):
                 test_param = self._param[0]
             else:
                 test_param = self._param
-            param_value = safe_getattr(test_param, param_name)
+            if test_param is None:
+                return "%s"
+            param_value = self.get_param_value(test_param, param_name)
             return _PARAM_TYPE_LOOKUP.get(type(param_value), "%s")
 
     @classmethod

--- a/pydapper/mssql/pymssql.py
+++ b/pydapper/mssql/pymssql.py
@@ -19,7 +19,7 @@ class PymssqlCommands(Commands):
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:
             if isinstance(self._param, list):
-                test_param = self._param[0]
+                test_param = self._param[0] if self._param else None
             else:
                 test_param = self._param
             if test_param is None:

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -5,15 +5,16 @@ from typing import Mapping
 from typing import MutableMapping
 from typing import Optional
 from typing import Protocol
+from typing import TypeAlias
 from typing import Union
 
 
 class SupportsAttrAccess(Protocol):
-    def __getattribute__(self, item): ...
+    def __getattribute__(self, item: str) -> Any: ...
 
 
-ParamType = Union[SupportsAttrAccess, Mapping, MutableMapping]
-ListParamType = Union[List[SupportsAttrAccess], List[Mapping], List[MutableMapping]]
+ParamType: TypeAlias = Union[Mapping[str, Any], MutableMapping[str, Any], SupportsAttrAccess]
+ListParamType: TypeAlias = List[ParamType]
 
 
 class ConnectionType(Protocol):

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -1,4 +1,5 @@
 import importlib
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 def safe_getattr(obj: Any, key: str) -> Any:
     try:
-        if isinstance(obj, dict):
+        if isinstance(obj, Mapping):
             return obj[key]
         return getattr(obj, key)
     except AttributeError:

--- a/tests/test_adapter_units.py
+++ b/tests/test_adapter_units.py
@@ -91,6 +91,13 @@ def test_pymssql_param_handler_uses_parameter_type_for_placeholder(param, expect
     assert handler.get_param_placeholder("value") == expected_placeholder
 
 
+def test_pymssql_param_handler_uses_default_placeholder_for_empty_executemany_params():
+    handler = mssql_module.PymssqlCommands.SqlParamHandler("select ?value?", [])
+
+    assert handler.get_param_placeholder("value") == "%s"
+    assert handler.prepared_sql == "select %s"
+
+
 def test_pymssql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
     dbapi = RecordingDbApi()
     import_calls = patch_dbapi_import(monkeypatch, mssql_module, "pymssql", dbapi)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,7 +1,10 @@
+from collections import UserDict
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
 
+from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.exceptions import NoResultException
@@ -22,6 +25,14 @@ pytestmark = pytest.mark.core
 class FalsyRow(tuple):
     def __bool__(self):
         return False
+
+
+@dataclass
+class TaskParams:
+    id: int
+    active: bool = True
+    name: str = "task"
+    ids: list[int] | None = None
 
 
 @pytest.fixture
@@ -333,6 +344,7 @@ class TestPublicExceptions:
             NoResultException,
             MoreThanOneResultException,
             MissingParameterException,
+            InvalidParameterShapeException,
             UnsupportedFeatureError,
             RowMappingException,
         ],
@@ -342,9 +354,18 @@ class TestPublicExceptions:
 
 
 class TestParamHandler:
-    def test__init__validation(self):
-        with pytest.raises(ValueError):
-            MockParamHandler("sup", param=[SimpleNamespace(), dict()])
+    @pytest.mark.parametrize("param", [1, "task", ("id", 1), {"id"}, object(), [1]])
+    def test__init__rejects_invalid_param_shapes(self, param):
+        with pytest.raises(InvalidParameterShapeException):
+            MockParamHandler("select * from table where id = ?id?", param=param)
+
+    def test__init__allows_mixed_executemany_record_types(self):
+        handler = MockParamHandler(
+            "insert into table (id) values (?id?)",
+            [SimpleNamespace(id=1), {"id": 2}, TaskParams(id=3)],
+        )
+
+        assert handler.ordered_param_values == [(1,), (2,), (3,)]
 
     def test_default_param_handler_get_param_placeholder(self):
         from pydapper.commands import DefaultSqlParamHandler
@@ -362,7 +383,10 @@ class TestParamHandler:
         assert repr(_PARAM_ALIAS_UNSET) == "None"
 
     def test_ordered_param_names(self):
-        handler = MockParamHandler("?sup? ?hello? ?world? ?foo? ?bar?", None)
+        handler = MockParamHandler(
+            "?sup? ?hello? ?world? ?foo? ?bar?",
+            {"sup": 1, "hello": 2, "world": 3, "foo": 4, "bar": 5},
+        )
         assert handler.ordered_param_names == ("sup", "hello", "world", "foo", "bar")
 
     def test_ordered_param_values(self):
@@ -371,6 +395,29 @@ class TestParamHandler:
             {"sup": "dude", "hello": "world", "world": "hello", "foo": "bar", "bar": "foo"},
         )
         assert handler.ordered_param_values == ("dude", "world", "hello", "bar", "foo")
+
+    def test_ordered_param_values_supports_mapping_subclasses(self):
+        handler = MockParamHandler("?id? ?name?", UserDict({"id": 1, "name": "Zach"}))
+
+        assert handler.ordered_param_values == (1, "Zach")
+
+    def test_ordered_param_values_supports_attribute_objects(self):
+        handler = MockParamHandler("?id? ?name?", SimpleNamespace(id=1, name="Zach"))
+
+        assert handler.ordered_param_values == (1, "Zach")
+
+    def test_ordered_param_values_supports_dataclass_instances_and_falsey_values(self):
+        handler = MockParamHandler(
+            "?id? ?active? ?name? ?ids?",
+            TaskParams(id=0, active=False, name="", ids=[]),
+        )
+
+        assert handler.ordered_param_values == (0, False, "", [])
+
+    @pytest.mark.parametrize("param", [None, {}, SimpleNamespace()])
+    def test_missing_params_raise_missing_parameter_exception(self, param):
+        with pytest.raises(MissingParameterException, match="'id'"):
+            MockParamHandler("select * from table where id = ?id?", param)
 
     def test_ordered_param_values_empty_top_level_list_is_executemany_input(self):
         handler = MockParamHandler("insert into table (id) values (?id?)", [])
@@ -382,6 +429,12 @@ class TestParamHandler:
         assert handler.ordered_param_values == ([],)
         assert handler.prepared_sql == "select * from table where id in %s"
 
+    def test_non_empty_list_inside_mapping_is_single_parameter_value(self):
+        handler = MockParamHandler("select * from table where id in ?ids?", {"ids": [1, 2, 3]})
+        assert handler.ordered_param_names == ("ids",)
+        assert handler.ordered_param_values == ([1, 2, 3],)
+        assert handler.prepared_sql == "select * from table where id in %s"
+
     def test_prepared_sql(self):
         handler = MockParamHandler("select * from table where id = ?id? and name = ?name?", {"id": 1, "name": "Zach"})
         assert handler.prepared_sql == "select * from table where id = %s and name = %s"
@@ -391,9 +444,9 @@ class TestParamHandler:
         assert handler.prepared_sql == "select * from table"
 
     @pytest.mark.parametrize("param", [None, {}, []])
-    def test_prepared_sql_with_falsey_params_preserves_original_sql(self, param):
-        handler = MockParamHandler("select * from table where id = ?id?", param)
-        assert handler.prepared_sql == "select * from table where id = ?id?"
+    def test_prepared_sql_with_falsey_params_and_no_placeholders_preserves_original_sql(self, param):
+        handler = MockParamHandler("select * from table", param)
+        assert handler.prepared_sql == "select * from table"
 
     def test_prepared_sql_ignores_placeholders_inside_quoted_text(self):
         sql = """select '?ignored?', 'it''s ?still_ignored?', "?quoted?", "a "" ?still_quoted? "" b", ?active?"""
@@ -778,9 +831,73 @@ class TestCommands:
         with MockCommands(NoCursorConnection()) as commands:
             assert commands.execute("insert into some_table (id) values (?id?)", params=[]) == 0
 
+    def test_execute_uses_executemany_for_mixed_record_list_params(self):
+        class RecordingCursor:
+            rowcount = 2
+
+            def __init__(self):
+                self.calls = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def execute(self, *args, **kwargs):
+                raise AssertionError("execute should not be called")
+
+            def executemany(self, sql, params):
+                self.calls.append((sql, params))
+
+        class RecordingConnection(MockConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = RecordingCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        connection = RecordingConnection()
+
+        with MockCommands(connection) as commands:
+            affected_rows = commands.execute(
+                "insert into some_table (id) values (?id?)",
+                params=[{"id": 1}, SimpleNamespace(id=2)],
+            )
+
+        assert affected_rows == 2
+        assert connection.cursor_instance.calls == [
+            ("insert into some_table (id) values (%s)", [(1,), (2,)]),
+        ]
+
+    @pytest.mark.parametrize(
+        "params, exception_type",
+        [
+            ([{"id": 1}, 2], InvalidParameterShapeException),
+            ([{"id": 1}, {}], MissingParameterException),
+        ],
+    )
+    def test_execute_rejects_invalid_executemany_records_before_opening_cursor(self, params, exception_type):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands, pytest.raises(exception_type):
+            commands.execute("insert into some_table (id) values (?id?)", params=params)
+
+    @pytest.mark.parametrize("call", SYNC_READ_LIST_PARAMS_CALLS)
+    def test_read_methods_reject_top_level_list_params_before_opening_cursor(self, call):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands, pytest.raises(InvalidParameterShapeException):
+            call(commands)
+
     @pytest.mark.parametrize("call", SYNC_READ_LIST_PARAMS_CALLS)
     def test_read_methods_reject_top_level_list_params(self, connection, call):
-        with MockCommands(connection) as commands, pytest.raises(ValueError):
+        with MockCommands(connection) as commands, pytest.raises(InvalidParameterShapeException):
             call(commands)
 
     @pytest.mark.parametrize("call, expected_handler_count", SYNC_PARAMS_CALLS)
@@ -862,7 +979,7 @@ class TestCommands:
         class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
             SqlParamHandler = MockParamHandler
 
-        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(ValueError):
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(InvalidParameterShapeException):
             commands.query_first("select id, name from some_table where id = ?id?", params=[])
 
     def test_query(self, connection):
@@ -1148,10 +1265,81 @@ class TestCommandsAsync:
             assert await commands.execute_async("insert into some_table (id) values (?id?)", params=[]) == 0
 
     @pytest.mark.asyncio
+    async def test_execute_async_uses_executemany_for_mixed_record_list_params(self):
+        class RecordingCursor:
+            rowcount = 2
+
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            async def execute(self, *args, **kwargs):
+                raise AssertionError("execute should not be called")
+
+            async def executemany(self, sql, params):
+                self.calls.append((sql, params))
+
+        class RecordingConnection(MockAsyncConnection):
+            def __init__(self):
+                super().__init__()
+                self.cursor_instance = RecordingCursor()
+
+            async def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        connection = RecordingConnection()
+
+        async with MockAsyncCommands(connection) as commands:
+            affected_rows = await commands.execute_async(
+                "insert into some_table (id) values (?id?)",
+                params=[{"id": 1}, SimpleNamespace(id=2)],
+            )
+
+        assert affected_rows == 2
+        assert connection.cursor_instance.calls == [
+            ("insert into some_table (id) values (%s)", [(1,), (2,)]),
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "params, exception_type",
+        [
+            ([{"id": 1}, 2], InvalidParameterShapeException),
+            ([{"id": 1}, {}], MissingParameterException),
+        ],
+    )
+    async def test_execute_async_rejects_invalid_executemany_records_before_opening_cursor(
+        self, params, exception_type
+    ):
+        class NoCursorConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        async with MockAsyncCommands(NoCursorConnection()) as commands:
+            with pytest.raises(exception_type):
+                await commands.execute_async("insert into some_table (id) values (?id?)", params=params)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call", ASYNC_READ_LIST_PARAMS_CALLS)
+    async def test_read_methods_reject_top_level_list_params_before_opening_cursor(self, call):
+        class NoCursorConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        async with MockAsyncCommands(NoCursorConnection()) as commands:
+            with pytest.raises(InvalidParameterShapeException):
+                await call(commands)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("call", ASYNC_READ_LIST_PARAMS_CALLS)
     async def test_read_methods_reject_top_level_list_params(self, connection, call):
         async with MockAsyncCommands(connection) as commands:
-            with pytest.raises(ValueError):
+            with pytest.raises(InvalidParameterShapeException):
                 await call(commands)
 
     @pytest.mark.asyncio

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -354,7 +354,7 @@ class TestPublicExceptions:
 
 
 class TestParamHandler:
-    @pytest.mark.parametrize("param", [1, "task", ("id", 1), {"id"}, object(), [1]])
+    @pytest.mark.parametrize("param", [1, "task", ("id", 1), {"id"}, object(), [1], TaskParams])
     def test__init__rejects_invalid_param_shapes(self, param):
         with pytest.raises(InvalidParameterShapeException):
             MockParamHandler("select * from table where id = ?id?", param=param)
@@ -413,6 +413,43 @@ class TestParamHandler:
         )
 
         assert handler.ordered_param_values == (0, False, "", [])
+
+    def test_ordered_param_values_are_resolved_once_for_single_record(self):
+        class LazyParams:
+            def __init__(self):
+                self.id_calls = 0
+
+            @property
+            def id(self):
+                self.id_calls += 1
+                return 1
+
+        params = LazyParams()
+        handler = MockParamHandler("?id?", params)
+
+        assert params.id_calls == 1
+        assert handler.ordered_param_values == (1,)
+        assert handler.ordered_param_values == (1,)
+        assert params.id_calls == 1
+
+    def test_ordered_param_values_are_resolved_once_for_executemany_records(self):
+        class LazyParams:
+            def __init__(self, id_):
+                self._id = id_
+                self.id_calls = 0
+
+            @property
+            def id(self):
+                self.id_calls += 1
+                return self._id
+
+        params = [LazyParams(1), LazyParams(2)]
+        handler = MockParamHandler("?id?", params)
+
+        assert [param.id_calls for param in params] == [1, 1]
+        assert handler.ordered_param_values == [(1,), (2,)]
+        assert handler.ordered_param_values == [(1,), (2,)]
+        assert [param.id_calls for param in params] == [1, 1]
 
     @pytest.mark.parametrize("param", [None, {}, SimpleNamespace()])
     def test_missing_params_raise_missing_parameter_exception(self, param):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 from contextlib import ExitStack
 from types import SimpleNamespace
 
@@ -17,6 +18,7 @@ pytestmark = pytest.mark.core
     "obj, key, expected",
     [
         ({"id": 1, "name": "Zach"}, "id", 1),
+        (UserDict({"id": 1, "name": "Zach"}), "id", 1),
         (SimpleNamespace(id=1, name="Zach"), "id", 1),
         ({"id": 1}, "name", KeyError),
         (SimpleNamespace(id=1), "name", AttributeError),

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -1,5 +1,6 @@
 import datetime
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from typing import AsyncGenerator
 from typing import Dict
@@ -12,6 +13,7 @@ import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.exceptions import NoResultException
@@ -32,6 +34,10 @@ class Task:
     owner_id: int
 
 
+class ParamsDict(dict[str, Any]):
+    pass
+
+
 def default_callable() -> str:
     return "sup"
 
@@ -41,6 +47,7 @@ def public_exceptions() -> None:
     assert_type(NoResultException(), NoResultException)
     assert_type(MoreThanOneResultException(), MoreThanOneResultException)
     assert_type(MissingParameterException(), MissingParameterException)
+    assert_type(InvalidParameterShapeException(), InvalidParameterShapeException)
     assert_type(UnsupportedFeatureError(), UnsupportedFeatureError)
     assert_type(RowMappingException(), RowMappingException)
 
@@ -49,11 +56,17 @@ class Commands:
     @staticmethod
     def execute(query: str) -> None:
         params = {"id": 1}
+        mapping_subclass_params = ParamsDict({"id": 1})
+        dataclass_params = Task(1, "task", datetime.date.today(), 1)
+        object_params = SimpleNamespace(id=1)
         batch_params = [{"id": 1}, {"id": 2}]
 
         with pydapper.connect() as commands:
             assert_type(commands.execute(query, param=params), int)
             assert_type(commands.execute(query, params=params), int)
+            assert_type(commands.execute(query, params=mapping_subclass_params), int)
+            assert_type(commands.execute(query, params=dataclass_params), int)
+            assert_type(commands.execute(query, params=object_params), int)
             assert_type(commands.execute(query, params=[]), int)
             assert_type(commands.execute(query, params=batch_params), int)
             assert_type(commands.execute_scalar(query, param=params), Any)
@@ -64,6 +77,9 @@ class Commands:
     @staticmethod
     def query(query: str) -> None:
         params = {"id": 1}
+        mapping_subclass_params = ParamsDict({"id": 1})
+        dataclass_params = Task(1, "task", datetime.date.today(), 1)
+        object_params = SimpleNamespace(id=1)
 
         with pydapper.connect() as commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
@@ -77,6 +93,9 @@ class Commands:
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
             assert_type(commands.query(query, param=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=mapping_subclass_params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=dataclass_params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=object_params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=params, model=Task), List[Task])
 
     @staticmethod
@@ -134,11 +153,17 @@ class CommandsAsync:
     @staticmethod
     async def execute(query: str) -> None:
         params = {"id": 1}
+        mapping_subclass_params = ParamsDict({"id": 1})
+        dataclass_params = Task(1, "task", datetime.date.today(), 1)
+        object_params = SimpleNamespace(id=1)
         batch_params = [{"id": 1}, {"id": 2}]
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.execute_async(query, param=params), int)
             assert_type(await commands.execute_async(query, params=params), int)
+            assert_type(await commands.execute_async(query, params=mapping_subclass_params), int)
+            assert_type(await commands.execute_async(query, params=dataclass_params), int)
+            assert_type(await commands.execute_async(query, params=object_params), int)
             assert_type(await commands.execute_async(query, params=[]), int)
             assert_type(await commands.execute_async(query, params=batch_params), int)
             assert_type(await commands.execute_scalar_async(query, param=params), Any)
@@ -149,6 +174,9 @@ class CommandsAsync:
     @staticmethod
     async def query(query: str):
         params = {"id": 1}
+        mapping_subclass_params = ParamsDict({"id": 1})
+        dataclass_params = Task(1, "task", datetime.date.today(), 1)
+        object_params = SimpleNamespace(id=1)
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_async(query, buffered=True), List[Dict[str, Any]])
@@ -157,6 +185,9 @@ class CommandsAsync:
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
             assert_type(await commands.query_async(query, param=params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=mapping_subclass_params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=dataclass_params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=object_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=params, model=Task), List[Task])
 
     @staticmethod


### PR DESCRIPTION
Closes #458

## What changed
- Defined and enforced the v1 parameter shape contract for `params=` and the `param=` compatibility alias.
- Added `InvalidParameterShapeException` for invalid parameter shapes.
- Supported mapping subclasses, dataclass/object attribute records, falsey bound values, mixed executemany record types, and empty top-level execute lists returning `0`.
- Updated public types, focused sync/async tests, and method docs.

## Behavior
Before:
- Top-level list params on read/scalar APIs raised incidental `ValueError`.
- Missing values could surface as `KeyError` or `AttributeError`.
- Executemany list records had to share the same concrete Python type.

After:
- Missing referenced params raise `MissingParameterException` with the missing name.
- Invalid shapes raise the public `InvalidParameterShapeException` before opening a cursor where practical.
- `execute(..., params=[{"id": 1}, SimpleNamespace(id=2)])` uses executemany with ordered tuples.
- `execute(..., params=[])` returns `0` without opening a cursor.
- `params={"ids": []}` and `params={"ids": [1, 2, 3]}` remain one parameter value, not executemany input.

## Checks
- `poetry run pytest tests/test_commands_interface.py tests/test_utils.py -m "core"` passed
- `poetry run mypy pydapper tests/type_tests.py` passed
- `poetry run black --check .` passed
- `poetry run isort --check .` passed
- `poetry run pytest -m "core"` passed
- `poetry run pytest -m "sqlite"` passed
- `poetry run mkdocs build --strict` failed because `mkdocs` is not installed in the current Poetry environment

## Skipped driver-specific tests
PostgreSQL, MSSQL, MySQL, Oracle, and BigQuery integrations were skipped because they require optional extras, external services, or testcontainers. Core and SQLite coverage exercised the shared parameter contract.

## Impact
- Public API: adds `InvalidParameterShapeException`; keeps `param=` compatibility.
- Type compatibility: updates `ParamType` and `ListParamType` to match runtime behavior.
- Docs: updates sync and async method pages for supported parameter shapes.
- Dependencies and optional extras: no changes.