### PR TITLE
fix: reject duplicate query columns

### DIFF
--- a/docs/.row_mapping.md
+++ b/docs/.row_mapping.md
@@ -1,0 +1,6 @@
+## Rows
+When rows are returned as dictionaries, they are insertion-ordered `dict[str, Any]` values. Key order follows the column order reported by the DB-API cursor.
+
+Column names must be unique exactly as the driver reports them. If a result includes duplicate names, pydapper raises `DuplicateColumnException` with `columns`, `duplicate_columns`, and `duplicate_indexes` attributes. Alias joined columns instead of using ambiguous `select *` joins.
+
+Missing keys on returned dict rows raise normal Python `KeyError`. When custom model construction is requested with `model=` or `models=`, pydapper uses the same column-name keyword argument mapping path for results with unique column names.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -14,9 +14,11 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## Cardinality
-- 0 rows with `buffered=True`: returns an empty list.
-- 0 rows with `buffered=False`: returns an async generator that yields no rows.
+- 0 rows with unique column names and `buffered=True`: returns an empty list.
+- 0 rows with unique column names and `buffered=False`: returns an async generator that yields no rows.
 
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query_async` method and map the results to a list of dataclasses.

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -12,6 +12,8 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -15,6 +15,8 @@ set contains no records.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -13,6 +13,8 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -13,6 +13,8 @@ record in the result set.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -15,6 +15,8 @@ set is empty; this method throws an exception if there is more than one element 
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -14,9 +14,11 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## Cardinality
-- 0 rows with `buffered=True`: returns an empty list.
-- 0 rows with `buffered=False`: returns a generator that yields no rows.
+- 0 rows with unique column names and `buffered=True`: returns an empty list.
+- 0 rows with unique column names and `buffered=False`: returns a generator that yields no rows.
 
 ## Example - Serialize to a dataclass
 The raw sql query can be executed using the `query` method and map the results to a list of dataclasses.

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -12,6 +12,8 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -15,6 +15,8 @@ set contains no records.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -13,6 +13,8 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -13,6 +13,8 @@ record in the result set.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -15,6 +15,8 @@ set is empty; this method throws an exception if there is more than one element 
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.row_mapping.md!}
+
 ## First, Single and Default
 {!docs/.first_single_default.md!}
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -25,6 +25,7 @@ from typing import overload
 from ._context import CoroContextManager
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
+from .exceptions import DuplicateColumnException
 from .exceptions import InvalidParameterShapeException
 from .exceptions import MissingParameterException
 from .exceptions import MoreThanOneResultException
@@ -32,6 +33,7 @@ from .exceptions import NoResultException
 from .utils import database_row_to_dict
 from .utils import get_col_names
 from .utils import serialize_dict_row
+from .utils import validate_no_duplicate_columns
 
 if TYPE_CHECKING:
     from .dsn_parser import PydapperParseResult
@@ -301,6 +303,11 @@ class Commands(BaseCommands, ABC):
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
+            try:
+                validate_no_duplicate_columns(headers)
+            except DuplicateColumnException:
+                self._on_duplicate_columns(cursor)
+                raise
             data = cursor.fetchall()
             return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
 
@@ -308,11 +315,26 @@ class Commands(BaseCommands, ABC):
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
+            try:
+                validate_no_duplicate_columns(headers)
+            except DuplicateColumnException:
+                self._on_duplicate_columns(cursor)
+                raise
+
+            row = cursor.fetchone()
+            if row is None:
+                return
+
+            yield serialize_dict_row(model, database_row_to_dict(headers, row))
+
             while True:
                 row = cursor.fetchone()
                 if row is None:
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
+
+    def _on_duplicate_columns(self, cursor: "CursorType") -> None:
+        pass
 
     def _on_query_single_more_than_one_result(self, cursor: "CursorType") -> None:
         pass
@@ -447,6 +469,7 @@ class Commands(BaseCommands, ABC):
                 if not data:
                     raise NoResultException(f"No results returned from query {query}")
 
+                validate_no_duplicate_columns(headers)
                 serialized_data = [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
                 results.append(serialized_data)
 
@@ -492,6 +515,7 @@ class Commands(BaseCommands, ABC):
             row = cursor.fetchone()
             if row is None:
                 raise NoResultException("Query returned no results")
+            validate_no_duplicate_columns(headers)
         return serialize_dict_row(model, database_row_to_dict(headers, row))
 
     @overload
@@ -624,6 +648,8 @@ class Commands(BaseCommands, ABC):
             elif num_records > 1:
                 self._on_query_single_more_than_one_result(cursor)
                 raise MoreThanOneResultException("Expected exactly one record, got at least two")
+
+            validate_no_duplicate_columns(headers)
 
         return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
 
@@ -769,6 +795,11 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
+            try:
+                validate_no_duplicate_columns(headers)
+            except DuplicateColumnException:
+                await self._on_duplicate_columns_async(cursor)
+                raise
             data = await cursor.fetchall()
             return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
 
@@ -778,11 +809,26 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
+            try:
+                validate_no_duplicate_columns(headers)
+            except DuplicateColumnException:
+                await self._on_duplicate_columns_async(cursor)
+                raise
+
+            row = await cursor.fetchone()
+            if row is None:
+                return
+
+            yield serialize_dict_row(model, database_row_to_dict(headers, row))
+
             while True:
                 row = await cursor.fetchone()
                 if row is None:
                     break
                 yield serialize_dict_row(model, database_row_to_dict(headers, row))
+
+    async def _on_duplicate_columns_async(self, cursor: "AsyncCursorType") -> None:
+        pass
 
     @overload
     async def query_async(
@@ -915,6 +961,7 @@ class CommandsAsync(BaseCommands, ABC):
                 if not data:
                     raise NoResultException(f"No results returned from query {query}")
 
+                validate_no_duplicate_columns(headers)
                 serialized_data = [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
                 results.append(serialized_data)
 
@@ -962,6 +1009,7 @@ class CommandsAsync(BaseCommands, ABC):
             row = await cursor.fetchone()
             if row is None:
                 raise NoResultException("Query returned no results")
+            validate_no_duplicate_columns(headers)
             return serialize_dict_row(model, database_row_to_dict(headers, row))
 
     @overload
@@ -1098,6 +1146,7 @@ class CommandsAsync(BaseCommands, ABC):
         elif num_records > 1:
             raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
+        validate_no_duplicate_columns(headers)
         return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
 
     @overload

--- a/pydapper/exceptions.py
+++ b/pydapper/exceptions.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+
+
 class PyDapperException(Exception):
     pass
 
@@ -24,3 +27,20 @@ class UnsupportedFeatureError(PyDapperException):
 
 class RowMappingException(PyDapperException):
     pass
+
+
+class DuplicateColumnException(RowMappingException):
+    def __init__(
+        self,
+        columns: Sequence[str],
+        duplicate_columns: Sequence[str],
+        duplicate_indexes: Sequence[int],
+    ) -> None:
+        self.columns = tuple(columns)
+        self.duplicate_columns = tuple(duplicate_columns)
+        self.duplicate_indexes = tuple(duplicate_indexes)
+        duplicate_names = ", ".join(repr(column) for column in self.duplicate_columns)
+        super().__init__(
+            f"Duplicate column names are not supported for dict row mapping: {duplicate_names}. "
+            "Alias duplicate columns in the query."
+        )

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -10,6 +10,7 @@ from ..utils import database_row_to_dict
 from ..utils import get_col_names
 from ..utils import import_dbapi_module
 from ..utils import serialize_dict_row
+from ..utils import validate_no_duplicate_columns
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
@@ -88,7 +89,11 @@ class MySqlConnectorPythonCommands(Commands):
             if row is None:
                 raise NoResultException("Query returned no results")
             cursor.fetchall()
+            validate_no_duplicate_columns(headers)
         return serialize_dict_row(model, database_row_to_dict(headers, row))
+
+    def _on_duplicate_columns(self, cursor: "CursorType") -> None:
+        _discard_unread_result(cursor)
 
     def _on_query_single_more_than_one_result(self, cursor: "CursorType") -> None:
         _discard_unread_result(cursor)

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -11,6 +11,8 @@ from typing import TypeVar
 from typing import Union
 from typing import overload
 
+from .exceptions import DuplicateColumnException
+
 if TYPE_CHECKING:
     _T = TypeVar("_T")
 
@@ -24,6 +26,27 @@ def safe_getattr(obj: Any, key: str) -> Any:
         raise AttributeError(f"Attribute {key!r} can not be accessed on {obj!r} or does not exist")
     except KeyError:
         raise KeyError(f"Key {key!r} can not be accessed on {obj!r} or does not exist")
+
+
+def _get_duplicate_column_data(col_names: List[str]) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+    column_indexes: Dict[str, List[int]] = {}
+    for index, col_name in enumerate(col_names):
+        column_indexes.setdefault(col_name, []).append(index)
+
+    duplicate_columns = tuple(col_name for col_name, indexes in column_indexes.items() if len(indexes) > 1)
+    duplicate_column_set = set(duplicate_columns)
+    duplicate_indexes = tuple(index for index, col_name in enumerate(col_names) if col_name in duplicate_column_set)
+    return duplicate_columns, duplicate_indexes
+
+
+def validate_no_duplicate_columns(col_names: List[str]) -> None:
+    duplicate_columns, duplicate_indexes = _get_duplicate_column_data(col_names)
+    if duplicate_columns:
+        raise DuplicateColumnException(
+            columns=tuple(col_names),
+            duplicate_columns=duplicate_columns,
+            duplicate_indexes=duplicate_indexes,
+        )
 
 
 def database_row_to_dict(col_names: List[str], row: Tuple[Any]) -> Dict[str, Any]:

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
@@ -80,6 +81,40 @@ class _QuerySingleConnection:
         return self.cursor_instance
 
 
+class _DuplicateColumnCursor:
+    rowcount = 0
+    description = ("id", "int"), ("name", "text"), ("id", "int")
+
+    def __init__(self, rows=((1, "Zach", 2),)):
+        self.rows = list(rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def execute(self, sql, parameters=None):
+        pass
+
+    def fetchall(self):
+        return tuple(self.rows)
+
+    def fetchmany(self, size=None):
+        return tuple(self.rows[:size])
+
+    def fetchone(self):
+        return self.rows.pop(0) if self.rows else None
+
+
+class _CursorConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+
+    def cursor(self, *args, **kwargs):
+        return self.cursor_instance
+
+
 class _AsyncQuerySingleFetchOneCursor:
     rowcount = 0
     description = ("id", "int"), ("name", "text")
@@ -123,6 +158,56 @@ class _AsyncQuerySingleConnection:
 
     async def cursor(self, *args, **kwargs):
         return self.cursor_instance
+
+
+class _AsyncDuplicateColumnCursor:
+    rowcount = 0
+    description = ("id", "int"), ("name", "text"), ("id", "int")
+
+    def __init__(self, rows=((1, "Zach", 2),)):
+        self.rows = list(rows)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def execute(self, sql, parameters=None):
+        pass
+
+    async def fetchall(self):
+        return tuple(self.rows)
+
+    async def fetchmany(self, size=None):
+        return tuple(self.rows[:size])
+
+    async def fetchone(self):
+        return self.rows.pop(0) if self.rows else None
+
+
+class _AsyncCursorConnection:
+    def __init__(self, cursor):
+        self.closed = 0
+        self.cursor_instance = cursor
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    async def cursor(self, *args, **kwargs):
+        return self.cursor_instance
+
+    async def close(self):
+        self.closed = 1
+
+
+def _assert_duplicate_column_exception(exc_info):
+    assert exc_info.value.columns == ("id", "name", "id")
+    assert exc_info.value.duplicate_columns == ("id",)
+    assert exc_info.value.duplicate_indexes == (0, 2)
 
 
 @pytest.fixture
@@ -431,6 +516,7 @@ class TestPublicExceptions:
     @pytest.mark.parametrize(
         "exception_type",
         [
+            DuplicateColumnException,
             NoResultException,
             MoreThanOneResultException,
             MissingParameterException,
@@ -441,6 +527,9 @@ class TestPublicExceptions:
     )
     def test_public_exceptions_subclass_pydapper_exception(self, exception_type):
         assert issubclass(exception_type, PyDapperException)
+
+    def test_duplicate_column_exception_subclasses_row_mapping_exception(self):
+        assert issubclass(DuplicateColumnException, RowMappingException)
 
 
 class TestParamHandler:
@@ -1116,6 +1205,60 @@ class TestCommands:
         with MockMySqlConnectorPythonCommands(connection) as commands, pytest.raises(InvalidParameterShapeException):
             commands.query_first("select id, name from some_table where id = ?id?", params=[])
 
+    def test_mysql_query_first_rejects_duplicate_columns(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query_first("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
+    def test_mysql_query_unbuffered_duplicate_columns_are_not_masked_by_unread_result_cleanup(self):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class UnreadResultCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text"), ("id", "int")
+
+            def __init__(self):
+                self.fetchall_calls = 0
+                self.unread_result = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                assert not self.unread_result
+
+            def execute(self, sql, parameters=None):
+                self.unread_result = True
+
+            def fetchall(self):
+                self.fetchall_calls += 1
+                self.unread_result = False
+                return tuple()
+
+            def fetchone(self):
+                self.unread_result = True
+                return 1, "Zach", 2
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        cursor = UnreadResultCursor()
+
+        with MockMySqlConnectorPythonCommands(_CursorConnection(cursor)) as commands:
+            generator = commands.query("select id, name, id from some_table", buffered=False)
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                list(generator)
+
+        _assert_duplicate_column_exception(exc_info)
+        assert cursor.fetchall_calls == 1
+
     def test_mysql_query_single_accepts_params(self, connection, captured_handler_params, set_fetchall_return_one):
         from pydapper.mysql import MySqlConnectorPythonCommands
 
@@ -1413,6 +1556,20 @@ class TestCommands:
         assert len(data) == 2
         assert all(isinstance(row, SimpleNamespace) for row in data)
 
+    def test_query_rejects_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
+    def test_query_rejects_duplicate_columns_with_no_rows(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor(rows=()))) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
     def test_query_returns_empty_list_on_no_results(self, connection, set_fetchall_return_empty):
         with MockCommands(connection) as commands:
             data = commands.query("select id, name from some_table")
@@ -1422,6 +1579,22 @@ class TestCommands:
         with MockCommands(connection) as commands:
             generator = commands.query("select id, name from some_table", buffered=False)
             assert list(generator) == []
+
+    def test_query_unbuffered_rejects_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            generator = commands.query("select id, name, id from some_table", buffered=False)
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                list(generator)
+
+        _assert_duplicate_column_exception(exc_info)
+
+    def test_query_unbuffered_rejects_duplicate_columns_with_no_rows(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor(rows=()))) as commands:
+            generator = commands.query("select id, name, id from some_table", buffered=False)
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                list(generator)
+
+        _assert_duplicate_column_exception(exc_info)
 
     def test_query_unbuffered_yields_rows_until_none(self):
         class OneRowCursor(MockCursor):
@@ -1456,6 +1629,13 @@ class TestCommands:
         assert all(isinstance(row, SimpleNamespace) for row in data1)
         assert all(isinstance(row, dict) for row in data2)
 
+    def test_query_multiple_rejects_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query_multiple(("select id, name, id from some_table",))
+
+        _assert_duplicate_column_exception(exc_info)
+
     @pytest.mark.parametrize(
         "sql, models",
         [
@@ -1478,6 +1658,13 @@ class TestCommands:
         assert isinstance(record, SimpleNamespace)
         assert record.id
         assert record.name
+
+    def test_query_first_rejects_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query_first("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
 
     def test_query_first_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
@@ -1523,6 +1710,13 @@ class TestCommands:
         assert record["id"]
         assert record["name"]
 
+    def test_query_single_rejects_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                commands.query_single("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
     def test_query_single_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
             commands.query_single("select * from some_table")
@@ -1530,6 +1724,18 @@ class TestCommands:
     def test_query_single_raises_on_many_results(self, connection):
         with MockCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
             commands.query_single("select * from some_table")
+
+    def test_query_single_no_result_precedes_duplicate_column_mapping(self):
+        connection = _CursorConnection(_DuplicateColumnCursor(rows=()))
+
+        with pytest.raises(NoResultException):
+            MockCommands(connection).query_single("select id, name, id from some_table")
+
+    def test_query_single_many_results_precede_duplicate_column_mapping(self):
+        connection = _CursorConnection(_DuplicateColumnCursor(rows=((1, "Zach", 2), (3, "Bob", 4))))
+
+        with pytest.raises(MoreThanOneResultException):
+            MockCommands(connection).query_single("select id, name, id from some_table")
 
     def test_query_single_uses_fetchmany_when_available(self):
         connection = _QuerySingleConnection(_QuerySingleFetchManyCursor([(1, "Zach")]))
@@ -1624,6 +1830,10 @@ class TestCommands:
         with MockCommands(connection) as commands:
             id_ = commands.execute_scalar("select id, name from some_table")
         assert id_ == 1
+
+    def test_execute_scalar_ignores_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            assert commands.execute_scalar("select id, name, id from some_table") == 1
 
     def test_execute_scalar_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
@@ -1882,6 +2092,22 @@ class TestCommandsAsync:
         assert all(isinstance(row, SimpleNamespace) for row in data)
 
     @pytest.mark.asyncio
+    async def test_query_rejects_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                await commands.query_async("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
+    @pytest.mark.asyncio
+    async def test_query_rejects_duplicate_columns_with_no_rows(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor(rows=()))) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                await commands.query_async("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
+    @pytest.mark.asyncio
     async def test_query_returns_empty_list_on_no_results(self, connection, set_fetchall_return_empty):
         async with MockAsyncCommands(connection) as commands:
             data = await commands.query_async("select id, name from some_table")
@@ -1892,6 +2118,24 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             generator = await commands.query_async("select id, name from some_table", buffered=False)
             assert [row async for row in generator] == []
+
+    @pytest.mark.asyncio
+    async def test_query_unbuffered_rejects_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            generator = await commands.query_async("select id, name, id from some_table", buffered=False)
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                [row async for row in generator]
+
+        _assert_duplicate_column_exception(exc_info)
+
+    @pytest.mark.asyncio
+    async def test_query_unbuffered_rejects_duplicate_columns_with_no_rows(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor(rows=()))) as commands:
+            generator = await commands.query_async("select id, name, id from some_table", buffered=False)
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                [row async for row in generator]
+
+        _assert_duplicate_column_exception(exc_info)
 
     @pytest.mark.asyncio
     async def test_query_unbuffered_yields_rows_until_none(self):
@@ -1931,6 +2175,14 @@ class TestCommandsAsync:
         assert all(isinstance(row, dict) for row in data2)
 
     @pytest.mark.asyncio
+    async def test_query_multiple_rejects_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                await commands.query_multiple_async(("select id, name, id from some_table",))
+
+        _assert_duplicate_column_exception(exc_info)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "sql, models",
         [
@@ -1956,6 +2208,14 @@ class TestCommandsAsync:
         assert isinstance(record, SimpleNamespace)
         assert record.id
         assert record.name
+
+    @pytest.mark.asyncio
+    async def test_query_first_rejects_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                await commands.query_first_async("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
 
     @pytest.mark.asyncio
     async def test_query_first_treats_falsy_row_as_result(self, connection, mocker):
@@ -2022,6 +2282,14 @@ class TestCommandsAsync:
         assert record["name"]
 
     @pytest.mark.asyncio
+    async def test_query_single_rejects_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            with pytest.raises(DuplicateColumnException) as exc_info:
+                await commands.query_single_async("select id, name, id from some_table")
+
+        _assert_duplicate_column_exception(exc_info)
+
+    @pytest.mark.asyncio
     async def test_query_single_raises_on_no_result(self, connection, set_fetchone_to_return_none):
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(NoResultException):
@@ -2032,6 +2300,20 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(MoreThanOneResultException):
                 await commands.query_single_async("select * from some_table")
+
+    @pytest.mark.asyncio
+    async def test_query_single_no_result_precedes_duplicate_column_mapping(self):
+        connection = _AsyncCursorConnection(_AsyncDuplicateColumnCursor(rows=()))
+
+        with pytest.raises(NoResultException):
+            await MockAsyncCommands(connection).query_single_async("select id, name, id from some_table")
+
+    @pytest.mark.asyncio
+    async def test_query_single_many_results_precede_duplicate_column_mapping(self):
+        connection = _AsyncCursorConnection(_AsyncDuplicateColumnCursor(rows=((1, "Zach", 2), (3, "Bob", 4))))
+
+        with pytest.raises(MoreThanOneResultException):
+            await MockAsyncCommands(connection).query_single_async("select id, name, id from some_table")
 
     @pytest.mark.asyncio
     async def test_query_single_async_uses_fetchmany_when_available(self):
@@ -2128,6 +2410,11 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             id_ = await commands.execute_scalar_async("select id, name from some_table")
         assert id_ == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_scalar_ignores_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            assert await commands.execute_scalar_async("select id, name, id from some_table") == 1
 
     @pytest.mark.asyncio
     async def test_execute_scalar_raises_on_no_result(self, connection, set_fetchone_to_return_none):

--- a/tests/test_sqlite/test_sqlite3.py
+++ b/tests/test_sqlite/test_sqlite3.py
@@ -5,6 +5,7 @@ import pytest
 
 from pydapper import connect
 from pydapper import using
+from pydapper.exceptions import DuplicateColumnException
 from pydapper.sqlite import Sqlite3Commands
 from tests.test_suites.commands import ExecuteScalarTestSuite
 from tests.test_suites.commands import ExecuteTestSuite
@@ -38,6 +39,28 @@ def test_connect_subfolder(driver, database_name, setup_sql_dir):
 def test_connect(driver, database_name):
     with connect(f"{driver}://{database_name}.db") as commands:
         assert isinstance(commands, Sqlite3Commands)
+
+
+def test_join_with_duplicate_id_columns_raises(commands, owner_table_name, task_table_name):
+    with pytest.raises(DuplicateColumnException) as exc_info:
+        commands.query(
+            f"select {task_table_name}.id, {owner_table_name}.id "
+            f"from {task_table_name} join {owner_table_name} on {task_table_name}.owner_id = {owner_table_name}.id"
+        )
+
+    assert exc_info.value.columns == ("id", "id")
+    assert exc_info.value.duplicate_columns == ("id",)
+    assert exc_info.value.duplicate_indexes == (0, 1)
+
+
+def test_join_with_aliased_id_columns_succeeds(commands, owner_table_name, task_table_name):
+    rows = commands.query(
+        f"select {task_table_name}.id as task_id, {owner_table_name}.id as owner_id "
+        f"from {task_table_name} join {owner_table_name} on {task_table_name}.owner_id = {owner_table_name}.id"
+    )
+
+    assert rows[0] == {"task_id": 1, "owner_id": 1}
+    assert list(rows[0]) == ["task_id", "owner_id"]
 
 
 class TestExecute(ExecuteTestSuite): ...

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 
 import pytest
 
+from pydapper.exceptions import DuplicateColumnException
 from pydapper.utils import database_row_to_dict
 from pydapper.utils import get_col_names
 from pydapper.utils import import_dbapi_module
 from pydapper.utils import import_module_obj_path
 from pydapper.utils import safe_getattr
+from pydapper.utils import validate_no_duplicate_columns
 from tests.mocks import MockCursor
 
 pytestmark = pytest.mark.core
@@ -32,7 +34,44 @@ def test_safe_getattr(obj, key, expected):
 
 
 def test_database_row_to_dict():
-    assert database_row_to_dict(["id", "name"], (1, "Zach")) == {"id": 1, "name": "Zach"}
+    row = database_row_to_dict(["id", "name"], (1, "Zach"))
+
+    assert row == {"id": 1, "name": "Zach"}
+    assert list(row) == ["id", "name"]
+
+
+@pytest.mark.parametrize(
+    "col_names, duplicate_columns, duplicate_indexes",
+    [
+        (["id", "id"], ("id",), (0, 1)),
+        (["id", "name", "id"], ("id",), (0, 2)),
+        (["id", "name", "id", "name"], ("id", "name"), (0, 1, 2, 3)),
+        (["id", "name", "id", "id"], ("id",), (0, 2, 3)),
+    ],
+)
+def test_validate_no_duplicate_columns_rejects_duplicate_columns(col_names, duplicate_columns, duplicate_indexes):
+    with pytest.raises(DuplicateColumnException) as exc_info:
+        validate_no_duplicate_columns(col_names)
+
+    assert exc_info.value.columns == tuple(col_names)
+    assert exc_info.value.duplicate_columns == duplicate_columns
+    assert exc_info.value.duplicate_indexes == duplicate_indexes
+    assert "Alias duplicate columns" in str(exc_info.value)
+
+
+def test_validate_no_duplicate_columns_allows_case_distinct_column_names():
+    validate_no_duplicate_columns(["id", "ID"])
+
+
+def test_database_row_to_dict_allows_case_distinct_column_names():
+    assert database_row_to_dict(["id", "ID"], (1, 2)) == {"id": 1, "ID": 2}
+
+
+def test_database_row_to_dict_missing_keys_raise_normal_key_error():
+    row = database_row_to_dict(["id"], (1,))
+
+    with pytest.raises(KeyError):
+        row["missing"]
 
 
 def test_get_col_names():

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -13,6 +13,7 @@ import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
@@ -44,6 +45,14 @@ def default_callable() -> str:
 
 def public_exceptions() -> None:
     assert_type(PyDapperException(), PyDapperException)
+    assert_type(
+        DuplicateColumnException(
+            columns=("id", "id"),
+            duplicate_columns=("id",),
+            duplicate_indexes=(0, 1),
+        ),
+        DuplicateColumnException,
+    )
     assert_type(NoResultException(), NoResultException)
     assert_type(MoreThanOneResultException(), MoreThanOneResultException)
     assert_type(MissingParameterException(), MissingParameterException)


### PR DESCRIPTION
Closes #460

## What changed and why
- Added public `DuplicateColumnException` as a `RowMappingException` subclass with structured `columns`, `duplicate_columns`, and `duplicate_indexes` attributes.
- Updated shared dict row conversion to reject duplicate driver-reported column names instead of silently overwriting earlier values.
- Preserved ordered `dict[str, Any]` rows, `model=` keyword mapping, normal `KeyError` missing-key behavior, and `execute_scalar()` behavior for unique columns.
- Documented the raw row contract and alias guidance for ambiguous joins.

## Before and after
Before, a query such as `select task.id, owner.id ...` returned a dict with one `id` value after silently dropping the other duplicate column.

After, the same duplicate `id` result raises `DuplicateColumnException`. A query with explicit aliases such as `task.id as task_id, owner.id as owner_id` returns ordered dict rows normally.

## Checks
- `python -m compileall pydapper tests`
- `poetry run pytest -m core`
- `poetry run pytest -m sqlite`
- `poetry run mypy pydapper`
- `poetry run mypy tests/type_tests.py`
- `poetry run black --check .`
- `poetry run isort --check .`

## Skipped
- Optional driver integration markers beyond SQLite, because this change is shared row mapping and is covered by core tests plus SQLite join coverage.
- `poetry run mkdocs build --strict`, because `mkdocs` is not installed in the current Poetry environment.

## Impact
- Public API: adds `DuplicateColumnException`.
- Docs: adds raw row ordering, duplicate-column rejection, alias guidance, normal missing-key behavior, and `model=` mapping notes.
- Optional extras: no dependency or extra changes.