### PR TITLE
fix: clean up mysql query_single unread results

### DIFF
--- a/docs/database_support/mysql.md
+++ b/docs/database_support/mysql.md
@@ -10,10 +10,15 @@ Supported drivers:
 because that is the name of the actual package that is installed.
 
 !!! note
-    Because of the build in behavior of `mysql-connector-python`, it is currently required to run `cursor.fetchall()`
-    in the `query_first` implementation in order to flush the result set from the server 
+    Because of the built-in behavior of `mysql-connector-python`, it is currently required to run `cursor.fetchall()`
+    in the `query_first` implementation in order to flush the result set from the server.
     When using `query_first` with MySQL, it is advisable to use `LIMIT 1` in your query to prevent downloading
     unneeded rows.
+
+    `query_single` reads only enough rows to detect that more than one row exists. If `mysql-connector-python`
+    cannot discard the unread rows with its driver-level reset behavior, pydapper drains the remaining rows before
+    raising `MoreThanOneResultException` so the connection remains usable. Use `LIMIT 2` with `query_single` to cap
+    the cleanup cost for queries that may return many rows.
 
 ### Installation
 === "pip"
@@ -58,5 +63,4 @@ Use *pydapper* with a `mysql-connector-python` connection pool.
 ```python
 {!docs/../docs_src/connections/mysql_connector_python_using.py!}
 ```
-
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -314,6 +314,9 @@ class Commands(BaseCommands, ABC):
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
 
