### PR TITLE
fix: handle callable default values safely

### DIFF
--- a/docs/.row_mapping.md
+++ b/docs/.row_mapping.md
@@ -4,3 +4,5 @@ When rows are returned as dictionaries, they are insertion-ordered `dict[str, An
 Column names must be unique exactly as the driver reports them. If a result includes duplicate names, pydapper raises `DuplicateColumnException` with `columns`, `duplicate_columns`, and `duplicate_indexes` attributes. Alias joined columns instead of using ambiguous `select *` joins.
 
 Missing keys on returned dict rows raise normal Python `KeyError`. When custom model construction is requested with `model=` or `models=`, pydapper uses the same column-name keyword argument mapping path for results with unique column names.
+
+Use `mapper=` when column-name mapping is too restrictive. The mapper receives a `RawRow` with `columns`, `values`, and `as_dict()`. `RawRow` preserves duplicate column names and positional values in cursor order, so mapper functions can intentionally project joined rows, nested objects, aliases, or duplicate names. `RawRow.as_dict()` still requires unique column names and raises `DuplicateColumnException` when a dict would be ambiguous.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -7,6 +7,7 @@
 | sql      | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
 | params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
  | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
 
 
@@ -32,6 +33,22 @@ The raw sql query can be executed using the `query_async` method and map the res
 You can get creative with what you pass in to the model kwarg of `query`
 ```python
 {!docs/../docs_src/async_methods/query/one_to_one_query.py!}
+```
+(This script is complete, it should run "as is")
+
+
+### Example - Project joined rows with duplicate column names
+Use `mapper=` when a join intentionally selects duplicate column names or when projection logic needs positional values.
+```python
+{!docs/../docs_src/async_methods/query/mapper_join.py!}
+```
+(This script is complete, it should run "as is")
+
+
+### Example - Project aliased rows by name
+`RawRow.as_dict()` and `row["column_name"]` are available when the referenced column names are unique.
+```python
+{!docs/../docs_src/async_methods/query/mapper_aliases.py!}
 ```
 (This script is complete, it should run "as is")
 

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -1,13 +1,14 @@
 
 `query_multiple_async` can execute multiple queries with the same cursor and serialize the results. This method
-will throw a `ValueError` if you don't supply the same number of queries and models.
+will throw a `ValueError` if you don't supply the same number of queries and models or mapper functions.
 
 ## Parameters
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
 | params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
- | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | models | `tuple[Any, ...]` | callables to serialize each result set; each callable must accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | mapper | `Callable[[RawRow], Any]` or tuple | one mapper for every result set, or a tuple of mapper functions. Mutually exclusive with `models`. | :thumbsup: | `None` |
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
@@ -19,5 +20,13 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 Query two tables and return the serialized results.
 ```python
 {!docs/../docs_src/async_methods/query_multiple/example.py!}
+```
+(This script is complete, it should run "as is")
+
+
+## Example - Mapper Functions
+Project each result set with `RawRow` mapper functions.
+```python
+{!docs/../docs_src/async_methods/query_multiple/mapper.py!}
 ```
 (This script is complete, it should run "as is")

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -7,6 +7,7 @@
 | sql      | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
 | params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
  | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
 
 
@@ -32,6 +33,22 @@ The raw sql query can be executed using the `query` method and map the results t
 You can get creative with what you pass in to the model kwarg of `query`
 ```python
 {!docs/../docs_src/methods/query/one_to_one_query.py!}
+```
+(This script is complete, it should run "as is")
+
+
+### Example - Project joined rows with duplicate column names
+Use `mapper=` when a join intentionally selects duplicate column names or when projection logic needs positional values.
+```python
+{!docs/../docs_src/methods/query/mapper_join.py!}
+```
+(This script is complete, it should run "as is")
+
+
+### Example - Project aliased rows by name
+`RawRow.as_dict()` and `row["column_name"]` are available when the referenced column names are unique.
+```python
+{!docs/../docs_src/methods/query/mapper_aliases.py!}
 ```
 (This script is complete, it should run "as is")
 

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -1,13 +1,14 @@
 
 `query_multiple` can execute multiple queries with the same cursor and serialize the results. This method
-will throw a `ValueError` if you don't supply the same number of queries and models.
+will throw a `ValueError` if you don't supply the same number of queries and models or mapper functions.
 
 ## Parameters
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |
 | params | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
- | model | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | models | `tuple[Any, ...]` | callables to serialize each result set; each callable must accept column names as kwargs. | :thumbsup:   | `dict`  |
+ | mapper | `Callable[[RawRow], Any]` or tuple | one mapper for every result set, or a tuple of mapper functions. Mutually exclusive with `models`. | :thumbsup: | `None` |
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.
 
@@ -19,5 +20,13 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 Query two tables and return the serialized results.
 ```python
 {!docs/../docs_src/methods/query_multiple/example.py!}
