### PR TITLE
fix: harden mapper typing ux

### DIFF
--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -11,5 +11,6 @@ from .postgresql import AiopgCommands as _AioPgCommand
 from .postgresql import Psycopg2Commands as _Psycopg2Commands
 from .postgresql import Psycopg3Commands as _Psycopg3Commands
 from .postgresql import Psycopg3CommandsAsync as _Psycopg3CommandsAsync
+from .rows import Mapper
 from .rows import RawRow
 from .sqlite import Sqlite3Commands as _Sqlite3Commands

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -49,6 +49,9 @@ if TYPE_CHECKING:
     _T = TypeVar("_T")
     _Default = TypeVar("_Default")
     _MapperT = TypeVar("_MapperT")
+    _MapperT1 = TypeVar("_MapperT1")
+    _MapperT2 = TypeVar("_MapperT2")
+    _MapperT3 = TypeVar("_MapperT3")
 
 
 class _ParamAliasUnset:
@@ -112,6 +115,20 @@ def _normalize_query_multiple_mappers(queries: Tuple[str, ...], mapper):
         raise ValueError("Number of queries must equal number of mappers")
 
     return mappers
+
+
+def _resolve_default_value(default):
+    if not callable(default):
+        return default
+
+    try:
+        signature(default).bind()
+    except TypeError:
+        return default
+    except ValueError:
+        return default()
+
+    return default()
 
 
 def _is_empty_executemany_params(param: Any) -> bool:
@@ -180,20 +197,6 @@ def _is_attribute_param_record(param: Any) -> bool:
 
 def _is_param_record(param: Any) -> bool:
     return isinstance(param, Mapping) or _is_attribute_param_record(param)
-
-
-def _resolve_default_value(default):
-    if not callable(default):
-        return default
-
-    try:
-        signature(default).bind()
-    except TypeError:
-        return default
-    except ValueError:
-        return default()
-
-    return default()
 
 
 def _raise_invalid_param_record(param: Any, location: str) -> None:
@@ -453,10 +456,88 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
+        *,
         param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List[Dict[str, Any]], typing.Generator[Dict[str, Any], None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List[Dict[str, Any]], typing.Generator[Dict[str, Any], None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
         buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[False]",
+    ) -> Generator["_T", None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> Generator["_T", None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: bool,
+    ) -> Union[List["_T"], Generator["_T", None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_T"], Generator["_T", None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
     ) -> List["_T"]: ...
 
     @overload
@@ -473,9 +554,9 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
     ) -> Generator["_T", None, None]: ...
 
@@ -488,6 +569,26 @@ class Commands(BaseCommands, ABC):
         buffered: "Literal[False]",
         params: Optional["ParamType"],
     ) -> Generator["_T", None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List["_T"], Generator["_T", None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_T"], Generator["_T", None, None]]: ...
 
     @overload
     def query(
@@ -528,6 +629,26 @@ class Commands(BaseCommands, ABC):
         buffered: "Literal[False]",
         params: Optional["ParamType"],
     ) -> Generator["_MapperT", None, None]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List["_MapperT"], Generator["_MapperT", None, None]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_MapperT"], Generator["_MapperT", None, None]]: ...
 
     def query(
         self,
@@ -562,11 +683,155 @@ class Commands(BaseCommands, ABC):
     @overload
     def query_multiple(
         self,
+        queries: Tuple[str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+    ) -> Tuple[List["_MapperT1"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[
+            Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
+        ],
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        *,
+        mapper: Tuple[
+            Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
+        ],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
+
+    @overload
+    def query_multiple(
+        self,
         queries: Tuple[str, ...],
         models: None = None,
         param: Optional["ParamType"] = None,
         *,
-        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], ...]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], ...]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], Any], ...],
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -575,7 +840,7 @@ class Commands(BaseCommands, ABC):
         queries: Tuple[str, ...],
         models: None = None,
         *,
-        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        mapper: Tuple[Callable[[RawRow], Any], ...],
         params: Optional["ParamType"] = None,
     ) -> Tuple[List[Any], ...]: ...
 
