### PR TITLE
fix: bound query_single row fetching

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -76,6 +76,38 @@ def _raise_if_list_params_for_read(param: Any) -> None:
         raise InvalidParameterShapeException("Top-level list params are only supported by execute and execute_async.")
 
 
+def _fetch_at_most_two_rows(cursor: "CursorType") -> Tuple[Any, ...]:
+    fetchmany = getattr(cursor, "fetchmany", None)
+    if callable(fetchmany):
+        return tuple(fetchmany(2))
+
+    first_row = cursor.fetchone()
+    if first_row is None:
+        return tuple()
+
+    second_row = cursor.fetchone()
+    if second_row is None:
+        return (first_row,)
+
+    return first_row, second_row
+
+
+async def _fetch_at_most_two_rows_async(cursor: "AsyncCursorType") -> Tuple[Any, ...]:
+    fetchmany = getattr(cursor, "fetchmany", None)
+    if callable(fetchmany):
+        return tuple(await fetchmany(2))
+
+    first_row = await cursor.fetchone()
+    if first_row is None:
+        return tuple()
+
+    second_row = await cursor.fetchone()
+    if second_row is None:
+        return (first_row,)
+
+    return first_row, second_row
+
+
 _INVALID_ATTRIBUTE_PARAM_TYPES = (
     str,
     bytes,
@@ -581,13 +613,13 @@ class Commands(BaseCommands, ABC):
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
-            data = cursor.fetchall()
+            data = _fetch_at_most_two_rows(cursor)
 
         num_records = len(data)
         if num_records == 0:
             raise NoResultException("Expected exactly one record, got zero")
         elif num_records > 1:
-            raise MoreThanOneResultException(f"Expected exactly one record, got {num_records}")
+            raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
         return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
 
@@ -1054,13 +1086,13 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
-            data = await cursor.fetchall()
+            data = await _fetch_at_most_two_rows_async(cursor)
 
         num_records = len(data)
         if num_records == 0:
             raise NoResultException("Expected exactly one record, got zero")
         elif num_records > 1:
-            raise MoreThanOneResultException(f"Expected exactly one record, got {num_records}")
+            raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
         return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
 

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -35,6 +35,96 @@ class TaskParams:
     ids: list[int] | None = None
 
 
+class _QuerySingleFetchOneCursor:
+    rowcount = 0
+    description = ("id", "int"), ("name", "text")
+
+    def __init__(self, rows):
+        self.fetchall_calls = 0
+        self.fetchone_calls = 0
+        self.rows = list(rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def execute(self, sql, parameters=None):
+        pass
+
+    def fetchall(self):
+        self.fetchall_calls += 1
+        return tuple()
+
+    def fetchone(self):
+        self.fetchone_calls += 1
+        return self.rows.pop(0) if self.rows else None
+
+
+class _QuerySingleFetchManyCursor(_QuerySingleFetchOneCursor):
+    def __init__(self, rows):
+        super().__init__(rows)
+        self.fetchmany_calls = []
+
+    def fetchmany(self, size=None):
+        self.fetchmany_calls.append(size)
+        return tuple(self.rows[:size])
+
+
+class _QuerySingleConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+
+    def cursor(self, *args, **kwargs):
+        return self.cursor_instance
+
+
+class _AsyncQuerySingleFetchOneCursor:
+    rowcount = 0
+    description = ("id", "int"), ("name", "text")
+
+    def __init__(self, rows):
+        self.fetchall_calls = 0
+        self.fetchone_calls = 0
+        self.rows = list(rows)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def execute(self, sql, parameters=None):
+        pass
+
+    async def fetchall(self):
+        self.fetchall_calls += 1
+        return tuple()
+
+    async def fetchone(self):
+        self.fetchone_calls += 1
+        return self.rows.pop(0) if self.rows else None
+
+
+class _AsyncQuerySingleFetchManyCursor(_AsyncQuerySingleFetchOneCursor):
+    def __init__(self, rows):
+        super().__init__(rows)
+        self.fetchmany_calls = []
+
+    async def fetchmany(self, size=None):
+        self.fetchmany_calls.append(size)
+        return tuple(self.rows[:size])
+
+
+class _AsyncQuerySingleConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+
+    async def cursor(self, *args, **kwargs):
+        return self.cursor_instance
+
+
 @pytest.fixture
 def captured_handler_params(monkeypatch):
     captured = []
@@ -759,6 +849,13 @@ class TestCommands:
     def set_fetchall_return_one(self, faker, monkeypatch):
         monkeypatch.setattr(MockCursor, "fetchall", lambda self_: ((1, faker.name()),))
 
+        rows = [(1, faker.name()), None]
+
+        def fetchone(self_):
+            return rows.pop(0) if rows else None
+
+        monkeypatch.setattr(MockCursor, "fetchone", fetchone)
+
     @pytest.fixture
     def set_fetchall_return_empty(self, monkeypatch):
         monkeypatch.setattr(MockCursor, "fetchall", lambda self_: tuple())
@@ -1135,7 +1232,7 @@ class TestCommands:
         assert record["id"]
         assert record["name"]
 
-    def test_query_single_raises_on_no_result(self, connection, set_fetchall_return_empty):
+    def test_query_single_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
             commands.query_single("select * from some_table")
 
@@ -1143,13 +1240,51 @@ class TestCommands:
         with MockCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
             commands.query_single("select * from some_table")
 
-    def test_query_single_or_default(self, connection, set_fetchall_return_empty):
+    def test_query_single_uses_fetchmany_when_available(self):
+        connection = _QuerySingleConnection(_QuerySingleFetchManyCursor([(1, "Zach")]))
+
+        record = MockCommands(connection).query_single("select * from some_table")
+
+        assert record == {"id": 1, "name": "Zach"}
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchone_calls == 0
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_query_single_fetchmany_raises_on_no_result(self):
+        connection = _QuerySingleConnection(_QuerySingleFetchManyCursor([]))
+
+        with pytest.raises(NoResultException):
+            MockCommands(connection).query_single("select * from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchone_calls == 0
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_query_single_fetchmany_consumes_at_most_two_rows_before_raising(self):
+        connection = _QuerySingleConnection(_QuerySingleFetchManyCursor([(1, "Zach"), (2, "Bob"), (3, "Alice")]))
+
+        with pytest.raises(MoreThanOneResultException):
+            MockCommands(connection).query_single("select * from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_query_single_fetchone_fallback_consumes_at_most_two_rows_before_raising(self):
+        connection = _QuerySingleConnection(_QuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob"), (3, "Alice")]))
+
+        with pytest.raises(MoreThanOneResultException):
+            MockCommands(connection).query_single("select * from some_table")
+
+        assert connection.cursor_instance.fetchone_calls == 2
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         with MockCommands(connection) as commands:
             record = commands.query_single_or_default("select * from some_table", default=default)
         assert record is default
 
-    def test_query_single_or_default_calls_callable_default_on_no_result(self, connection, set_fetchall_return_empty):
+    def test_query_single_or_default_calls_callable_default_on_no_result(self, connection, set_fetchone_to_return_none):
         sentinel = object()
         calls = []
 
@@ -1221,6 +1356,13 @@ class TestCommandsAsync:
             return ((1, faker.name()),)
 
         mocker.patch("tests.mocks.MockAsyncCursor.fetchall", fetchall)
+
+        rows = [(1, faker.name()), None]
+
+        async def fetchone(s):
+            return rows.pop(0) if rows else None
+
+        mocker.patch("tests.mocks.MockAsyncCursor.fetchone", fetchone)
 
     @pytest.fixture
     def set_fetchall_return_empty(self, mocker):
@@ -1575,7 +1717,7 @@ class TestCommandsAsync:
         assert record["name"]
 
     @pytest.mark.asyncio
-    async def test_query_single_raises_on_no_result(self, connection, set_fetchall_return_empty):
+    async def test_query_single_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(NoResultException):
                 await commands.query_single_async("select * from some_table")
@@ -1587,7 +1729,53 @@ class TestCommandsAsync:
                 await commands.query_single_async("select * from some_table")
 
     @pytest.mark.asyncio
-    async def test_query_single_or_default(self, connection, set_fetchall_return_empty):
+    async def test_query_single_async_uses_fetchmany_when_available(self):
+        connection = _AsyncQuerySingleConnection(_AsyncQuerySingleFetchManyCursor([(1, "Zach")]))
+
+        record = await MockAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert record == {"id": 1, "name": "Zach"}
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchone_calls == 0
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_fetchmany_raises_on_no_result(self):
+        connection = _AsyncQuerySingleConnection(_AsyncQuerySingleFetchManyCursor([]))
+
+        with pytest.raises(NoResultException):
+            await MockAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchone_calls == 0
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_fetchmany_consumes_at_most_two_rows_before_raising(self):
+        connection = _AsyncQuerySingleConnection(
+            _AsyncQuerySingleFetchManyCursor([(1, "Zach"), (2, "Bob"), (3, "Alice")])
+        )
+
+        with pytest.raises(MoreThanOneResultException):
+            await MockAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_fetchone_fallback_consumes_at_most_two_rows_before_raising(self):
+        connection = _AsyncQuerySingleConnection(
+            _AsyncQuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob"), (3, "Alice")])
+        )
+
+        with pytest.raises(MoreThanOneResultException):
+            await MockAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert connection.cursor_instance.fetchone_calls == 2
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         async with MockAsyncCommands(connection) as commands:
             record = await commands.query_single_or_default_async("select * from some_table", default=default)
@@ -1595,7 +1783,7 @@ class TestCommandsAsync:
 
     @pytest.mark.asyncio
     async def test_query_single_or_default_calls_callable_default_on_no_result(
-        self, connection, set_fetchall_return_empty
+        self, connection, set_fetchone_to_return_none
     ):
         sentinel = object()
         calls = []


### PR DESCRIPTION
## What changed
- Changed base `query_single()` and `query_single_async()` to read at most two rows instead of calling `fetchall()`.
- Prefer `fetchmany(2)` when available, with sequential `fetchone()` fallback for cursor compatibility.
- Added core sync and async cursor-spy tests for bounded reads, zero-row fetchmany results, and no `fetchall()`.

## Behavior
Before, `query_single()` loaded every returned row before deciding whether to raise `MoreThanOneResultException`.
After, it reads only enough rows to distinguish zero, one, or many results.

## Checks
- `poetry run pytest tests/test_commands_interface.py` passed, 206 tests
- `poetry run black --check pydapper/commands.py tests/test_commands_interface.py` passed
- `poetry run isort --check pydapper/commands.py tests/test_commands_interface.py` passed

## Notes
- First PR in the #459 stack.
- Refs #459