+    def _on_query_single_more_than_one_result(self, cursor: "CursorType") -> None:
+        pass
+
     @overload
     def query(
         self,
@@ -615,11 +618,12 @@ class Commands(BaseCommands, ABC):
             headers = get_col_names(cursor)
             data = _fetch_at_most_two_rows(cursor)
 
-        num_records = len(data)
-        if num_records == 0:
-            raise NoResultException("Expected exactly one record, got zero")
-        elif num_records > 1:
-            raise MoreThanOneResultException("Expected exactly one record, got at least two")
+            num_records = len(data)
+            if num_records == 0:
+                raise NoResultException("Expected exactly one record, got zero")
+            elif num_records > 1:
+                self._on_query_single_more_than_one_result(cursor)
+                raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
         return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
 

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -13,6 +13,41 @@ from ..utils import serialize_dict_row
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
+    from ..types import CursorType
+
+
+def _discard_unread_result(cursor: "CursorType") -> None:
+    reset = getattr(cursor, "reset", None)
+    if callable(reset):
+        try:
+            try:
+                reset(free=True)
+            except TypeError:
+                reset()
+        except Exception:
+            pass
+
+    connection = getattr(cursor, "_connection", None)
+    has_unread_result = getattr(cursor, "unread_result", False) or (
+        connection is not None and getattr(connection, "unread_result", False)
+    )
+    if not has_unread_result:
+        return
+
+    # Pure mysql-connector-python has no no-drain discard API. Once the second
+    # row proves this is an error, drain the remainder so the connection stays usable.
+    try:
+        cursor.fetchall()
+        return
+    except Exception:
+        pass
+
+    consume_results = getattr(connection, "consume_results", None)
+    if callable(consume_results):
+        try:
+            consume_results()
+        except Exception:
+            pass
 
 
 @register("mysql")
@@ -54,3 +89,6 @@ class MySqlConnectorPythonCommands(Commands):
                 raise NoResultException("Query returned no results")
             cursor.fetchall()
         return serialize_dict_row(model, database_row_to_dict(headers, row))
+
+    def _on_query_single_more_than_one_result(self, cursor: "CursorType") -> None:
+        _discard_unread_result(cursor)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1116,6 +1116,297 @@ class TestCommands:
         with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(InvalidParameterShapeException):
             commands.query_first("select id, name from some_table where id = ?id?", params=[])
 
+    def test_mysql_query_single_accepts_params(self, connection, captured_handler_params, set_fetchall_return_one):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        params = {"id": 1}
+
+        with MockMySqlConnectorPythonCommands(connection) as commands:
+            commands.query_single("select id, name from some_table where id = ?id?", params=params)
+
+        assert captured_handler_params == [params]
+
+    def test_mysql_query_single_discards_unread_result_before_many_result_exception(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.fetchall_calls = 0
+                self.fetchmany_calls = []
+                self.reset_calls = 0
+                self.unread_result = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                assert not self.unread_result
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                return tuple()
+
+            def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                self.unread_result = True
+                return [(1, "Zach"), (2, "Bob")]
+
+            def reset(self):
+                self.reset_calls += 1
+                self.unread_result = False
+
+        class UnreadResultConnection:
+            def __init__(self):
+                self.cursor_instance = UnreadResultCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        connection = UnreadResultConnection()
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single("select id, name from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.reset_calls == 1
+        assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_mysql_query_single_drains_when_reset_does_not_clear_unread_result(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultState:
+            def __init__(self):
+                self.close_calls = 0
+                self.consume_results_calls = 0
+                self.unread_result = False
+
+            def close(self):
+                self.close_calls += 1
+                raise AssertionError("connection close should not be called")
+
+            def consume_results(self):
+                raise AssertionError("consume_results should not be called")
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.connection_state = UnreadResultState()
+                self._connection = self.connection_state
+                self.close_calls = 0
+                self.fetchall_calls = 0
+                self.fetchmany_calls = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.close()
+
+            def close(self):
+                self.close_calls += 1
+                if self._connection is not None and self._connection.unread_result:
+                    raise AssertionError("unread result found")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                self._connection.unread_result = False
+                return tuple()
+
+            def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                self._connection.unread_result = True
+                return [(1, "Zach"), (2, "Bob")]
+
+            def reset(self):
+                pass
+
+        class UnreadResultConnection:
+            def __init__(self):
+                self.cursor_instance = UnreadResultCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        connection = UnreadResultConnection()
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single("select id, name from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.connection_state.close_calls == 0
+        assert connection.cursor_instance.connection_state.consume_results_calls == 0
+        assert connection.cursor_instance._connection is connection.cursor_instance.connection_state
+        assert connection.cursor_instance.close_calls == 1
+        assert connection.cursor_instance.fetchall_calls == 1
+
+    def test_mysql_query_single_cleanup_errors_do_not_mask_many_result_exception(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultState:
+            def __init__(self):
+                self.consume_results_calls = 0
+                self.unread_result = True
+
+            def consume_results(self):
+                self.consume_results_calls += 1
+                raise RuntimeError("cleanup failed")
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self._connection = UnreadResultState()
+                self.fetchall_calls = 0
+                self.fetchmany_calls = []
+
+            def close(self):
+                raise RuntimeError("cursor close failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                raise RuntimeError("fetchall failed")
+
+            def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                return [(1, "Zach"), (2, "Bob")]
+
+            def reset(self):
+                raise RuntimeError("reset failed")
+
+        class UnreadResultConnection:
+            def __init__(self):
+                self.cursor_instance = UnreadResultCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        connection = UnreadResultConnection()
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single("select id, name from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchall_calls == 1
+        assert connection.cursor_instance._connection.consume_results_calls == 1
+
+    def test_mysql_query_single_missing_cleanup_hooks_do_not_mask_many_result_exception(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.fetchall_calls = 0
+                self.fetchmany_calls = []
+                self.unread_result = False
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                raise RuntimeError("fetchall failed")
+
+            def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                self.unread_result = True
+                return [(1, "Zach"), (2, "Bob")]
+
+        class UnreadResultConnection:
+            def __init__(self):
+                self.cursor_instance = UnreadResultCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        connection = UnreadResultConnection()
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single("select id, name from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchall_calls == 1
+
+    def test_mysql_query_single_drains_cursor_without_connection_reference(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.fetchall_calls = 0
+                self.fetchmany_calls = []
+                self.unread_result = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                assert not self.unread_result
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                self.unread_result = False
+                return tuple()
+
+            def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                self.unread_result = True
+                return [(1, "Zach"), (2, "Bob")]
+
+        class UnreadResultConnection:
+            def __init__(self):
+                self.cursor_instance = UnreadResultCursor()
+
+            def cursor(self, *args, **kwargs):
+                return self.cursor_instance
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        connection = UnreadResultConnection()
+
+        with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
+            commands.query_single("select id, name from some_table")
+
+        assert connection.cursor_instance.fetchmany_calls == [2]
+        assert connection.cursor_instance.fetchall_calls == 1
+
     def test_query(self, connection):
         with MockCommands(connection) as commands:
             data = commands.query("select id, name from some_table", model=SimpleNamespace)
@@ -1277,6 +1568,20 @@ class TestCommands:
 
         assert connection.cursor_instance.fetchone_calls == 2
         assert connection.cursor_instance.fetchall_calls == 0
+
+    def test_query_single_calls_more_than_one_hook_before_raising(self):
+        calls = []
+
+        class HookedCommands(MockCommands):
+            def _on_query_single_more_than_one_result(self, cursor):
+                calls.append(cursor)
+
+        connection = _QuerySingleConnection(_QuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob")]))
+
+        with pytest.raises(MoreThanOneResultException):
+            HookedCommands(connection).query_single("select * from some_table")
+
+        assert calls == [connection.cursor_instance]
 
     def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")


### PR DESCRIPTION
## What changed
- Added a base `query_single()` hook that lets adapters clean up before `MoreThanOneResultException` is raised.
- MySQL Connector uses `cursor.reset(free=True)`/`reset()` as the no-drain cleanup path when that clears unread state.
- If unread rows remain, MySQL now drains the remainder with `cursor.fetchall()`, falling back to `connection.consume_results()` if needed, instead of closing or detaching the caller's connection.
- Added MySQL docs noting that pure `mysql-connector-python` may drain after detecting the second row, and recommending `LIMIT 2` to cap cleanup cost.
- Added MySQL-specific unit coverage for params, reset cleanup, drain fallback, cleanup errors, missing cleanup hooks, and cursor-only unread state.

## Behavior
Before, the base bounded read could leave unread MySQL Connector rows when many results were detected. The earlier adapter cleanup closed/detached the connection if reset did not clear unread state.

After, MySQL `query_single()` still detects cardinality with a bounded two-row read, raises `MoreThanOneResultException`, and preserves the caller's connection when cleanup succeeds. For pure `mysql-connector-python`, preserving the connection can require draining the remaining rows on the error path.

## Checks
- `poetry run pytest tests/test_commands_interface.py --cov=pydapper --cov-branch --cov-report=term-missing` passed, 213 tests.
- `poetry run pytest -m "core" --cov=. --cov-branch -v --durations=25 --cov-report=xml --cov-report=term-missing` passed, 308 selected / 206 deselected, 100% coverage.
- `poetry run black --check pydapper/mysql/mysql_connector_python.py tests/test_commands_interface.py` passed.
- `poetry run isort --check pydapper/mysql/mysql_connector_python.py tests/test_commands_interface.py` passed.
- `poetry run mypy pydapper` passed.
- `poetry run mkdocs build --strict` was attempted but could not run because `mkdocs` is not installed in this Poetry environment.

## Driver-specific tests
- MySQL integration tests were not rerun for this amendment. Earlier `poetry run pytest -m "mysql"` attempts could not connect to Docker/testcontainers in this environment.

Refs #459