@@ -643,9 +908,26 @@ class Commands(BaseCommands, ABC):
     def query_first(
         self,
         sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> "_T": ...
+
+    @overload
+    def query_first(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    @overload
+    def query_first(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> "_T": ...
 
     @overload
@@ -742,9 +1024,28 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -762,9 +1063,28 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: "_Default",
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -853,9 +1173,26 @@ class Commands(BaseCommands, ABC):
     def query_single(
         self,
         sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> "_T": ...
+
+    @overload
+    def query_single(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    @overload
+    def query_single(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> "_T": ...
 
     @overload
@@ -959,9 +1296,28 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -979,9 +1335,28 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: "_Default",
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1199,10 +1574,88 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
+        *,
         param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
         buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+        buffered: "Literal[True]" = True,
+    ) -> List["_T"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: "Literal[False]",
+    ) -> AsyncGenerator["_T", None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        buffered: "Literal[False]",
+        params: Optional["ParamType"],
+    ) -> AsyncGenerator["_T", None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        *,
+        buffered: bool,
+    ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
     ) -> List["_T"]: ...
 
     @overload
@@ -1219,9 +1672,9 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
     ) -> AsyncGenerator["_T", None]: ...
 
@@ -1234,6 +1687,26 @@ class CommandsAsync(BaseCommands, ABC):
         buffered: "Literal[False]",
         params: Optional["ParamType"],
     ) -> AsyncGenerator["_T", None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
 
     @overload
     async def query_async(
@@ -1274,6 +1747,26 @@ class CommandsAsync(BaseCommands, ABC):
         buffered: "Literal[False]",
         params: Optional["ParamType"],
     ) -> AsyncGenerator["_MapperT", None]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
+        buffered: bool,
+    ) -> Union[List["_MapperT"], AsyncGenerator["_MapperT", None]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        buffered: bool,
+        params: Optional["ParamType"],
+    ) -> Union[List["_MapperT"], AsyncGenerator["_MapperT", None]]: ...
 
     async def query_async(
         self,
@@ -1307,11 +1800,155 @@ class CommandsAsync(BaseCommands, ABC):
     @overload
     async def query_multiple_async(
         self,
+        queries: Tuple[str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+    ) -> Tuple[List["_MapperT1"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[
+            Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
+        ],
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str],
+        models: None = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str],
+        models: None = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, str, str],
+        models: None = None,
+        *,
+        mapper: Tuple[
+            Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
+        ],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
         queries: Tuple[str, ...],
         models: None = None,
         param: Optional["ParamType"] = None,
         *,
-        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        mapper: Callable[[RawRow], "_MapperT"],
+    ) -> Tuple[List["_MapperT"], ...]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        *,
+        mapper: Callable[[RawRow], "_MapperT"],
+        params: Optional["ParamType"] = None,
+    ) -> Tuple[List["_MapperT"], ...]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: None = None,
+        param: Optional["ParamType"] = None,
+        *,
+        mapper: Tuple[Callable[[RawRow], Any], ...],
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -1320,7 +1957,7 @@ class CommandsAsync(BaseCommands, ABC):
         queries: Tuple[str, ...],
         models: None = None,
         *,
-        mapper: Union[Callable[[RawRow], Any], Tuple[Callable[[RawRow], Any], ...]],
+        mapper: Tuple[Callable[[RawRow], Any], ...],
         params: Optional["ParamType"] = None,
     ) -> Tuple[List[Any], ...]: ...
 
@@ -1390,9 +2027,26 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_async(
         self,
         sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> "_T": ...
+
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> "_T": ...
 
     @overload
@@ -1489,9 +2143,28 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1509,9 +2182,28 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1602,9 +2294,26 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_async(
         self,
         sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> "_T": ...
+
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> "_T": ...
+
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> "_T": ...
 
     @overload
@@ -1706,9 +2415,28 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: Callable[[], "_Default"],
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1726,9 +2454,28 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
+        model: Union[Type["_T"], Callable[..., "_T"]],
+        *,
+        params: Optional["ParamType"],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
+        default: "_Default",
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_T"]: ...
 
     @overload

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -493,10 +493,10 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
-        buffered: "Literal[True]" = True,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -513,9 +513,9 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
     ) -> Generator["_MapperT", None, None]: ...
 
@@ -661,9 +661,9 @@ class Commands(BaseCommands, ABC):
     def query_first(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> "_MapperT": ...
 
     @overload
@@ -782,9 +782,9 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -802,9 +802,9 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -871,9 +871,9 @@ class Commands(BaseCommands, ABC):
     def query_single(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> "_MapperT": ...
 
     @overload
@@ -999,9 +999,9 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1019,9 +1019,9 @@ class Commands(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1239,10 +1239,10 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
-        buffered: "Literal[True]" = True,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
+        buffered: "Literal[True]" = True,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -1259,9 +1259,9 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
     ) -> AsyncGenerator["_MapperT", None]: ...
 
@@ -1408,9 +1408,9 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_async(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> "_MapperT": ...
 
     @overload
@@ -1529,9 +1529,9 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1549,9 +1549,9 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1620,9 +1620,9 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_async(
         self,
         sql: str,
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> "_MapperT": ...
 
     @overload
@@ -1746,9 +1746,9 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: Callable[[], "_Default"],
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1766,9 +1766,9 @@ class CommandsAsync(BaseCommands, ABC):
         self,
         sql: str,
         default: "_Default",
-        param: Optional["ParamType"] = ...,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        param: Optional["ParamType"] = ...,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload

--- a/pydapper/rows.py
+++ b/pydapper/rows.py
@@ -18,8 +18,6 @@ from .exceptions import DuplicateColumnException
 
 _MapperT = TypeVar("_MapperT")
 
-Mapper: TypeAlias = Callable[["RawRow"], _MapperT]
-
 
 @dataclass(frozen=True)
 class RawRow:
@@ -67,7 +65,10 @@ class RawRow:
     @overload
     def __getitem__(self, key: str) -> Any: ...
 
-    def __getitem__(self, key: Union[int, str]) -> Any:
+    @overload
+    def __getitem__(self, key: slice) -> Tuple[Any, ...]: ...
+
+    def __getitem__(self, key: Union[int, str, slice]) -> Any:
         if isinstance(key, str):
             return self._get_by_column_name(key)
         return self.values[key]
@@ -93,3 +94,6 @@ class RawRow:
             column_indexes = MappingProxyType({column: tuple(indexes) for column, indexes in index_lists.items()})
             object.__setattr__(self, "_column_indexes", column_indexes)
         return column_indexes
+
+
+Mapper: TypeAlias = Callable[[RawRow], _MapperT]

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
+from types import SimpleNamespace
 from typing import Any
+from typing import ClassVar
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
@@ -9,12 +11,22 @@ from typing import TypeAlias
 from typing import Union
 
 
+class SupportsDataclassFields(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
 class SupportsAttrAccess(Protocol):
-    def __getattribute__(self, item: str) -> Any: ...
+    def __getattr__(self, item: str) -> Any: ...
 
 
-ParamType: TypeAlias = Union[Mapping[str, Any], MutableMapping[str, Any], SupportsAttrAccess]
-ListParamType: TypeAlias = List[ParamType]
+ParamType: TypeAlias = Union[
+    Mapping[str, Any],
+    MutableMapping[str, Any],
+    SimpleNamespace,
+    SupportsDataclassFields,
+    SupportsAttrAccess,
+]
+ListParamType: TypeAlias = List[Any]
 
 
 class ConnectionType(Protocol):

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -1,7 +1,5 @@
 from abc import abstractmethod
-from types import SimpleNamespace
 from typing import Any
-from typing import ClassVar
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
@@ -11,22 +9,12 @@ from typing import TypeAlias
 from typing import Union
 
 
-class SupportsDataclassFields(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
-
-
 class SupportsAttrAccess(Protocol):
-    def __getattr__(self, item: str) -> Any: ...
+    def __getattribute__(self, item: str) -> Any: ...
 
 
-ParamType: TypeAlias = Union[
-    Mapping[str, Any],
-    MutableMapping[str, Any],
-    SimpleNamespace,
-    SupportsDataclassFields,
-    SupportsAttrAccess,
-]
-ListParamType: TypeAlias = List[Any]
+ParamType: TypeAlias = Union[Mapping[str, Any], MutableMapping[str, Any], SupportsAttrAccess]
+ListParamType: TypeAlias = List[ParamType]
 
 
 class ConnectionType(Protocol):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import pydapper
 from pydapper import RawRow
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
@@ -241,6 +242,20 @@ def _assert_duplicate_column_exception(exc_info):
 
 
 class TestRawRow:
+    def test_mapper_alias_resolves_runtime_type_hints_without_raw_row_import(self):
+        namespace = {}
+
+        exec(
+            "import pydapper\n"
+            "from typing import get_type_hints\n"
+            "def f(mapper: pydapper.Mapper[int]) -> None:\n"
+            "    pass\n"
+            "hints = get_type_hints(f)\n",
+            namespace,
+        )
+
+        assert namespace["hints"]["mapper"] == pydapper.Mapper[int]
+
     def test_columns_and_values_are_tuples_in_driver_order(self):
         row = RawRow(["id", "name"], [1, "Zach"])
 
@@ -289,6 +304,11 @@ class TestRawRow:
 
         with pytest.raises(TypeError):
             column_indexes["id"] = (2,)
+
+    def test_slice_access_returns_values_slice(self):
+        row = RawRow(("id", "name"), (1, "Zach"))
+
+        assert row[0:1] == (1,)
 
     def test_name_access_raises_for_duplicate_column_name(self):
         row = RawRow(("id", "name", "id"), (1, "Zach", 2))

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -52,6 +52,14 @@ def to_task(row: pydapper.RawRow) -> Task:
     )
 
 
+def to_id(row: pydapper.RawRow) -> int:
+    return row[0]
+
+
+def to_description(row: pydapper.RawRow) -> str:
+    return row[1]
+
+
 task_mapper: pydapper.Mapper[Task] = to_task
 
 
@@ -60,6 +68,7 @@ def public_exceptions() -> None:
     assert_type(pydapper.RawRow(("id",), (1,)), pydapper.RawRow)
     assert_type(pydapper.RawRow(("id",), (1,)).columns, Tuple[str, ...])
     assert_type(pydapper.RawRow(("id",), (1,)).values, Tuple[Any, ...])
+    assert_type(pydapper.RawRow(("id", "name"), (1, "task"))[0:1], Tuple[Any, ...])
     assert_type(pydapper.RawRow(("id",), (1,)).as_dict(), Dict[str, Any])
     assert_type(PyDapperException(), PyDapperException)
     assert_type(
@@ -99,7 +108,12 @@ class Commands:
             assert_type(commands.execute_scalar(query, params=params), Any)
             assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
             assert_type(commands.query_multiple((query,), params=params), Tuple[List[Any], ...])
-            assert_type(commands.query_multiple((query,), mapper=to_task), Tuple[List[Any], ...])
+            assert_type(commands.query_multiple((query,), mapper=to_task), Tuple[List[Task]])
+            assert_type(commands.query_multiple((query, query), mapper=to_task), Tuple[List[Task], List[Task]])
+            assert_type(
+                commands.query_multiple((query, query), mapper=(to_id, to_description)),
+                Tuple[List[int], List[str]],
+            )
 
     @staticmethod
     def query(query: str) -> None:
@@ -107,15 +121,45 @@ class Commands:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        buffered: bool = bool(query)
 
         with pydapper.connect() as commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
+            assert_type(
+                commands.query(query, buffered=buffered),
+                Union[List[Dict[str, Any]], Generator[Dict[str, Any], None, None]],
+            )
+            assert_type(
+                commands.query(query, params=params, buffered=buffered),
+                Union[List[Dict[str, Any]], Generator[Dict[str, Any], None, None]],
+            )
+            assert_type(commands.query(query, Task, buffered=True), List[Task])
+            assert_type(
+                commands.query(query, Task, buffered=buffered),
+                Union[List[Task], Generator[Task, None, None]],
+            )
+            assert_type(
+                commands.query(query, Task, params=params, buffered=buffered),
+                Union[List[Task], Generator[Task, None, None]],
+            )
             assert_type(commands.query(query, model=Task, buffered=True), List[Task])
+            assert_type(
+                commands.query(query, model=Task, buffered=buffered),
+                Union[List[Task], Generator[Task, None, None]],
+            )
+            assert_type(
+                commands.query(query, model=Task, params=params, buffered=buffered),
+                Union[List[Task], Generator[Task, None, None]],
+            )
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
             assert_type(commands.query(query, mapper=to_task), List[Task])
             assert_type(commands.query(query, param=params, mapper=to_task), List[Task])
             assert_type(commands.query(query, params=params, mapper=to_task), List[Task])
+            assert_type(
+                commands.query(query, mapper=to_task, buffered=buffered),
+                Union[List[Task], Generator[Task, None, None]],
+            )
             assert_type(
                 commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False),
                 Generator[Task, None, None],
@@ -126,11 +170,16 @@ class Commands:
                 commands.query(query, param=params, mapper=to_task, buffered=False),
                 Generator[Task, None, None],
             )
+            assert_type(
+                commands.query(query, params=params, mapper=to_task, buffered=False),
+                Generator[Task, None, None],
+            )
             assert_type(commands.query(query, param=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=mapping_subclass_params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=dataclass_params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=object_params), List[Dict[str, Any]])
+            assert_type(commands.query(query, Task, params=params), List[Task])
             assert_type(commands.query(query, params=params, model=Task), List[Task])
 
     @staticmethod
@@ -139,6 +188,8 @@ class Commands:
 
         with pydapper.connect() as commands:
             assert_type(commands.query_first(query), Dict[str, Any])
+            assert_type(commands.query_first(query, Task), Task)
+            assert_type(commands.query_first(query, Task, params), Task)
             assert_type(commands.query_first(query, model=Task), Task)
             assert_type(commands.query_first(query, mapper=to_task), Task)
             assert_type(commands.query_first(query, param=params, mapper=to_task), Task)
@@ -156,7 +207,12 @@ class Commands:
             assert_type(commands.query_first_or_default(query, default_callable, model=Task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, default_callable, mapper=to_task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, default_callable), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_first_or_default(query, task_mapper, mapper=to_task),
+                Union[pydapper.Mapper[Task], Task],
+            )
             # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(commands.query_first_or_default(query, "hello", Task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, "hello", model=Task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(commands.query_first_or_default(query, "hello"), Union[str, Dict[str, Any]])
@@ -169,6 +225,8 @@ class Commands:
 
         with pydapper.connect() as commands:
             assert_type(commands.query_single(query), Dict[str, Any])
+            assert_type(commands.query_single(query, Task), Task)
+            assert_type(commands.query_single(query, Task, params), Task)
             assert_type(commands.query_single(query, model=Task), Task)
             assert_type(commands.query_single(query, mapper=to_task), Task)
             assert_type(commands.query_single(query, param=params, mapper=to_task), Task)
@@ -186,7 +244,12 @@ class Commands:
             assert_type(commands.query_single_or_default(query, default_callable, model=Task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, default_callable, mapper=to_task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, default_callable), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_single_or_default(query, task_mapper, mapper=to_task),
+                Union[pydapper.Mapper[Task], Task],
+            )
             # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(commands.query_single_or_default(query, "hello", Task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, "hello", model=Task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(commands.query_single_or_default(query, "hello"), Union[str, Dict[str, Any]])
@@ -215,7 +278,15 @@ class CommandsAsync:
             assert_type(await commands.execute_scalar_async(query, params=params), Any)
             assert_type(await commands.query_multiple_async((query,), param=params), Tuple[List[Any], ...])
             assert_type(await commands.query_multiple_async((query,), params=params), Tuple[List[Any], ...])
-            assert_type(await commands.query_multiple_async((query,), mapper=to_task), Tuple[List[Any], ...])
+            assert_type(await commands.query_multiple_async((query,), mapper=to_task), Tuple[List[Task]])
+            assert_type(
+                await commands.query_multiple_async((query, query), mapper=to_task),
+                Tuple[List[Task], List[Task]],
+            )
+            assert_type(
+                await commands.query_multiple_async((query, query), mapper=(to_id, to_description)),
+                Tuple[List[int], List[str]],
+            )
 
     @staticmethod
     async def query(query: str):
@@ -223,17 +294,52 @@ class CommandsAsync:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        buffered: bool = bool(query)
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_async(query, buffered=True), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, buffered=False), AsyncGenerator[Dict[str, Any], None])
+            assert_type(
+                await commands.query_async(query, buffered=buffered),
+                Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]],
+            )
+            assert_type(
+                await commands.query_async(query, params=params, buffered=buffered),
+                Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]],
+            )
+            assert_type(await commands.query_async(query, Task, buffered=True), List[Task])
+            assert_type(
+                await commands.query_async(query, Task, buffered=buffered),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
+            assert_type(
+                await commands.query_async(query, Task, params=params, buffered=buffered),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
             assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
+            assert_type(
+                await commands.query_async(query, model=Task, buffered=buffered),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
+            assert_type(
+                await commands.query_async(query, model=Task, params=params, buffered=buffered),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
             assert_type(await commands.query_async(query, mapper=to_task), List[Task])
             assert_type(await commands.query_async(query, param=params, mapper=to_task), List[Task])
+            assert_type(await commands.query_async(query, params=params, mapper=to_task), List[Task])
             assert_type(await commands.query_async(query, mapper=to_task, buffered=False), AsyncGenerator[Task, None])
             assert_type(
+                await commands.query_async(query, mapper=to_task, buffered=buffered),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
+            assert_type(
                 await commands.query_async(query, param=params, mapper=to_task, buffered=False),
+                AsyncGenerator[Task, None],
+            )
+            assert_type(
+                await commands.query_async(query, params=params, mapper=to_task, buffered=False),
                 AsyncGenerator[Task, None],
             )
             assert_type(await commands.query_async(query, param=params), List[Dict[str, Any]])
@@ -241,6 +347,7 @@ class CommandsAsync:
             assert_type(await commands.query_async(query, params=mapping_subclass_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=dataclass_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=object_params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, Task, params=params), List[Task])
             assert_type(await commands.query_async(query, params=params, model=Task), List[Task])
 
     @staticmethod
@@ -249,6 +356,8 @@ class CommandsAsync:
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_first_async(query), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, Task), Task)
+            assert_type(await commands.query_first_async(query, Task, params), Task)
             assert_type(await commands.query_first_async(query, model=Task), Task)
             assert_type(await commands.query_first_async(query, mapper=to_task), Task)
             assert_type(await commands.query_first_async(query, param=params, mapper=to_task), Task)
@@ -272,7 +381,12 @@ class CommandsAsync:
             assert_type(
                 await commands.query_first_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
             )
+            assert_type(
+                await commands.query_first_or_default_async(query, task_mapper, mapper=to_task),
+                Union[pydapper.Mapper[Task], Task],
+            )
             # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(await commands.query_first_or_default_async(query, "hello", Task), Union[str, Task])
             assert_type(await commands.query_first_or_default_async(query, "hello", model=Task), Union[str, Task])
             assert_type(await commands.query_first_or_default_async(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(await commands.query_first_or_default_async(query, "hello"), Union[str, Dict[str, Any]])
@@ -289,6 +403,8 @@ class CommandsAsync:
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_single_async(query), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, Task), Task)
+            assert_type(await commands.query_single_async(query, Task, params), Task)
             assert_type(await commands.query_single_async(query, model=Task), Task)
             assert_type(await commands.query_single_async(query, mapper=to_task), Task)
             assert_type(await commands.query_single_async(query, param=params, mapper=to_task), Task)
@@ -312,7 +428,12 @@ class CommandsAsync:
             assert_type(
                 await commands.query_single_or_default_async(query, default_callable), Union[str, Dict[str, Any]]
             )
+            assert_type(
+                await commands.query_single_or_default_async(query, task_mapper, mapper=to_task),
+                Union[pydapper.Mapper[Task], Task],
+            )
             # passing a non-callable, the return type of the callable is a union of the model + default type
+            assert_type(await commands.query_single_or_default_async(query, "hello", Task), Union[str, Task])
             assert_type(await commands.query_single_or_default_async(query, "hello", model=Task), Union[str, Task])
             assert_type(await commands.query_single_or_default_async(query, "hello", mapper=to_task), Union[str, Task])
             assert_type(await commands.query_single_or_default_async(query, "hello"), Union[str, Dict[str, Any]])

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -52,7 +52,11 @@ def to_task(row: pydapper.RawRow) -> Task:
     )
 
 
+task_mapper: pydapper.Mapper[Task] = to_task
+
+
 def public_exceptions() -> None:
+    assert_type(task_mapper, pydapper.Mapper[Task])
     assert_type(pydapper.RawRow(("id",), (1,)), pydapper.RawRow)
     assert_type(pydapper.RawRow(("id",), (1,)).columns, Tuple[str, ...])
     assert_type(pydapper.RawRow(("id",), (1,)).values, Tuple[Any, ...])
@@ -110,6 +114,7 @@ class Commands:
             assert_type(commands.query(query, model=Task, buffered=True), List[Task])
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
             assert_type(commands.query(query, mapper=to_task), List[Task])
+            assert_type(commands.query(query, param=params, mapper=to_task), List[Task])
             assert_type(commands.query(query, params=params, mapper=to_task), List[Task])
             assert_type(
                 commands.query(query, model=lambda **kwargs: Task(**kwargs), buffered=False),
@@ -117,6 +122,10 @@ class Commands:
             )
             assert_type(commands.query(query, model=Task, buffered=False), Generator[Task, None, None])
             assert_type(commands.query(query, mapper=to_task, buffered=False), Generator[Task, None, None])
+            assert_type(
+                commands.query(query, param=params, mapper=to_task, buffered=False),
+                Generator[Task, None, None],
+            )
             assert_type(commands.query(query, param=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=mapping_subclass_params), List[Dict[str, Any]])
@@ -132,6 +141,7 @@ class Commands:
             assert_type(commands.query_first(query), Dict[str, Any])
             assert_type(commands.query_first(query, model=Task), Task)
             assert_type(commands.query_first(query, mapper=to_task), Task)
+            assert_type(commands.query_first(query, param=params, mapper=to_task), Task)
             assert_type(commands.query_first(query, param=params), Dict[str, Any])
             assert_type(commands.query_first(query, params=params), Dict[str, Any])
             assert_type(commands.query_first(query, params=params, model=Task), Task)
@@ -161,6 +171,7 @@ class Commands:
             assert_type(commands.query_single(query), Dict[str, Any])
             assert_type(commands.query_single(query, model=Task), Task)
             assert_type(commands.query_single(query, mapper=to_task), Task)
+            assert_type(commands.query_single(query, param=params, mapper=to_task), Task)
             assert_type(commands.query_single(query, param=params), Dict[str, Any])
             assert_type(commands.query_single(query, params=params), Dict[str, Any])
             assert_type(commands.query_single(query, params=params, model=Task), Task)
@@ -219,7 +230,12 @@ class CommandsAsync:
             assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
             assert_type(await commands.query_async(query, mapper=to_task), List[Task])
+            assert_type(await commands.query_async(query, param=params, mapper=to_task), List[Task])
             assert_type(await commands.query_async(query, mapper=to_task, buffered=False), AsyncGenerator[Task, None])
+            assert_type(
+                await commands.query_async(query, param=params, mapper=to_task, buffered=False),
+                AsyncGenerator[Task, None],
+            )
             assert_type(await commands.query_async(query, param=params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=mapping_subclass_params), List[Dict[str, Any]])
@@ -235,6 +251,7 @@ class CommandsAsync:
             assert_type(await commands.query_first_async(query), Dict[str, Any])
             assert_type(await commands.query_first_async(query, model=Task), Task)
             assert_type(await commands.query_first_async(query, mapper=to_task), Task)
+            assert_type(await commands.query_first_async(query, param=params, mapper=to_task), Task)
             assert_type(await commands.query_first_async(query, param=params), Dict[str, Any])
             assert_type(await commands.query_first_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_first_async(query, params=params, model=Task), Task)
@@ -274,6 +291,7 @@ class CommandsAsync:
             assert_type(await commands.query_single_async(query), Dict[str, Any])
             assert_type(await commands.query_single_async(query, model=Task), Task)
             assert_type(await commands.query_single_async(query, mapper=to_task), Task)
+            assert_type(await commands.query_single_async(query, param=params, mapper=to_task), Task)
             assert_type(await commands.query_single_async(query, param=params), Dict[str, Any])
             assert_type(await commands.query_single_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_single_async(query, params=params, model=Task), Task)

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -39,6 +39,22 @@ class ParamsDict(dict[str, Any]):
     pass
 
 
+class Params:
+    id: int
+
+    def __init__(self, id: int) -> None:
+        self.id = id
+
+
+class SlottedParams:
+    __slots__ = ("id",)
+
+    id: int
+
+    def __init__(self, id: int) -> None:
+        self.id = id
+
+
 def default_callable() -> str:
     return "sup"
 
@@ -94,6 +110,8 @@ class Commands:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        attribute_params = Params(1)
+        slotted_params = SlottedParams(1)
         batch_params = [{"id": 1}, {"id": 2}]
 
         with pydapper.connect() as commands:
@@ -102,6 +120,8 @@ class Commands:
             assert_type(commands.execute(query, params=mapping_subclass_params), int)
             assert_type(commands.execute(query, params=dataclass_params), int)
             assert_type(commands.execute(query, params=object_params), int)
+            assert_type(commands.execute(query, params=attribute_params), int)
+            assert_type(commands.execute(query, params=slotted_params), int)
             assert_type(commands.execute(query, params=[]), int)
             assert_type(commands.execute(query, params=batch_params), int)
             assert_type(commands.execute_scalar(query, param=params), Any)
@@ -121,6 +141,8 @@ class Commands:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        attribute_params = Params(1)
+        slotted_params = SlottedParams(1)
         buffered: bool = bool(query)
 
         with pydapper.connect() as commands:
@@ -179,6 +201,8 @@ class Commands:
             assert_type(commands.query(query, params=mapping_subclass_params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=dataclass_params), List[Dict[str, Any]])
             assert_type(commands.query(query, params=object_params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=attribute_params), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=slotted_params), List[Dict[str, Any]])
             assert_type(commands.query(query, Task, params=params), List[Task])
             assert_type(commands.query(query, params=params, model=Task), List[Task])
 
@@ -264,6 +288,8 @@ class CommandsAsync:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        attribute_params = Params(1)
+        slotted_params = SlottedParams(1)
         batch_params = [{"id": 1}, {"id": 2}]
 
         async with pydapper.connect_async() as commands:
@@ -272,6 +298,8 @@ class CommandsAsync:
             assert_type(await commands.execute_async(query, params=mapping_subclass_params), int)
             assert_type(await commands.execute_async(query, params=dataclass_params), int)
             assert_type(await commands.execute_async(query, params=object_params), int)
+            assert_type(await commands.execute_async(query, params=attribute_params), int)
+            assert_type(await commands.execute_async(query, params=slotted_params), int)
             assert_type(await commands.execute_async(query, params=[]), int)
             assert_type(await commands.execute_async(query, params=batch_params), int)
             assert_type(await commands.execute_scalar_async(query, param=params), Any)
@@ -294,6 +322,8 @@ class CommandsAsync:
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
+        attribute_params = Params(1)
+        slotted_params = SlottedParams(1)
         buffered: bool = bool(query)
 
         async with pydapper.connect_async() as commands:
@@ -347,6 +377,8 @@ class CommandsAsync:
             assert_type(await commands.query_async(query, params=mapping_subclass_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=dataclass_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, params=object_params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=attribute_params), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=slotted_params), List[Dict[str, Any]])
             assert_type(await commands.query_async(query, Task, params=params), List[Task])
             assert_type(await commands.query_async(query, params=params, model=Task), List[Task])
 


### PR DESCRIPTION
## Stack

Stacked on #525.

1. #526 - callable default handling
2. #525 - raw row mapper runtime API
3. This PR - mapper typing and type-test hardening
4. #528 - mapper docs and reference cleanup

## What changed

Tightens the public typing around the mapper API:

- Adds overloads so `mapper=` preserves the mapper return type on sync and async query APIs.
- Handles dynamic `buffered: bool` with a list/generator union instead of rejecting normal boolean variables.
- Improves common `query_multiple` mapper inference for one, two, and three result sets, including heterogeneous tuple mappers.
- Makes `pydapper.Mapper[T]` runtime type-hint resolution work without requiring users to import `RawRow` separately.
- Narrows supported static parameter shapes to mappings, dataclasses, `SimpleNamespace`, or objects exposing attributes via `__getattr__`.
- Extends `tests/type_tests.py` to lock the public typing behavior.

## Before / after

Before, calls such as this were valid at runtime but awkward or incorrect in type checkers:

```python
buffered: bool = should_buffer()
commands.query("select ...", mapper=to_task, buffered=buffered)
commands.query_multiple(("select ...", "select ..."), mapper=(to_id, to_name))
```

After, those calls infer useful return types:

```python
list[Task] | Generator[Task, None, None]
tuple[list[int], list[str]]
```

## Checks

- `poetry run mypy pydapper` - passed
- `poetry run mypy tests/type_tests.py` - passed
- `poetry run pytest tests/test_commands_interface.py::TestRawRow -q` - 11 passed
- Focused stacked regression subset - 8 passed
- Full top-of-stack validation also passed: `poetry run pytest -m core`, `poetry run pytest -m sqlite`, `poetry run black --check .`, `poetry run isort --check .`, `poetry run mkdocs build --strict`, and `git diff --check`.

## Skipped

Driver-specific optional integrations were skipped because this PR changes static typing and shared mock-backed behavior, not real driver integrations.

## Impact

Public typing impact only. No mandatory dependency or optional-extra changes.