+```
+(This script is complete, it should run "as is")
+
+
+## Example - Mapper Functions
+Project each result set with `RawRow` mapper functions.
+```python
+{!docs/../docs_src/methods/query_multiple/mapper.py!}
 ```
 (This script is complete, it should run "as is")

--- a/docs_src/async_methods/query/mapper_aliases.py
+++ b/docs_src/async_methods/query/mapper_aliases.py
@@ -1,0 +1,34 @@
+import asyncio
+from typing import Any
+
+from pydapper import RawRow
+from pydapper import connect_async
+
+
+def to_summary(row: RawRow) -> dict[str, Any]:
+    values = row.as_dict()
+    return {
+        "task_id": values["task_id"],
+        "owner_name": row["owner_name"],
+    }
+
+
+query = """
+select
+    t.id as task_id,
+    o.name as owner_name
+from task t
+join owner o on t.owner_id = o.id
+limit 1
+"""
+
+
+async def main():
+    async with connect_async() as commands:
+        data = await commands.query_async(query, mapper=to_summary)
+
+    print(data)
+    # [{'task_id': 1, 'owner_name': 'Zach Schumacher'}]
+
+
+asyncio.run(main())

--- a/docs_src/async_methods/query/mapper_join.py
+++ b/docs_src/async_methods/query/mapper_join.py
@@ -1,0 +1,49 @@
+import asyncio
+from dataclasses import dataclass
+
+from pydapper import RawRow
+from pydapper import connect_async
+
+
+@dataclass
+class Owner:
+    id: int
+    name: str
+
+
+@dataclass
+class TaskWithOwner:
+    id: int
+    description: str
+    owner: Owner
+
+
+def to_task_with_owner(row: RawRow) -> TaskWithOwner:
+    return TaskWithOwner(
+        id=row.values[0],
+        description=row.values[1],
+        owner=Owner(id=row.values[2], name=row.values[3]),
+    )
+
+
+query = """
+select
+    t.id,
+    t.description,
+    o.id,
+    o.name
+from task t
+join owner o on t.owner_id = o.id
+limit 1
+"""
+
+
+async def main():
+    async with connect_async() as commands:
+        data = await commands.query_async(query, mapper=to_task_with_owner)
+
+    print(data)
+    # [TaskWithOwner(id=1, description='Set up a test database', owner=Owner(id=1, name='Zach Schumacher'))]
+
+
+asyncio.run(main())

--- a/docs_src/async_methods/query_multiple/mapper.py
+++ b/docs_src/async_methods/query_multiple/mapper.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from pydapper import RawRow
+from pydapper import connect_async
+
+
+def to_task_description(row: RawRow) -> str:
+    return row["description"]
+
+
+def to_owner_name(row: RawRow) -> str:
+    return row["name"]
+
+
+async def main():
+    async with connect_async() as commands:
+        task_descriptions, owner_names = await commands.query_multiple_async(
+            ("select description from task limit 1", "select name from owner limit 1"),
+            mapper=(to_task_description, to_owner_name),
+        )
+
+    print(task_descriptions)
+    # ['Set up a test database']
+    print(owner_names)
+    # ['Zach Schumacher']
+
+
+asyncio.run(main())

--- a/docs_src/methods/query/mapper_aliases.py
+++ b/docs_src/methods/query/mapper_aliases.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from pydapper import RawRow
+from pydapper import connect
+
+
+def to_summary(row: RawRow) -> dict[str, Any]:
+    values = row.as_dict()
+    return {
+        "task_id": values["task_id"],
+        "owner_name": row["owner_name"],
+    }
+
+
+query = """
+select
+    t.id as task_id,
+    o.name as owner_name
+from task t
+join owner o on t.owner_id = o.id
+limit 1
+"""
+
+with connect() as commands:
+    data = commands.query(query, mapper=to_summary)
+
+print(data)
+# [{'task_id': 1, 'owner_name': 'Zach Schumacher'}]

--- a/docs_src/methods/query/mapper_join.py
+++ b/docs_src/methods/query/mapper_join.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+
+from pydapper import RawRow
+from pydapper import connect
+
+
+@dataclass
+class Owner:
+    id: int
+    name: str
+
+
+@dataclass
+class TaskWithOwner:
+    id: int
+    description: str
+    owner: Owner
+
+
+def to_task_with_owner(row: RawRow) -> TaskWithOwner:
+    return TaskWithOwner(
+        id=row.values[0],
+        description=row.values[1],
+        owner=Owner(id=row.values[2], name=row.values[3]),
+    )
+
+
+query = """
+select
+    t.id,
+    t.description,
+    o.id,
+    o.name
+from task t
+join owner o on t.owner_id = o.id
+limit 1
+"""
+
+with connect() as commands:
+    data = commands.query(query, mapper=to_task_with_owner)
+
+print(data)
+# [TaskWithOwner(id=1, description='Set up a test database', owner=Owner(id=1, name='Zach Schumacher'))]

--- a/docs_src/methods/query_multiple/mapper.py
+++ b/docs_src/methods/query_multiple/mapper.py
@@ -1,0 +1,22 @@
+from pydapper import RawRow
+from pydapper import connect
+
+
+def to_task_description(row: RawRow) -> str:
+    return row["description"]
+
+
+def to_owner_name(row: RawRow) -> str:
+    return row["name"]
+
+
+with connect() as commands:
+    task_descriptions, owner_names = commands.query_multiple(
+        ("select description from task limit 1", "select name from owner limit 1"),
+        mapper=(to_task_description, to_owner_name),
+    )
+
+print(task_descriptions)
+# ['Set up a test database']
+print(owner_names)
+# ['Zach Schumacher']

--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -11,4 +11,5 @@ from .postgresql import AiopgCommands as _AioPgCommand
 from .postgresql import Psycopg2Commands as _Psycopg2Commands
 from .postgresql import Psycopg3Commands as _Psycopg3Commands
 from .postgresql import Psycopg3CommandsAsync as _Psycopg3CommandsAsync
+from .rows import RawRow
 from .sqlite import Sqlite3Commands as _Sqlite3Commands

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -147,9 +147,11 @@ _UNINSPECTABLE_NO_ARG_DEFAULT_FACTORIES = (
     float,
     frozenset,
     int,
+    list,
     object,
     set,
     str,
+    tuple,
 )
 
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -138,23 +138,6 @@ def _is_param_record(param: Any) -> bool:
     return isinstance(param, Mapping) or _is_attribute_param_record(param)
 
 
-_UNINSPECTABLE_NO_ARG_DEFAULT_FACTORIES = (
-    bool,
-    bytearray,
-    bytes,
-    complex,
-    dict,
-    float,
-    frozenset,
-    int,
-    list,
-    object,
-    set,
-    str,
-    tuple,
-)
-
-
 def _resolve_default_value(default):
     if not callable(default):
         return default
@@ -164,9 +147,7 @@ def _resolve_default_value(default):
     except TypeError:
         return default
     except ValueError:
-        if any(default is factory for factory in _UNINSPECTABLE_NO_ARG_DEFAULT_FACTORIES):
-            return default()
-        return default
+        return default()
 
     return default()
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -138,6 +138,21 @@ def _is_param_record(param: Any) -> bool:
     return isinstance(param, Mapping) or _is_attribute_param_record(param)
 
 
+_UNINSPECTABLE_NO_ARG_DEFAULT_FACTORIES = (
+    bool,
+    bytearray,
+    bytes,
+    complex,
+    dict,
+    float,
+    frozenset,
+    int,
+    object,
+    set,
+    str,
+)
+
+
 def _resolve_default_value(default):
     if not callable(default):
         return default
@@ -147,10 +162,9 @@ def _resolve_default_value(default):
     except TypeError:
         return default
     except ValueError:
-        try:
+        if any(default is factory for factory in _UNINSPECTABLE_NO_ARG_DEFAULT_FACTORIES):
             return default()
-        except TypeError:
-            return default
+        return default
 
     return default()
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -6,6 +6,7 @@ from contextlib import ExitStack
 from contextlib import contextmanager
 from dataclasses import is_dataclass
 from functools import cached_property
+from inspect import signature
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncGenerator
@@ -135,6 +136,23 @@ def _is_attribute_param_record(param: Any) -> bool:
 
 def _is_param_record(param: Any) -> bool:
     return isinstance(param, Mapping) or _is_attribute_param_record(param)
+
+
+def _resolve_default_value(default):
+    if not callable(default):
+        return default
+
+    try:
+        signature(default).bind()
+    except TypeError:
+        return default
+    except ValueError:
+        try:
+            return default()
+        except TypeError:
+            return default
+
+    return default()
 
 
 def _raise_invalid_param_record(param: Any, location: str) -> None:
@@ -601,7 +619,7 @@ class Commands(BaseCommands, ABC):
         try:
             return self.query_first(sql, model=model, param=resolved_params)
         except NoResultException:
-            return default() if callable(default) else default
+            return _resolve_default_value(default)
 
     @overload
     def query_single(
@@ -736,7 +754,7 @@ class Commands(BaseCommands, ABC):
         try:
             return self.query_single(sql, model=model, param=resolved_params)
         except NoResultException:
-            return default() if callable(default) else default
+            return _resolve_default_value(default)
 
     @overload
     def execute_scalar(self, sql: str, params: Optional["ParamType"] = None) -> Any: ...
@@ -1097,7 +1115,7 @@ class CommandsAsync(BaseCommands, ABC):
         try:
             return await self.query_first_async(sql, model=model, param=resolved_params)
         except NoResultException:
-            return default() if callable(default) else default
+            return _resolve_default_value(default)
 
     @overload
     async def query_single_async(
@@ -1234,7 +1252,7 @@ class CommandsAsync(BaseCommands, ABC):
         try:
             return await self.query_single_async(sql, model=model, param=resolved_params)
         except NoResultException:
-            return default() if callable(default) else default
+            return _resolve_default_value(default)
 
     @overload
     async def execute_scalar_async(self, sql: str, params: Optional["ParamType"] = None) -> Any: ...

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -31,6 +31,7 @@ from .exceptions import InvalidParameterShapeException
 from .exceptions import MissingParameterException
 from .exceptions import MoreThanOneResultException
 from .exceptions import NoResultException
+from .rows import RawRow
 from .utils import database_row_to_dict
 from .utils import get_col_names
 from .utils import serialize_dict_row
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 
     _T = TypeVar("_T")
     _Default = TypeVar("_Default")
+    _MapperT = TypeVar("_MapperT")
 
 
 class _ParamAliasUnset:
@@ -55,6 +57,21 @@ class _ParamAliasUnset:
 
 
 _PARAM_ALIAS_UNSET = _ParamAliasUnset()
+
+
+class _ModelUnset:
+    def __repr__(self) -> str:
+        return "dict"
+
+
+_MODEL_UNSET = _ModelUnset()
+
+
+class _MapperUnset:
+    pass
+
+
+_MAPPER_UNSET = _MapperUnset()
 
 
 def _resolve_param_aliases(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
@@ -68,6 +85,33 @@ def _resolve_param_aliases(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
         return param
 
     return None
+
+
+def _resolve_row_projector(model=_MODEL_UNSET, mapper=_MAPPER_UNSET):
+    if mapper is not _MAPPER_UNSET:
+        if model is not _MODEL_UNSET:
+            raise ValueError("Pass either 'model' or 'mapper', not both.")
+        return mapper, True
+
+    return dict if model is _MODEL_UNSET else model, False
+
+
+def _project_row(projector, maps_raw_row: bool, headers, row):
+    if maps_raw_row:
+        return projector(RawRow(headers, row))
+    return serialize_dict_row(projector, database_row_to_dict(headers, row))
+
+
+def _normalize_query_multiple_mappers(queries: Tuple[str, ...], mapper):
+    if isinstance(mapper, tuple):
+        mappers = mapper
+    else:
+        mappers = tuple(mapper for _ in queries)
+
+    if len(queries) != len(mappers):
+        raise ValueError("Number of queries must equal number of mappers")
+
+    return mappers
 
 
 def _is_empty_executemany_params(param: Any) -> bool:
@@ -289,9 +333,10 @@ class Commands(BaseCommands, ABC):
         """Not all dbapis implement the cursor as a context manager.  This function handles that polymorphism."""
         with ExitStack() as stack:
             try:
-                yield stack.enter_context(self.cursor())  # type: ignore
+                cursor = stack.enter_context(self.cursor())  # type: ignore
             except (AttributeError, TypeError):
-                yield self.cursor()
+                cursor = self.cursor()
+            yield cursor
 
     def cursor(self, *args, **kwargs) -> "CursorType":
         return self.connection.cursor(*args, **kwargs)
@@ -313,40 +358,50 @@ class Commands(BaseCommands, ABC):
         return rowcount
 
     def _buffered_query(
-        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
+        self,
+        handler: BaseSqlParamHandler,
+        projector: Union[Type["_T"], Callable[..., "_T"]],
+        maps_raw_row: bool,
     ) -> List["_T"]:
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
-            try:
-                validate_no_duplicate_columns(headers)
-            except DuplicateColumnException:
-                self._on_duplicate_columns(cursor)
-                raise
+            if not maps_raw_row:
+                try:
+                    validate_no_duplicate_columns(headers)
+                except DuplicateColumnException:
+                    self._on_duplicate_columns(cursor)
+                    raise
             data = cursor.fetchall()
-            return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
+            return [_project_row(projector, maps_raw_row, headers, row) for row in data]
 
-    def _unbuffered_query(self, handler: BaseSqlParamHandler, model: "Type[_T]") -> Generator["_T", None, None]:
+    def _unbuffered_query(
+        self,
+        handler: BaseSqlParamHandler,
+        projector: Union[Type["_T"], Callable[..., "_T"]],
+        maps_raw_row: bool,
+    ) -> Generator["_T", None, None]:
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             headers = get_col_names(cursor)
-            try:
-                validate_no_duplicate_columns(headers)
-            except DuplicateColumnException:
-                self._on_duplicate_columns(cursor)
-                raise
+            if not maps_raw_row:
+                try:
+                    validate_no_duplicate_columns(headers)
+                except DuplicateColumnException:
+                    self._on_duplicate_columns(cursor)
+                    raise
 
             row = cursor.fetchone()
             if row is None:
                 return
 
-            yield serialize_dict_row(model, database_row_to_dict(headers, row))
+            yield _project_row(projector, maps_raw_row, headers, row)
 
             while True:
                 row = cursor.fetchone()
                 if row is None:
                     break
-                yield serialize_dict_row(model, database_row_to_dict(headers, row))
+                yield _project_row(projector, maps_raw_row, headers, row)
 
     def _on_duplicate_columns(self, cursor: "CursorType") -> None:
         pass
@@ -434,11 +489,63 @@ class Commands(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> Generator["_T", None, None]: ...
 
-    def query(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    def query(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> List["_MapperT"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_MapperT"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: "Literal[False]",
+    ) -> Generator["_MapperT", None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> Generator["_MapperT", None, None]: ...
+
+    def query(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        buffered=True,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
-        return self._buffered_query(handler, model) if buffered else self._unbuffered_query(handler, model)
+        if buffered:
+            return self._buffered_query(handler, projector, maps_raw_row)
+        return self._unbuffered_query(handler, projector, maps_raw_row)
 
     # endregion
 
@@ -452,6 +559,26 @@ class Commands(BaseCommands, ABC):
         self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
     ) -> Tuple[List[Any], ...]: ...
 
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        *,
+        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List[Any], ...]: ...
+
     def query_multiple(
         self,
         queries: Tuple[str, ...],
@@ -459,6 +586,7 @@ class Commands(BaseCommands, ABC):
         param=_PARAM_ALIAS_UNSET,
         *,
         params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
@@ -467,15 +595,24 @@ class Commands(BaseCommands, ABC):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
-        if models is None:
-            models = tuple(dict for _ in queries)
+        if mapper is not _MAPPER_UNSET:
+            if models is not None:
+                raise ValueError("Pass either 'models' or 'mapper', not both.")
+            projectors = _normalize_query_multiple_mappers(queries, mapper)
+            maps_raw_row = True
+        else:
+            if models is None:
+                models = tuple(dict for _ in queries)
 
-        if len(queries) != len(models):
-            raise ValueError("Number of queries must equal number of models")
+            if len(queries) != len(models):
+                raise ValueError("Number of queries must equal number of models")
+
+            projectors = models
+            maps_raw_row = False
 
         results = list()
         with self._cursor_context_proxy() as cursor:
-            for query, model in zip(queries, models):
+            for query, projector in zip(queries, projectors):
                 handler = self.SqlParamHandler(query, resolved_params)
                 handler.execute(cursor)
                 headers = get_col_names(cursor)
@@ -484,8 +621,9 @@ class Commands(BaseCommands, ABC):
                 if not data:
                     raise NoResultException(f"No results returned from query {query}")
 
-                validate_no_duplicate_columns(headers)
-                serialized_data = [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
+                if not maps_raw_row:
+                    validate_no_duplicate_columns(headers)
+                serialized_data = [_project_row(projector, maps_raw_row, headers, row) for row in data]
                 results.append(serialized_data)
 
         return tuple(results)
@@ -519,9 +657,36 @@ class Commands(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> "_T": ...
 
-    def query_first(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    def query_first(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> "_MapperT": ...
+
+    @overload
+    def query_first(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> "_MapperT": ...
+
+    def query_first(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
@@ -530,8 +695,9 @@ class Commands(BaseCommands, ABC):
             row = cursor.fetchone()
             if row is None:
                 raise NoResultException("Query returned no results")
-            validate_no_duplicate_columns(headers)
-        return serialize_dict_row(model, database_row_to_dict(headers, row))
+            if not maps_raw_row:
+                validate_no_duplicate_columns(headers)
+        return _project_row(projector, maps_raw_row, headers, row)
 
     @overload
     def query_first_or_default(
@@ -611,9 +777,63 @@ class Commands(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> Union["_Default", "_T"]: ...
 
-    def query_first_or_default(self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    def query_first_or_default(
+        self,
+        sql,
+        default,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
+        _resolve_row_projector(model, mapper)
         try:
+            if mapper is not _MAPPER_UNSET:
+                return self.query_first(sql, param=resolved_params, mapper=mapper)
+            if model is _MODEL_UNSET:
+                return self.query_first(sql, param=resolved_params)
             return self.query_first(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
@@ -647,9 +867,36 @@ class Commands(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> "_T": ...
 
-    def query_single(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    def query_single(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> "_MapperT": ...
+
+    @overload
+    def query_single(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> "_MapperT": ...
+
+    def query_single(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
@@ -664,9 +911,10 @@ class Commands(BaseCommands, ABC):
                 self._on_query_single_more_than_one_result(cursor)
                 raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
-            validate_no_duplicate_columns(headers)
+            if not maps_raw_row:
+                validate_no_duplicate_columns(headers)
 
-        return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
+        return _project_row(projector, maps_raw_row, headers, data[0])
 
     @overload
     def query_single_or_default(
@@ -746,9 +994,63 @@ class Commands(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> Union["_Default", "_T"]: ...
 
-    def query_single_or_default(self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    def query_single_or_default(
+        self,
+        sql,
+        default,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
+        _resolve_row_projector(model, mapper)
         try:
+            if mapper is not _MAPPER_UNSET:
+                return self.query_single(sql, param=resolved_params, mapper=mapper)
+            if model is _MODEL_UNSET:
+                return self.query_single(sql, param=resolved_params)
             return self.query_single(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
@@ -805,42 +1107,50 @@ class CommandsAsync(BaseCommands, ABC):
             return await handler.execute_async(cursor)
 
     async def _buffered_query(
-        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
+        self,
+        handler: BaseSqlParamHandler,
+        projector: Union[Type["_T"], Callable[..., "_T"]],
+        maps_raw_row: bool,
     ) -> List["_T"]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
-            try:
-                validate_no_duplicate_columns(headers)
-            except DuplicateColumnException:
-                await self._on_duplicate_columns_async(cursor)
-                raise
+            if not maps_raw_row:
+                try:
+                    validate_no_duplicate_columns(headers)
+                except DuplicateColumnException:
+                    await self._on_duplicate_columns_async(cursor)
+                    raise
             data = await cursor.fetchall()
-            return [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
+            return [_project_row(projector, maps_raw_row, headers, row) for row in data]
 
     async def _unbuffered_query(
-        self, handler: BaseSqlParamHandler, model: Union[Type["_T"], Callable[..., "_T"]]
+        self,
+        handler: BaseSqlParamHandler,
+        projector: Union[Type["_T"], Callable[..., "_T"]],
+        maps_raw_row: bool,
     ) -> AsyncGenerator["_T", None]:
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
-            try:
-                validate_no_duplicate_columns(headers)
-            except DuplicateColumnException:
-                await self._on_duplicate_columns_async(cursor)
-                raise
+            if not maps_raw_row:
+                try:
+                    validate_no_duplicate_columns(headers)
+                except DuplicateColumnException:
+                    await self._on_duplicate_columns_async(cursor)
+                    raise
 
             row = await cursor.fetchone()
             if row is None:
                 return
 
-            yield serialize_dict_row(model, database_row_to_dict(headers, row))
+            yield _project_row(projector, maps_raw_row, headers, row)
 
             while True:
                 row = await cursor.fetchone()
                 if row is None:
                     break
-                yield serialize_dict_row(model, database_row_to_dict(headers, row))
+                yield _project_row(projector, maps_raw_row, headers, row)
 
     async def _on_duplicate_columns_async(self, cursor: "AsyncCursorType") -> None:
         pass
@@ -925,14 +1235,64 @@ class CommandsAsync(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> AsyncGenerator["_T", None]: ...
 
-    async def query_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, buffered=True, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> List["_MapperT"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_MapperT"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: "Literal[False]",
+    ) -> AsyncGenerator["_MapperT", None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> AsyncGenerator["_MapperT", None]: ...
+
+    async def query_async(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        buffered=True,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
         if buffered:
-            records = await self._buffered_query(handler, model)
+            records = await self._buffered_query(handler, projector, maps_raw_row)
             return records
-        return self._unbuffered_query(handler, model)
+        return self._unbuffered_query(handler, projector, maps_raw_row)
 
     @overload
     async def query_multiple_async(
@@ -944,6 +1304,26 @@ class CommandsAsync(BaseCommands, ABC):
         self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
     ) -> Tuple[List[Any], ...]: ...
 
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        *,
+        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List[Any], ...]: ...
+
     async def query_multiple_async(
         self,
         queries: Tuple[str, ...],
@@ -951,6 +1331,7 @@ class CommandsAsync(BaseCommands, ABC):
         param=_PARAM_ALIAS_UNSET,
         *,
         params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
@@ -959,15 +1340,24 @@ class CommandsAsync(BaseCommands, ABC):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
-        if models is None:
-            models = cast(Tuple[dict], tuple(dict for _ in queries))
+        if mapper is not _MAPPER_UNSET:
+            if models is not None:
+                raise ValueError("Pass either 'models' or 'mapper', not both.")
+            projectors = _normalize_query_multiple_mappers(queries, mapper)
+            maps_raw_row = True
+        else:
+            if models is None:
+                models = cast(Tuple[dict], tuple(dict for _ in queries))
 
-        if len(queries) != len(models):
-            raise ValueError("Number of queries must equal number of models")
+            if len(queries) != len(models):
+                raise ValueError("Number of queries must equal number of models")
+
+            projectors = models
+            maps_raw_row = False
 
         results = list()
         async with self.cursor() as cursor:
-            for query, model in zip(queries, models):
+            for query, projector in zip(queries, projectors):
                 handler = self.SqlParamHandler(query, resolved_params)
                 await handler.execute_async(cursor)
                 headers = get_col_names(cursor)
@@ -976,8 +1366,9 @@ class CommandsAsync(BaseCommands, ABC):
                 if not data:
                     raise NoResultException(f"No results returned from query {query}")
 
-                validate_no_duplicate_columns(headers)
-                serialized_data = [serialize_dict_row(model, database_row_to_dict(headers, row)) for row in data]
+                if not maps_raw_row:
+                    validate_no_duplicate_columns(headers)
+                serialized_data = [_project_row(projector, maps_raw_row, headers, row) for row in data]
                 results.append(serialized_data)
 
         return cast(Tuple[List[Any]], tuple(results))
@@ -1013,9 +1404,36 @@ class CommandsAsync(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> "_T": ...
 
-    async def query_first_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> "_MapperT": ...
+
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> "_MapperT": ...
+
+    async def query_first_async(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
@@ -1024,8 +1442,9 @@ class CommandsAsync(BaseCommands, ABC):
             row = await cursor.fetchone()
             if row is None:
                 raise NoResultException("Query returned no results")
-            validate_no_duplicate_columns(headers)
-            return serialize_dict_row(model, database_row_to_dict(headers, row))
+            if not maps_raw_row:
+                validate_no_duplicate_columns(headers)
+            return _project_row(projector, maps_raw_row, headers, row)
 
     @overload
     async def query_first_or_default_async(
@@ -1105,11 +1524,63 @@ class CommandsAsync(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> Union["_Default", "_T"]: ...
 
+    @overload
     async def query_first_or_default_async(
-        self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    async def query_first_or_default_async(
+        self,
+        sql,
+        default,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
     ):
         resolved_params = self._resolve_params(param, params)
+        _resolve_row_projector(model, mapper)
         try:
+            if mapper is not _MAPPER_UNSET:
+                return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
+            if model is _MODEL_UNSET:
+                return await self.query_first_async(sql, param=resolved_params)
             return await self.query_first_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
@@ -1145,9 +1616,36 @@ class CommandsAsync(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> "_T": ...
 
-    async def query_single_async(self, sql, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET):
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> "_MapperT": ...
+
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> "_MapperT": ...
+
+    async def query_single_async(
+        self,
+        sql,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
+    ):
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
@@ -1161,8 +1659,9 @@ class CommandsAsync(BaseCommands, ABC):
         elif num_records > 1:
             raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
-        validate_no_duplicate_columns(headers)
-        return serialize_dict_row(model, database_row_to_dict(headers, data[0]))
+        if not maps_raw_row:
+            validate_no_duplicate_columns(headers)
+        return _project_row(projector, maps_raw_row, headers, data[0])
 
     @overload
     async def query_single_or_default_async(
@@ -1242,11 +1741,63 @@ class CommandsAsync(BaseCommands, ABC):
         params: Optional["ParamType"],
     ) -> Union["_Default", "_T"]: ...
 
+    @overload
     async def query_single_or_default_async(
-        self, sql, default, model=dict, param=_PARAM_ALIAS_UNSET, *, params=_PARAM_ALIAS_UNSET
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        param: Optional["ParamType"] = ...,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_MapperT"]: ...
+
+    async def query_single_or_default_async(
+        self,
+        sql,
+        default,
+        model=_MODEL_UNSET,
+        param=_PARAM_ALIAS_UNSET,
+        *,
+        params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
     ):
         resolved_params = self._resolve_params(param, params)
+        _resolve_row_projector(model, mapper)
         try:
+            if mapper is not _MAPPER_UNSET:
+                return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
+            if model is _MODEL_UNSET:
+                return await self.query_single_async(sql, param=resolved_params)
             return await self.query_single_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -1,15 +1,17 @@
 from typing import TYPE_CHECKING
 
 from pydapper import register
+from pydapper.commands import _MAPPER_UNSET
+from pydapper.commands import _MODEL_UNSET
 from pydapper.commands import _PARAM_ALIAS_UNSET
 from pydapper.commands import Commands
+from pydapper.commands import _project_row
 from pydapper.commands import _raise_if_list_params_for_read
+from pydapper.commands import _resolve_row_projector
 
 from ..exceptions import NoResultException
-from ..utils import database_row_to_dict
 from ..utils import get_col_names
 from ..utils import import_dbapi_module
-from ..utils import serialize_dict_row
 from ..utils import validate_no_duplicate_columns
 
 if TYPE_CHECKING:
@@ -69,10 +71,11 @@ class MySqlConnectorPythonCommands(Commands):
     def query_first(
         self,
         sql,
-        model=dict,
+        model=_MODEL_UNSET,
         param=_PARAM_ALIAS_UNSET,
         *,
         params=_PARAM_ALIAS_UNSET,
+        mapper=_MAPPER_UNSET,
     ):
         """
         the mysql connector throws an exception if you only read one row from a cursor.  Unfortunately, we have to
@@ -80,6 +83,7 @@ class MySqlConnectorPythonCommands(Commands):
         """
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
+        projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self.cursor() as cursor:
@@ -89,8 +93,9 @@ class MySqlConnectorPythonCommands(Commands):
             if row is None:
                 raise NoResultException("Query returned no results")
             cursor.fetchall()
-            validate_no_duplicate_columns(headers)
-        return serialize_dict_row(model, database_row_to_dict(headers, row))
+            if not maps_raw_row:
+                validate_no_duplicate_columns(headers)
+        return _project_row(projector, maps_raw_row, headers, row)
 
     def _on_duplicate_columns(self, cursor: "CursorType") -> None:
         _discard_unread_result(cursor)

--- a/pydapper/rows.py
+++ b/pydapper/rows.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
-from dataclasses import field
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -25,12 +25,9 @@ Mapper: TypeAlias = Callable[["RawRow"], _MapperT]
 class RawRow:
     columns: Tuple[str, ...]
     values: Tuple[Any, ...]
-    _column_indexes: Optional[Mapping[str, Tuple[int, ...]]] = field(
-        default=None,
-        init=False,
-        repr=False,
-        compare=False,
-    )
+
+    if TYPE_CHECKING:
+        _column_indexes: Optional[Mapping[str, Tuple[int, ...]]]
 
     def __init__(self, columns: Sequence[str], values: Sequence[Any]) -> None:
         column_tuple = tuple(columns)
@@ -40,6 +37,14 @@ class RawRow:
 
         object.__setattr__(self, "columns", column_tuple)
         object.__setattr__(self, "values", value_tuple)
+        object.__setattr__(self, "_column_indexes", None)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        return {"columns": self.columns, "values": self.values}
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        object.__setattr__(self, "columns", state["columns"])
+        object.__setattr__(self, "values", state["values"])
         object.__setattr__(self, "_column_indexes", None)
 
     def as_dict(self) -> Dict[str, Any]:

--- a/pydapper/rows.py
+++ b/pydapper/rows.py
@@ -1,7 +1,12 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
+from dataclasses import field
+from types import MappingProxyType
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import List
+from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import TypeAlias
@@ -10,7 +15,6 @@ from typing import Union
 from typing import overload
 
 from .exceptions import DuplicateColumnException
-from .utils import validate_no_duplicate_columns
 
 _MapperT = TypeVar("_MapperT")
 
@@ -21,6 +25,12 @@ Mapper: TypeAlias = Callable[["RawRow"], _MapperT]
 class RawRow:
     columns: Tuple[str, ...]
     values: Tuple[Any, ...]
+    _column_indexes: Optional[Mapping[str, Tuple[int, ...]]] = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def __init__(self, columns: Sequence[str], values: Sequence[Any]) -> None:
         column_tuple = tuple(columns)
@@ -30,9 +40,20 @@ class RawRow:
 
         object.__setattr__(self, "columns", column_tuple)
         object.__setattr__(self, "values", value_tuple)
+        object.__setattr__(self, "_column_indexes", None)
 
     def as_dict(self) -> Dict[str, Any]:
-        validate_no_duplicate_columns(self.columns)
+        column_indexes = self._get_column_indexes()
+        duplicate_columns = tuple(column for column, indexes in column_indexes.items() if len(indexes) > 1)
+        if duplicate_columns:
+            duplicate_indexes = tuple(
+                index for index, column in enumerate(self.columns) if len(column_indexes[column]) > 1
+            )
+            raise DuplicateColumnException(
+                columns=self.columns,
+                duplicate_columns=duplicate_columns,
+                duplicate_indexes=duplicate_indexes,
+            )
         return dict(zip(self.columns, self.values))
 
     @overload
@@ -47,7 +68,7 @@ class RawRow:
         return self.values[key]
 
     def _get_by_column_name(self, key: str) -> Any:
-        indexes = tuple(index for index, column in enumerate(self.columns) if column == key)
+        indexes = self._get_column_indexes().get(key)
         if not indexes:
             raise KeyError(key)
         if len(indexes) > 1:
@@ -57,3 +78,13 @@ class RawRow:
                 duplicate_indexes=indexes,
             )
         return self.values[indexes[0]]
+
+    def _get_column_indexes(self) -> Mapping[str, Tuple[int, ...]]:
+        column_indexes = self._column_indexes
+        if column_indexes is None:
+            index_lists: Dict[str, List[int]] = {}
+            for index, column in enumerate(self.columns):
+                index_lists.setdefault(column, []).append(index)
+            column_indexes = MappingProxyType({column: tuple(indexes) for column, indexes in index_lists.items()})
+            object.__setattr__(self, "_column_indexes", column_indexes)
+        return column_indexes

--- a/pydapper/rows.py
+++ b/pydapper/rows.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Sequence
+from typing import Tuple
+from typing import TypeAlias
+from typing import TypeVar
+from typing import Union
+from typing import overload
+
+from .exceptions import DuplicateColumnException
+from .utils import validate_no_duplicate_columns
+
+_MapperT = TypeVar("_MapperT")
+
+Mapper: TypeAlias = Callable[["RawRow"], _MapperT]
+
+
+@dataclass(frozen=True)
+class RawRow:
+    columns: Tuple[str, ...]
+    values: Tuple[Any, ...]
+
+    def __init__(self, columns: Sequence[str], values: Sequence[Any]) -> None:
+        column_tuple = tuple(columns)
+        value_tuple = tuple(values)
+        if len(column_tuple) != len(value_tuple):
+            raise ValueError("RawRow columns and values must have the same length.")
+
+        object.__setattr__(self, "columns", column_tuple)
+        object.__setattr__(self, "values", value_tuple)
+
+    def as_dict(self) -> Dict[str, Any]:
+        validate_no_duplicate_columns(self.columns)
+        return dict(zip(self.columns, self.values))
+
+    @overload
+    def __getitem__(self, key: int) -> Any: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __getitem__(self, key: Union[int, str]) -> Any:
+        if isinstance(key, str):
+            return self._get_by_column_name(key)
+        return self.values[key]
+
+    def _get_by_column_name(self, key: str) -> Any:
+        indexes = tuple(index for index, column in enumerate(self.columns) if column == key)
+        if not indexes:
+            raise KeyError(key)
+        if len(indexes) > 1:
+            raise DuplicateColumnException(
+                columns=self.columns,
+                duplicate_columns=(key,),
+                duplicate_indexes=indexes,
+            )
+        return self.values[indexes[0]]

--- a/pydapper/rows.py
+++ b/pydapper/rows.py
@@ -39,10 +39,10 @@ class RawRow:
         object.__setattr__(self, "values", value_tuple)
         object.__setattr__(self, "_column_indexes", None)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> Dict[str, Any]:  # pragma: no cover
         return {"columns": self.columns, "values": self.values}
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: Dict[str, Any]) -> None:  # pragma: no cover
         object.__setattr__(self, "columns", state["columns"])
         object.__setattr__(self, "values", state["values"])
         object.__setattr__(self, "_column_indexes", None)

--- a/pydapper/utils.py
+++ b/pydapper/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -28,7 +29,7 @@ def safe_getattr(obj: Any, key: str) -> Any:
         raise KeyError(f"Key {key!r} can not be accessed on {obj!r} or does not exist")
 
 
-def _get_duplicate_column_data(col_names: List[str]) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+def _get_duplicate_column_data(col_names: Sequence[str]) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
     column_indexes: Dict[str, List[int]] = {}
     for index, col_name in enumerate(col_names):
         column_indexes.setdefault(col_name, []).append(index)
@@ -39,7 +40,7 @@ def _get_duplicate_column_data(col_names: List[str]) -> Tuple[Tuple[str, ...], T
     return duplicate_columns, duplicate_indexes
 
 
-def validate_no_duplicate_columns(col_names: List[str]) -> None:
+def validate_no_duplicate_columns(col_names: Sequence[str]) -> None:
     duplicate_columns, duplicate_indexes = _get_duplicate_column_data(col_names)
     if duplicate_columns:
         raise DuplicateColumnException(

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1709,39 +1709,41 @@ class TestCommands:
 
         assert data is default
 
-    def test_query_first_or_default_returns_uninspectable_callable_default(
+    def test_query_first_or_default_propagates_uninspectable_callable_default_error(
         self, connection, set_fetchone_to_return_none, mocker
     ):
+        calls = []
+        error = TypeError("factory failed")
+
+        def default():
+            calls.append(None)
+            raise error
+
+        mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
+
+        with MockCommands(connection) as commands, pytest.raises(TypeError) as exc_info:
+            commands.query_first_or_default("select * from some_table", default=default)
+
+        assert exc_info.value is error
+        assert calls == [None]
+
+    def test_query_first_or_default_calls_uninspectable_callable_default(
+        self, connection, set_fetchone_to_return_none, mocker
+    ):
+        sentinel = object()
         calls = []
 
         def default():
             calls.append(None)
-            raise TypeError("factory failed")
+            return sentinel
 
         mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
 
         with MockCommands(connection) as commands:
             data = commands.query_first_or_default("select * from some_table", default=default)
 
-        assert data is default
-        assert calls == []
-
-    @pytest.mark.parametrize(
-        "default_factory, expected",
-        [
-            (list, []),
-            (tuple, ()),
-        ],
-    )
-    def test_query_first_or_default_calls_common_factory_when_signature_is_unavailable(
-        self, connection, set_fetchone_to_return_none, mocker, default_factory, expected
-    ):
-        mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
-
-        with MockCommands(connection) as commands:
-            data = commands.query_first_or_default("select * from some_table", default=default_factory)
-
-        assert data == expected
+        assert data is sentinel
+        assert calls == [None]
 
     def test_query_first_or_default_returns_first_row(self, connection):
         calls = []
@@ -2315,8 +2317,8 @@ class TestCommandsAsync:
         assert data is default
 
     @pytest.mark.asyncio
-    async def test_query_first_or_default_calls_callable_default_on_no_result(
-        self, connection, set_fetchone_to_return_none
+    async def test_query_first_or_default_calls_uninspectable_callable_default_on_no_result(
+        self, connection, set_fetchone_to_return_none, mocker
     ):
         sentinel = object()
         calls = []
@@ -2324,6 +2326,8 @@ class TestCommandsAsync:
         def default():
             calls.append(None)
             return sentinel
+
+        mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
 
         async with MockAsyncCommands(connection) as commands:
             data = await commands.query_first_or_default_async("select * from some_table", default=default)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1690,6 +1690,25 @@ class TestCommands:
         assert data is sentinel
         assert calls == [None]
 
+    def test_query_first_or_default_calls_builtin_default_factory_on_no_result(
+        self, connection, set_fetchone_to_return_none
+    ):
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=dict)
+
+        assert data == {}
+
+    def test_query_first_or_default_returns_callable_default_that_requires_args(
+        self, connection, set_fetchone_to_return_none
+    ):
+        def default(row):
+            return row
+
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=default)
+
+        assert data is default
+
     def test_query_first_or_default_returns_first_row(self, connection):
         calls = []
 
@@ -1808,6 +1827,25 @@ class TestCommands:
 
         assert record is sentinel
         assert calls == [None]
+
+    def test_query_single_or_default_calls_builtin_default_factory_on_no_result(
+        self, connection, set_fetchone_to_return_none
+    ):
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default("select * from some_table", default=set)
+
+        assert record == set()
+
+    def test_query_single_or_default_returns_callable_default_that_requires_args(
+        self, connection, set_fetchone_to_return_none
+    ):
+        def default(row):
+            return row
+
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default("select * from some_table", default=default)
+
+        assert record is default
 
     def test_query_single_or_default_returns_single_row(self, connection, set_fetchall_return_one):
         calls = []
@@ -2260,6 +2298,27 @@ class TestCommandsAsync:
         assert calls == [None]
 
     @pytest.mark.asyncio
+    async def test_query_first_or_default_calls_builtin_default_factory_on_no_result(
+        self, connection, set_fetchone_to_return_none
+    ):
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async("select * from some_table", default=dict)
+
+        assert data == {}
+
+    @pytest.mark.asyncio
+    async def test_query_first_or_default_returns_callable_default_that_requires_args(
+        self, connection, set_fetchone_to_return_none
+    ):
+        def default(row):
+            return row
+
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async("select * from some_table", default=default)
+
+        assert data is default
+
+    @pytest.mark.asyncio
     async def test_query_first_or_default_returns_first_row(self, connection):
         calls = []
 
@@ -2384,6 +2443,27 @@ class TestCommandsAsync:
 
         assert record is sentinel
         assert calls == [None]
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_calls_builtin_default_factory_on_no_result(
+        self, connection, set_fetchone_to_return_none
+    ):
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async("select * from some_table", default=set)
+
+        assert record == set()
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_returns_callable_default_that_requires_args(
+        self, connection, set_fetchone_to_return_none
+    ):
+        def default(row):
+            return row
+
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async("select * from some_table", default=default)
+
+        assert record is default
 
     @pytest.mark.asyncio
     async def test_query_single_or_default_returns_single_row(self, connection, set_fetchall_return_one):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1726,6 +1726,23 @@ class TestCommands:
         assert data is default
         assert calls == []
 
+    @pytest.mark.parametrize(
+        "default_factory, expected",
+        [
+            (list, []),
+            (tuple, ()),
+        ],
+    )
+    def test_query_first_or_default_calls_common_factory_when_signature_is_unavailable(
+        self, connection, set_fetchone_to_return_none, mocker, default_factory, expected
+    ):
+        mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
+
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=default_factory)
+
+        assert data == expected
+
     def test_query_first_or_default_returns_first_row(self, connection):
         calls = []
 

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,6 +1,7 @@
 from collections import UserDict
 from dataclasses import FrozenInstanceError
 from dataclasses import dataclass
+from types import MappingProxyType
 from types import SimpleNamespace
 
 import pytest
@@ -270,6 +271,23 @@ class TestRawRow:
         assert row[0] == 1
         assert row["name"] == "Zach"
 
+    def test_column_indexes_are_lazily_created_and_reused(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+
+        assert row._column_indexes is None
+        assert row[0] == 1
+        assert row._column_indexes is None
+
+        assert row["name"] == "Zach"
+        column_indexes = row._column_indexes
+        assert isinstance(column_indexes, MappingProxyType)
+        assert column_indexes == {"id": (0,), "name": (1,)}
+        assert row.as_dict() == {"id": 1, "name": "Zach"}
+        assert row._column_indexes is column_indexes
+
+        with pytest.raises(TypeError):
+            column_indexes["id"] = (2,)
+
     def test_name_access_raises_for_duplicate_column_name(self):
         row = RawRow(("id", "name", "id"), (1, "Zach", 2))
 
@@ -277,6 +295,16 @@ class TestRawRow:
             row["id"]
 
         _assert_duplicate_column_exception(exc_info)
+
+    def test_as_dict_duplicate_indexes_are_globally_ordered(self):
+        row = RawRow(("a", "b", "a", "b"), (1, 2, 3, 4))
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            row.as_dict()
+
+        assert exc_info.value.columns == ("a", "b", "a", "b")
+        assert exc_info.value.duplicate_columns == ("a", "b")
+        assert exc_info.value.duplicate_indexes == (0, 1, 2, 3)
 
     def test_name_access_raises_key_error_for_missing_column_name(self):
         row = RawRow(("id", "name"), (1, "Zach"))

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,9 +1,11 @@
 from collections import UserDict
+from dataclasses import FrozenInstanceError
 from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
 
+from pydapper import RawRow
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
@@ -115,6 +117,32 @@ class _CursorConnection:
         return self.cursor_instance
 
 
+class _TrackingContextCursor:
+    rowcount = 0
+    description = ("id", "int"), ("name", "text")
+
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+        self.rows = [(1, "Zach")]
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.exited = True
+
+    def execute(self, sql, parameters=None):
+        pass
+
+    def fetchall(self):
+        return tuple(self.rows)
+
+    def fetchone(self):
+        return self.rows.pop(0) if self.rows else None
+
+
 class _AsyncQuerySingleFetchOneCursor:
     rowcount = 0
     description = ("id", "int"), ("name", "text")
@@ -208,6 +236,63 @@ def _assert_duplicate_column_exception(exc_info):
     assert exc_info.value.columns == ("id", "name", "id")
     assert exc_info.value.duplicate_columns == ("id",)
     assert exc_info.value.duplicate_indexes == (0, 2)
+
+
+class TestRawRow:
+    def test_columns_and_values_are_tuples_in_driver_order(self):
+        row = RawRow(["id", "name"], [1, "Zach"])
+
+        assert row.columns == ("id", "name")
+        assert row.values == (1, "Zach")
+
+    def test_duplicate_columns_are_preserved(self):
+        row = RawRow(("id", "name", "id"), (1, "Zach", 2))
+
+        assert row.columns == ("id", "name", "id")
+        assert row.values == (1, "Zach", 2)
+
+    def test_as_dict_returns_dict_for_unique_columns(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+
+        assert row.as_dict() == {"id": 1, "name": "Zach"}
+
+    def test_as_dict_raises_duplicate_column_exception_for_duplicate_columns(self):
+        row = RawRow(("id", "name", "id"), (1, "Zach", 2))
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            row.as_dict()
+
+        _assert_duplicate_column_exception(exc_info)
+
+    def test_positional_and_name_access(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+
+        assert row[0] == 1
+        assert row["name"] == "Zach"
+
+    def test_name_access_raises_for_duplicate_column_name(self):
+        row = RawRow(("id", "name", "id"), (1, "Zach", 2))
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            row["id"]
+
+        _assert_duplicate_column_exception(exc_info)
+
+    def test_name_access_raises_key_error_for_missing_column_name(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+
+        with pytest.raises(KeyError, match="missing"):
+            row["missing"]
+
+    def test_row_is_immutable(self):
+        row = RawRow(("id",), (1,))
+
+        with pytest.raises(FrozenInstanceError):
+            row.columns = ("other",)
+
+    def test_columns_and_values_must_have_same_length(self):
+        with pytest.raises(ValueError, match="same length"):
+            RawRow(("id",), ())
 
 
 @pytest.fixture
@@ -557,9 +642,11 @@ class TestParamHandler:
         assert handler.get_param_placeholder("sup") == "%s"
 
     def test_param_alias_unset_repr_matches_legacy_default_display(self):
+        from pydapper.commands import _MODEL_UNSET
         from pydapper.commands import _PARAM_ALIAS_UNSET
 
         assert repr(_PARAM_ALIAS_UNSET) == "None"
+        assert repr(_MODEL_UNSET) == "dict"
 
     def test_ordered_param_names(self):
         handler = MockParamHandler(
@@ -1176,6 +1263,32 @@ class TestCommands:
 
         assert captured_handler_params == [params]
 
+    def test_mysql_query_first_accepts_mapper(self, connection):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(connection) as commands:
+            data = commands.query_first("select id, name from some_table", mapper=lambda row: row["id"])
+
+        assert data == 1
+
+    def test_mysql_query_first_or_default_accepts_mapper(self, connection):
+        from pydapper.mysql import MySqlConnectorPythonCommands
+
+        class MockMySqlConnectorPythonCommands(MySqlConnectorPythonCommands):
+            SqlParamHandler = MockParamHandler
+
+        with MockMySqlConnectorPythonCommands(connection) as commands:
+            data = commands.query_first_or_default(
+                "select id, name from some_table",
+                default=None,
+                mapper=lambda row: row["id"],
+            )
+
+        assert data == 1
+
     def test_mysql_query_first_treats_only_none_as_no_result(self, connection, set_fetchone_to_return_falsy_row):
         from pydapper.mysql import MySqlConnectorPythonCommands
 
@@ -1556,6 +1669,75 @@ class TestCommands:
         assert len(data) == 2
         assert all(isinstance(row, SimpleNamespace) for row in data)
 
+    def test_query_mapper_receives_raw_rows(self, connection):
+        seen_rows = []
+
+        def mapper(row):
+            seen_rows.append(row)
+            return row.columns, row.values, row[0], row["name"]
+
+        with MockCommands(connection) as commands:
+            data = commands.query("select id, name from some_table", mapper=mapper)
+
+        assert len(data) == 2
+        assert data[0][0] == ("id", "name")
+        assert data[0][1][0] == 1
+        assert data[0][2] == 1
+        assert seen_rows
+        assert all(isinstance(row, RawRow) for row in seen_rows)
+
+    def test_query_mapper_can_handle_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            data = commands.query(
+                "select id, name, id from some_table",
+                mapper=lambda row: (row.columns, row.values[0], row.values[2]),
+            )
+
+        assert data == [(("id", "name", "id"), 1, 2)]
+
+    def test_query_unbuffered_mapper_can_handle_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            generator = commands.query(
+                "select id, name, id from some_table",
+                mapper=lambda row: row.values,
+                buffered=False,
+            )
+
+            assert list(generator) == [(1, "Zach", 2)]
+
+    def test_query_unbuffered_mapper_yields_multiple_rows(self):
+        connection = _CursorConnection(_QuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob")]))
+
+        with MockCommands(connection) as commands:
+            generator = commands.query(
+                "select id, name from some_table",
+                mapper=lambda row: row[0],
+                buffered=False,
+            )
+
+            assert list(generator) == [1, 2]
+
+    @pytest.mark.parametrize("buffered", [True, False])
+    def test_query_mapper_exceptions_are_not_masked_by_cursor_context_proxy(self, buffered):
+        cursor = _TrackingContextCursor()
+
+        with pytest.raises(AttributeError, match="missing"):
+            result = MockCommands(_CursorConnection(cursor)).query(
+                "select id, name from some_table",
+                mapper=lambda row: row.missing,
+                buffered=buffered,
+            )
+            if not buffered:
+                list(result)
+
+        assert cursor.entered is True
+        assert cursor.exited is True
+
+    def test_query_rejects_model_and_mapper(self, connection):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                commands.query("select id, name from some_table", model=SimpleNamespace, mapper=lambda row: row)
+
     def test_query_rejects_duplicate_columns(self):
         with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
             with pytest.raises(DuplicateColumnException) as exc_info:
@@ -1629,6 +1811,53 @@ class TestCommands:
         assert all(isinstance(row, SimpleNamespace) for row in data1)
         assert all(isinstance(row, dict) for row in data2)
 
+    def test_query_multiple_mapper(self, connection):
+        with MockCommands(connection) as commands:
+            data1, data2 = commands.query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=(lambda row: row["id"], lambda row: row["name"]),
+            )
+
+        assert data1 == [1, 2]
+        assert len(data2) == 2
+        assert all(isinstance(name, str) for name in data2)
+
+    def test_query_multiple_single_mapper_applies_to_each_result_set(self, connection):
+        with MockCommands(connection) as commands:
+            data1, data2 = commands.query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=lambda row: row.columns,
+            )
+
+        assert data1 == [("id", "name"), ("id", "name")]
+        assert data2 == [("id", "name"), ("id", "name")]
+
+    def test_query_multiple_mapper_can_handle_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            (data,) = commands.query_multiple(
+                ("select id, name, id from some_table",),
+                mapper=lambda row: row.values,
+            )
+
+        assert data == [(1, "Zach", 2)]
+
+    def test_query_multiple_rejects_models_and_mapper(self, connection):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'models' or 'mapper'"):
+                commands.query_multiple(
+                    ("select id, name from some_table",),
+                    models=(dict,),
+                    mapper=lambda row: row,
+                )
+
+    def test_query_multiple_rejects_mapper_count_mismatch(self, connection):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Number of queries must equal number of mappers"):
+                commands.query_multiple(
+                    ("select id, name from some_table", "select id, name from another_table"),
+                    mapper=(lambda row: row,),
+                )
+
     def test_query_multiple_rejects_duplicate_columns(self):
         with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
             with pytest.raises(DuplicateColumnException) as exc_info:
@@ -1658,6 +1887,23 @@ class TestCommands:
         assert isinstance(record, SimpleNamespace)
         assert record.id
         assert record.name
+
+    def test_query_first_mapper(self, connection):
+        with MockCommands(connection) as commands:
+            record = commands.query_first("select id, name from some_table", mapper=lambda row: row["id"])
+
+        assert record == 1
+
+    def test_query_first_mapper_can_handle_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            record = commands.query_first("select id, name, id from some_table", mapper=lambda row: row.values)
+
+        assert record == (1, "Zach", 2)
+
+    def test_query_first_rejects_model_and_mapper(self, connection):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                commands.query_first("select id, name from some_table", model=dict, mapper=lambda row: row)
 
     def test_query_first_rejects_duplicate_columns(self):
         with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
@@ -1758,12 +2004,54 @@ class TestCommands:
         assert data["id"] == 1
         assert calls == []
 
+    def test_query_first_or_default_model_returns_first_row(self, connection):
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=None, model=SimpleNamespace)
+
+        assert isinstance(data, SimpleNamespace)
+        assert data.id == 1
+
+    def test_query_first_or_default_mapper_returns_first_row(self, connection):
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=None, mapper=lambda row: row[0])
+
+        assert data == 1
+
+    def test_query_first_or_default_rejects_model_and_mapper_before_default(
+        self, connection, set_fetchone_to_return_none
+    ):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                commands.query_first_or_default(
+                    "select * from some_table",
+                    default=None,
+                    model=dict,
+                    mapper=lambda row: row,
+                )
+
     def test_query_single(self, connection, set_fetchall_return_one):
         with MockCommands(connection) as commands:
             record = commands.query_single("select * from some_table")
         assert isinstance(record, dict)
         assert record["id"]
         assert record["name"]
+
+    def test_query_single_mapper(self, connection, set_fetchall_return_one):
+        with MockCommands(connection) as commands:
+            record = commands.query_single("select * from some_table", mapper=lambda row: row["id"])
+
+        assert record == 1
+
+    def test_query_single_mapper_can_handle_duplicate_columns(self):
+        with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
+            record = commands.query_single("select id, name, id from some_table", mapper=lambda row: row.values)
+
+        assert record == (1, "Zach", 2)
+
+    def test_query_single_rejects_model_and_mapper(self, connection, set_fetchall_return_one):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                commands.query_single("select * from some_table", model=dict, mapper=lambda row: row)
 
     def test_query_single_rejects_duplicate_columns(self):
         with MockCommands(_CursorConnection(_DuplicateColumnCursor())) as commands:
@@ -1895,6 +2183,33 @@ class TestCommands:
 
         assert record["id"] == 1
         assert calls == []
+
+    def test_query_single_or_default_model_returns_single_row(self, connection, set_fetchall_return_one):
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default("select * from some_table", default=None, model=SimpleNamespace)
+
+        assert isinstance(record, SimpleNamespace)
+        assert record.id == 1
+
+    def test_query_single_or_default_mapper_returns_single_row(self, connection, set_fetchall_return_one):
+        with MockCommands(connection) as commands:
+            record = commands.query_single_or_default(
+                "select * from some_table", default=None, mapper=lambda row: row[0]
+            )
+
+        assert record == 1
+
+    def test_query_single_or_default_rejects_model_and_mapper_before_default(
+        self, connection, set_fetchone_to_return_none
+    ):
+        with MockCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                commands.query_single_or_default(
+                    "select * from some_table",
+                    default=None,
+                    model=dict,
+                    mapper=lambda row: row,
+                )
 
     def test_query_single_or_default_raises_on_many_results(self, connection):
         with MockCommands(connection) as commands, pytest.raises(MoreThanOneResultException):
@@ -2166,6 +2481,66 @@ class TestCommandsAsync:
         assert all(isinstance(row, SimpleNamespace) for row in data)
 
     @pytest.mark.asyncio
+    async def test_query_mapper_receives_raw_rows(self, connection):
+        seen_rows = []
+
+        def mapper(row):
+            seen_rows.append(row)
+            return row.columns, row.values, row[0], row["name"]
+
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_async("select id, name from some_table", mapper=mapper)
+
+        assert len(data) == 2
+        assert data[0][0] == ("id", "name")
+        assert data[0][1][0] == 1
+        assert data[0][2] == 1
+        assert seen_rows
+        assert all(isinstance(row, RawRow) for row in seen_rows)
+
+    @pytest.mark.asyncio
+    async def test_query_mapper_can_handle_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            data = await commands.query_async(
+                "select id, name, id from some_table",
+                mapper=lambda row: (row.columns, row.values[0], row.values[2]),
+            )
+
+        assert data == [(("id", "name", "id"), 1, 2)]
+
+    @pytest.mark.asyncio
+    async def test_query_unbuffered_mapper_can_handle_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            generator = await commands.query_async(
+                "select id, name, id from some_table",
+                mapper=lambda row: row.values,
+                buffered=False,
+            )
+
+            assert [row async for row in generator] == [(1, "Zach", 2)]
+
+    @pytest.mark.asyncio
+    async def test_query_unbuffered_mapper_yields_multiple_rows(self):
+        connection = _AsyncCursorConnection(_AsyncQuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob")]))
+
+        async with MockAsyncCommands(connection) as commands:
+            generator = await commands.query_async(
+                "select id, name from some_table",
+                mapper=lambda row: row[0],
+                buffered=False,
+            )
+
+            assert [row async for row in generator] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_query_rejects_model_and_mapper(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                await commands.query_async(
+                    "select id, name from some_table", model=SimpleNamespace, mapper=lambda row: row
+                )
+
+    @pytest.mark.asyncio
     async def test_query_rejects_duplicate_columns(self):
         async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
             with pytest.raises(DuplicateColumnException) as exc_info:
@@ -2249,6 +2624,58 @@ class TestCommandsAsync:
         assert all(isinstance(row, dict) for row in data2)
 
     @pytest.mark.asyncio
+    async def test_query_multiple_mapper(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            data1, data2 = await commands.query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=(lambda row: row["id"], lambda row: row["name"]),
+            )
+
+        assert data1 == [1, 2]
+        assert len(data2) == 2
+        assert all(isinstance(name, str) for name in data2)
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_single_mapper_applies_to_each_result_set(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            data1, data2 = await commands.query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=lambda row: row.columns,
+            )
+
+        assert data1 == [("id", "name"), ("id", "name")]
+        assert data2 == [("id", "name"), ("id", "name")]
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_mapper_can_handle_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            (data,) = await commands.query_multiple_async(
+                ("select id, name, id from some_table",),
+                mapper=lambda row: row.values,
+            )
+
+        assert data == [(1, "Zach", 2)]
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_rejects_models_and_mapper(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'models' or 'mapper'"):
+                await commands.query_multiple_async(
+                    ("select id, name from some_table",),
+                    models=(dict,),
+                    mapper=lambda row: row,
+                )
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_rejects_mapper_count_mismatch(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Number of queries must equal number of mappers"):
+                await commands.query_multiple_async(
+                    ("select id, name from some_table", "select id, name from another_table"),
+                    mapper=(lambda row: row,),
+                )
+
+    @pytest.mark.asyncio
     async def test_query_multiple_rejects_duplicate_columns(self):
         async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
             with pytest.raises(DuplicateColumnException) as exc_info:
@@ -2282,6 +2709,29 @@ class TestCommandsAsync:
         assert isinstance(record, SimpleNamespace)
         assert record.id
         assert record.name
+
+    @pytest.mark.asyncio
+    async def test_query_first_mapper(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_first_async("select id, name from some_table", mapper=lambda row: row["id"])
+
+        assert record == 1
+
+    @pytest.mark.asyncio
+    async def test_query_first_mapper_can_handle_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            record = await commands.query_first_async(
+                "select id, name, id from some_table",
+                mapper=lambda row: row.values,
+            )
+
+        assert record == (1, "Zach", 2)
+
+    @pytest.mark.asyncio
+    async def test_query_first_rejects_model_and_mapper(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                await commands.query_first_async("select id, name from some_table", model=dict, mapper=lambda row: row)
 
     @pytest.mark.asyncio
     async def test_query_first_rejects_duplicate_columns(self):
@@ -2371,12 +2821,71 @@ class TestCommandsAsync:
         assert calls == []
 
     @pytest.mark.asyncio
+    async def test_query_first_or_default_model_returns_first_row(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async(
+                "select * from some_table",
+                default=None,
+                model=SimpleNamespace,
+            )
+
+        assert isinstance(data, SimpleNamespace)
+        assert data.id == 1
+
+    @pytest.mark.asyncio
+    async def test_query_first_or_default_mapper_returns_first_row(self, connection):
+        async with MockAsyncCommands(connection) as commands:
+            data = await commands.query_first_or_default_async(
+                "select * from some_table",
+                default=None,
+                mapper=lambda row: row[0],
+            )
+
+        assert data == 1
+
+    @pytest.mark.asyncio
+    async def test_query_first_or_default_rejects_model_and_mapper_before_default(
+        self, connection, set_fetchone_to_return_none
+    ):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                await commands.query_first_or_default_async(
+                    "select * from some_table",
+                    default=None,
+                    model=dict,
+                    mapper=lambda row: row,
+                )
+
+    @pytest.mark.asyncio
     async def test_query_single(self, connection, set_fetchall_return_one):
         async with MockAsyncCommands(connection) as commands:
             record = await commands.query_single_async("select * from some_table")
         assert isinstance(record, dict)
         assert record["id"]
         assert record["name"]
+
+    @pytest.mark.asyncio
+    async def test_query_single_mapper(self, connection, set_fetchall_return_one):
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_async("select * from some_table", mapper=lambda row: row["id"])
+
+        assert record == 1
+
+    @pytest.mark.asyncio
+    async def test_query_single_mapper_can_handle_duplicate_columns(self):
+        async with MockAsyncCommands(_AsyncCursorConnection(_AsyncDuplicateColumnCursor())) as commands:
+            record = await commands.query_single_async(
+                "select id, name, id from some_table",
+                mapper=lambda row: row.values,
+            )
+
+        assert record == (1, "Zach", 2)
+
+    @pytest.mark.asyncio
+    async def test_query_single_rejects_model_and_mapper(self, connection, set_fetchall_return_one):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                await commands.query_single_async("select * from some_table", model=dict, mapper=lambda row: row)
 
     @pytest.mark.asyncio
     async def test_query_single_rejects_duplicate_columns(self):
@@ -2516,6 +3025,42 @@ class TestCommandsAsync:
 
         assert record["id"] == 1
         assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_model_returns_single_row(self, connection, set_fetchall_return_one):
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async(
+                "select * from some_table",
+                default=None,
+                model=SimpleNamespace,
+            )
+
+        assert isinstance(record, SimpleNamespace)
+        assert record.id == 1
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_mapper_returns_single_row(self, connection, set_fetchall_return_one):
+        async with MockAsyncCommands(connection) as commands:
+            record = await commands.query_single_or_default_async(
+                "select * from some_table",
+                default=None,
+                mapper=lambda row: row[0],
+            )
+
+        assert record == 1
+
+    @pytest.mark.asyncio
+    async def test_query_single_or_default_rejects_model_and_mapper_before_default(
+        self, connection, set_fetchone_to_return_none
+    ):
+        async with MockAsyncCommands(connection) as commands:
+            with pytest.raises(ValueError, match="Pass either 'model' or 'mapper'"):
+                await commands.query_single_or_default_async(
+                    "select * from some_table",
+                    default=None,
+                    model=dict,
+                    mapper=lambda row: row,
+                )
 
     @pytest.mark.asyncio
     async def test_query_single_or_default_raises_on_many_results(self, connection):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,5 +1,8 @@
+import pickle
 from collections import UserDict
+from copy import deepcopy
 from dataclasses import FrozenInstanceError
+from dataclasses import asdict
 from dataclasses import dataclass
 from types import MappingProxyType
 from types import SimpleNamespace
@@ -287,6 +290,17 @@ class TestRawRow:
 
         with pytest.raises(TypeError):
             column_indexes["id"] = (2,)
+
+    def test_column_indexes_are_excluded_from_dataclass_and_pickle_state(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+        expected_state = {"columns": ("id", "name"), "values": (1, "Zach")}
+
+        assert asdict(row) == expected_state
+        assert row["name"] == "Zach"
+        assert asdict(row) == expected_state
+
+        assert pickle.loads(pickle.dumps(row)) == row
+        assert deepcopy(row) == row
 
     def test_name_access_raises_for_duplicate_column_name(self):
         row = RawRow(("id", "name", "id"), (1, "Zach", 2))

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1709,6 +1709,23 @@ class TestCommands:
 
         assert data is default
 
+    def test_query_first_or_default_returns_uninspectable_callable_default(
+        self, connection, set_fetchone_to_return_none, mocker
+    ):
+        calls = []
+
+        def default():
+            calls.append(None)
+            raise TypeError("factory failed")
+
+        mocker.patch("pydapper.commands.signature", side_effect=ValueError("no signature"))
+
+        with MockCommands(connection) as commands:
+            data = commands.query_first_or_default("select * from some_table", default=default)
+
+        assert data is default
+        assert calls == []
+
     def test_query_first_or_default_returns_first_row(self, connection):
         calls = []
 

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,6 +1,4 @@
-import pickle
 from collections import UserDict
-from copy import deepcopy
 from dataclasses import FrozenInstanceError
 from dataclasses import asdict
 from dataclasses import dataclass
@@ -286,21 +284,11 @@ class TestRawRow:
         assert isinstance(column_indexes, MappingProxyType)
         assert column_indexes == {"id": (0,), "name": (1,)}
         assert row.as_dict() == {"id": 1, "name": "Zach"}
+        assert asdict(row) == {"columns": ("id", "name"), "values": (1, "Zach")}
         assert row._column_indexes is column_indexes
 
         with pytest.raises(TypeError):
             column_indexes["id"] = (2,)
-
-    def test_column_indexes_are_excluded_from_dataclass_and_pickle_state(self):
-        row = RawRow(("id", "name"), (1, "Zach"))
-        expected_state = {"columns": ("id", "name"), "values": (1, "Zach")}
-
-        assert asdict(row) == expected_state
-        assert row["name"] == "Zach"
-        assert asdict(row) == expected_state
-
-        assert pickle.loads(pickle.dumps(row)) == row
-        assert deepcopy(row) == row
 
     def test_name_access_raises_for_duplicate_column_name(self):
         row = RawRow(("id", "name", "id"), (1, "Zach", 2))

--- a/tests/test_sqlite/test_sqlite3.py
+++ b/tests/test_sqlite/test_sqlite3.py
@@ -1,8 +1,10 @@
 import os
 import sqlite3
+from dataclasses import dataclass
 
 import pytest
 
+from pydapper import RawRow
 from pydapper import connect
 from pydapper import using
 from pydapper.exceptions import DuplicateColumnException
@@ -61,6 +63,62 @@ def test_join_with_aliased_id_columns_succeeds(commands, owner_table_name, task_
 
     assert rows[0] == {"task_id": 1, "owner_id": 1}
     assert list(rows[0]) == ["task_id", "owner_id"]
+
+
+def test_mapper_can_project_join_with_duplicate_columns(commands, owner_table_name, task_table_name):
+    @dataclass
+    class Owner:
+        id: int
+        name: str
+
+    @dataclass
+    class TaskWithOwner:
+        id: int
+        description: str
+        owner: Owner
+
+    def to_task(row: RawRow) -> TaskWithOwner:
+        return TaskWithOwner(
+            id=row.values[0],
+            description=row.values[1],
+            owner=Owner(id=row.values[2], name=row.values[3]),
+        )
+
+    rows = commands.query(
+        f"""
+        select
+            {task_table_name}.id,
+            {task_table_name}.description,
+            {owner_table_name}.id,
+            {owner_table_name}.name
+        from {task_table_name}
+        join {owner_table_name} on {task_table_name}.owner_id = {owner_table_name}.id
+        order by {task_table_name}.id
+        """,
+        mapper=to_task,
+    )
+
+    assert rows[0] == TaskWithOwner(
+        id=1,
+        description="Set up a test database",
+        owner=Owner(id=1, name="Zach Schumacher"),
+    )
+
+
+def test_mapper_can_use_aliases_by_name(commands, owner_table_name, task_table_name):
+    rows = commands.query(
+        f"""
+        select
+            {task_table_name}.id as task_id,
+            {owner_table_name}.name as owner_name
+        from {task_table_name}
+        join {owner_table_name} on {task_table_name}.owner_id = {owner_table_name}.id
+        order by {task_table_name}.id
+        """,
+        mapper=lambda row: {"task_id": row["task_id"], "owner_name": row.as_dict()["owner_name"]},
+    )
+
+    assert rows[0] == {"task_id": 1, "owner_name": "Zach Schumacher"}
 
 
 class TestExecute(ExecuteTestSuite): ...

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -43,7 +43,20 @@ def default_callable() -> str:
     return "sup"
 
 
+def to_task(row: pydapper.RawRow) -> Task:
+    return Task(
+        id=row.values[0],
+        description=row.values[1],
+        due_date=row.values[2],
+        owner_id=row.values[3],
+    )
+
+
 def public_exceptions() -> None:
+    assert_type(pydapper.RawRow(("id",), (1,)), pydapper.RawRow)
+    assert_type(pydapper.RawRow(("id",), (1,)).columns, Tuple[str, ...])
+    assert_type(pydapper.RawRow(("id",), (1,)).values, Tuple[Any, ...])
+    assert_type(pydapper.RawRow(("id",), (1,)).as_dict(), Dict[str, Any])
     assert_type(PyDapperException(), PyDapperException)
     assert_type(
         DuplicateColumnException(
@@ -82,6 +95,7 @@ class Commands:
             assert_type(commands.execute_scalar(query, params=params), Any)
             assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
             assert_type(commands.query_multiple((query,), params=params), Tuple[List[Any], ...])
+            assert_type(commands.query_multiple((query,), mapper=to_task), Tuple[List[Any], ...])
 
     @staticmethod
     def query(query: str) -> None:
@@ -95,11 +109,14 @@ class Commands:
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
             assert_type(commands.query(query, model=Task, buffered=True), List[Task])
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
+            assert_type(commands.query(query, mapper=to_task), List[Task])
+            assert_type(commands.query(query, params=params, mapper=to_task), List[Task])
             assert_type(
                 commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False),
                 Generator[Task, None, None],
             )
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
+            assert_type(commands.query(query, mapper=to_task, buffered=False), Generator[Task, None, None])
             assert_type(commands.query(query, param=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=mapping_subclass_params), List[Dict[str, Any]])
@@ -114,9 +131,11 @@ class Commands:
         with pydapper.connect() as commands:
             assert_type(commands.query_first(query), Dict[str, Any])
             assert_type(commands.query_first(query, model=Task), Task)
+            assert_type(commands.query_first(query, mapper=to_task), Task)
             assert_type(commands.query_first(query, param=params), Dict[str, Any])
             assert_type(commands.query_first(query, params=params), Dict[str, Any])
             assert_type(commands.query_first(query, params=params, model=Task), Task)
+            assert_type(commands.query_first(query, params=params, mapper=to_task), Task)
 
     @staticmethod
     def query_first_or_default(query: str) -> None:
@@ -125,9 +144,11 @@ class Commands:
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(commands.query_first_or_default(query, default_callable, model=Task), Union[str, Task])
+            assert_type(commands.query_first_or_default(query, default_callable, mapper=to_task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, default_callable), Union[str, Dict[str, Any]])
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(commands.query_first_or_default(query, "hello", model=Task), Union[str, Task])
+            assert_type(commands.query_first_or_default(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(commands.query_first_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
             assert_type(commands.query_first_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
@@ -139,9 +160,11 @@ class Commands:
         with pydapper.connect() as commands:
             assert_type(commands.query_single(query), Dict[str, Any])
             assert_type(commands.query_single(query, model=Task), Task)
+            assert_type(commands.query_single(query, mapper=to_task), Task)
             assert_type(commands.query_single(query, param=params), Dict[str, Any])
             assert_type(commands.query_single(query, params=params), Dict[str, Any])
             assert_type(commands.query_single(query, params=params, model=Task), Task)
+            assert_type(commands.query_single(query, params=params, mapper=to_task), Task)
 
     @staticmethod
     def query_single_or_default(query: str) -> None:
@@ -150,9 +173,11 @@ class Commands:
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
             assert_type(commands.query_single_or_default(query, default_callable, model=Task), Union[str, Task])
+            assert_type(commands.query_single_or_default(query, default_callable, mapper=to_task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, default_callable), Union[str, Dict[str, Any]])
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(commands.query_single_or_default(query, "hello", model=Task), Union[str, Task])
+            assert_type(commands.query_single_or_default(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(commands.query_single_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
             assert_type(commands.query_single_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
@@ -179,6 +204,7 @@ class CommandsAsync:
             assert_type(await commands.execute_scalar_async(query, params=params), Any)
             assert_type(await commands.query_multiple_async((query,), param=params), Tuple[List[Any], ...])
             assert_type(await commands.query_multiple_async((query,), params=params), Tuple[List[Any], ...])
+            assert_type(await commands.query_multiple_async((query,), mapper=to_task), Tuple[List[Any], ...])
 
     @staticmethod
     async def query(query: str):
@@ -192,6 +218,8 @@ class CommandsAsync:
             assert_type(await commands.query_async(query, buffered=False), AsyncGenerator[Dict[str, Any], None])
             assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
+            assert_type(await commands.query_async(query, mapper=to_task), List[Task])
+            assert_type(await commands.query_async(query, mapper=to_task, buffered=False), AsyncGenerator[Task, None])
             assert_type(await commands.query_async(query, param=params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=mapping_subclass_params), List[Dict[str, Any]])
@@ -206,9 +234,11 @@ class CommandsAsync:
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_first_async(query), Dict[str, Any])
             assert_type(await commands.query_first_async(query, model=Task), Task)
+            assert_type(await commands.query_first_async(query, mapper=to_task), Task)
             assert_type(await commands.query_first_async(query, param=params), Dict[str, Any])
             assert_type(await commands.query_first_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_first_async(query, params=params, model=Task), Task)
+            assert_type(await commands.query_first_async(query, params=params, mapper=to_task), Task)
 
     @staticmethod
     async def query_first_or_default(query: str) -> None:
@@ -220,10 +250,14 @@ class CommandsAsync:
                 await commands.query_first_or_default_async(query, default_callable, model=Task), Union[str, Task]
             )
             assert_type(
+                await commands.query_first_or_default_async(query, default_callable, mapper=to_task), Union[str, Task]
+            )
+            assert_type(
                 await commands.query_first_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
             )
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(await commands.query_first_or_default_async(query, "hello", model=Task), Union[str, Task])
+            assert_type(await commands.query_first_or_default_async(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(await commands.query_first_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(
                 await commands.query_first_or_default_async(query, "hello", param=params), Union[str, Dict[str, Any]]
@@ -239,9 +273,11 @@ class CommandsAsync:
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_single_async(query), Dict[str, Any])
             assert_type(await commands.query_single_async(query, model=Task), Task)
+            assert_type(await commands.query_single_async(query, mapper=to_task), Task)
             assert_type(await commands.query_single_async(query, param=params), Dict[str, Any])
             assert_type(await commands.query_single_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_single_async(query, params=params, model=Task), Task)
+            assert_type(await commands.query_single_async(query, params=params, mapper=to_task), Task)
 
     @staticmethod
     async def query_single_or_default(query: str) -> None:
@@ -253,10 +289,14 @@ class CommandsAsync:
                 await commands.query_single_or_default_async(query, default_callable, model=Task), Union[str, Task]
             )
             assert_type(
+                await commands.query_single_or_default_async(query, default_callable, mapper=to_task), Union[str, Task]
+            )
+            assert_type(
                 await commands.query_single_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
             )
             # passing a non-callable, the return type of the callable is a union of the model + default type
             assert_type(await commands.query_single_or_default_async(query, "hello", model=Task), Union[str, Task])
+            assert_type(await commands.query_single_or_default_async(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(await commands.query_single_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(
                 await commands.query_single_or_default_async(query, "hello", param=params), Union[str, Dict[str, Any]]


### PR DESCRIPTION
## Stack

This is the base PR for the stack.

1. This PR - callable default handling
2. #525 - raw row mapper runtime API
3. #527 - mapper typing and type-test hardening
4. #528 - mapper docs and reference cleanup

## What changed

`query_first_or_default`, `query_single_or_default`, and their async variants now resolve callable defaults more carefully.

Callable defaults that accept no arguments are still called when no row is returned. Callable values that require arguments are returned unchanged instead of being called with the wrong arity.

## Before / after

Before:

```python
commands.query_first_or_default("select ...", default=needs_row_argument)
```

would try to call `needs_row_argument()` on an empty result and raise `TypeError`.

After:

```python
commands.query_first_or_default("select ...", default=needs_row_argument)
```

returns the callable itself, while no-arg factories such as `dict` and `set` are still called.

## Checks

- `poetry run pytest tests/test_commands_interface.py::TestCommands::test_query_first_or_default_calls_builtin_default_factory_on_no_result tests/test_commands_interface.py::TestCommands::test_query_first_or_default_returns_callable_default_that_requires_args tests/test_commands_interface.py::TestCommands::test_query_single_or_default_calls_builtin_default_factory_on_no_result tests/test_commands_interface.py::TestCommands::test_query_single_or_default_returns_callable_default_that_requires_args tests/test_commands_interface.py::TestCommandsAsync::test_query_first_or_default_calls_builtin_default_factory_on_no_result tests/test_commands_interface.py::TestCommandsAsync::test_query_first_or_default_returns_callable_default_that_requires_args tests/test_commands_interface.py::TestCommandsAsync::test_query_single_or_default_calls_builtin_default_factory_on_no_result tests/test_commands_interface.py::TestCommandsAsync::test_query_single_or_default_returns_callable_default_that_requires_args -q` - 8 passed
- `poetry run mypy pydapper` - passed
- `poetry run black --check pydapper/commands.py tests/test_commands_interface.py` - passed
- `poetry run isort --check pydapper/commands.py tests/test_commands_interface.py` - passed

## Skipped

Driver-specific optional integrations were skipped because this only changes shared default handling and mock-backed core command behavior.

## Impact

No dependency or optional-extra changes. This is a small runtime compatibility improvement and the base of the mapper PR stack.

----
## Summary by Gitar

- **New feature:**
  - Added `RawRow` class to allow row-level access to cursor data, including support for duplicate column names.
  - Introduced `mapper` keyword argument to `query`, `query_multiple`, `query_first`, and `query_single` (and async variants) as an alternative to `model`.
- **Improved functionality:**
  - Integrated `RawRow` support across all primary query methods, allowing for positional index access or mapping via `RawRow.as_dict()`.
  - Added `_resolve_row_projector` and `_project_row` to manage the transition between standard dictionary-based model serialization and raw mapper functions.
- **Documentation:**
  - Added comprehensive guides and examples for `mapper` usage, including handling joined rows and aliased column names.
- **Bug fixes:**
  - `query_first_or_default` and `query_single_or_default` now correctly differentiate between callable default factories and callables intended as return values.

<sub>This will update automatically on new commits.</sub>