### PR TITLE
fix: guarantee query cursor cleanup

### DIFF
--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -57,7 +57,18 @@ Use `mapper=` when a join intentionally selects duplicate column names or when p
 By default, `query_async` fetches all results and stores them in a list (buffered). By setting `buffered=False`, you can
 instead have `query_async` return an async generator that fetches one record from the result set at a time. This may be
 useful if querying a large amount of data that would not fit into memory, but note that this keeps both the connection
-and cursor open while you're retrieving results.
+and cursor open while you're retrieving results. Breaking out of a plain async generator does not by itself guarantee
+immediate cleanup while the generator remains referenced, so explicitly close it when stopping early.
+
+```python
+rows = await db.query_async(sql, buffered=False)
+try:
+    async for row in rows:
+        break
+finally:
+    await rows.aclose()
+```
+
 ```python
 {!docs/../docs_src/async_methods/query/query_unbuffered.py!}
 ```

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -57,7 +57,18 @@ Use `mapper=` when a join intentionally selects duplicate column names or when p
 By default, `query` fetches all results and stores them in a list (buffered).  By setting `buffered=False`, you can
 instead have `query` act as a generator function, fetching one record from the result set at a time.  This may be useful
 if querying a large amount of data that would not fit into memory, but note that this keeps both the connection and
-cursor open while you're retrieving results.
+cursor open while you're retrieving results. Breaking out of a plain generator does not by itself guarantee immediate
+cleanup while the generator remains referenced, so explicitly close it when stopping early.
+
+```python
+rows = db.query(sql, buffered=False)
+try:
+    for row in rows:
+        break
+finally:
+    rows.close()
+```
+
 ```python
 {!docs/../docs_src/methods/query/query_unbuffered.py!}
 ```

--- a/docs_src/async_methods/query/query_unbuffered.py
+++ b/docs_src/async_methods/query/query_unbuffered.py
@@ -5,17 +5,17 @@ from pydapper import connect_async
 
 async def main():
     async with connect_async() as commands:
-        data = await commands.query_async("select * from task", buffered=False)
+        rows = await commands.query_async("select * from task", buffered=False)
 
-        print(type(data))
+        print(type(rows))
         # <class 'async_generator'>
 
-        async for row in data:
-            print(row)
-
-        # {'id': 1, 'description': 'Set up a test database', 'due_date': datetime.date(2021, 12, 31), 'owner_id': 1}
-        # {'id': 2, 'description': 'Seed the test database', 'due_date': datetime.date(2021, 12, 31), 'owner_id': 1}
-        # {'id': 3, 'description': 'Run the test suite', 'due_date': datetime.date(2022, 1, 1), 'owner_id': 1}
+        try:
+            async for row in rows:
+                print(row)
+                break
+        finally:
+            await rows.aclose()
 
 
 asyncio.run(main())

--- a/docs_src/methods/query/query_unbuffered.py
+++ b/docs_src/methods/query/query_unbuffered.py
@@ -1,6 +1,13 @@
 from pydapper import connect
 
 with connect() as commands:
-    data = commands.query("select * from task", buffered=False)
-    print(type(data))
+    rows = commands.query("select * from task", buffered=False)
+    print(type(rows))
     # <class 'generator'>
+
+    try:
+        for row in rows:
+            print(row)
+            break
+    finally:
+        rows.close()

--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -1,3 +1,4 @@
+from inspect import isawaitable
 from types import TracebackType
 from typing import Any
 from typing import Coroutine
@@ -47,11 +48,31 @@ class CoroContextManager(Coroutine[Any, Any, _TObj], Generic[_TObj]):
     async def __aenter__(self) -> _TObj:
         if self._obj is None:  # pragma: no branch
             self._obj = await self._coro
-        if hasattr(self._obj, "__aenter__"):  # pragma: no branch
-            await self._obj.__aenter__()  # type: ignore
-        assert self._obj
+        enter = getattr(type(self._obj), "__aenter__", None)
+        exit = getattr(type(self._obj), "__aexit__", None)
+        if callable(enter) and callable(exit):  # pragma: no branch
+            entered_obj = enter(self._obj)
+            self._obj = await entered_obj if isawaitable(entered_obj) else entered_obj
         return self._obj
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if hasattr(self._obj, "__aexit__"):  # pragma: no branch
-            await self._obj.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore
+        exit = getattr(type(self._obj), "__aexit__", None)
+        if callable(exit):  # pragma: no branch
+            try:
+                result = exit(self._obj, exc_type, exc_val, exc_tb)
+                return await result if isawaitable(result) else result
+            except BaseException:
+                if exc_type is not None:
+                    return False
+                raise
+
+        close = getattr(self._obj, "close", None)
+        if callable(close):
+            try:
+                result = close()
+                if isawaitable(result):
+                    await result
+            except BaseException:
+                if exc_type is not None:
+                    return False
+                raise

--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -12,17 +12,27 @@ from typing import Union
 _TObj = TypeVar("_TObj")
 
 
-class CoroContextManager(Coroutine[Any, Any, _TObj], Generic[_TObj]):
+async def _await_if_needed(value: Any) -> Any:
+    return await value if isawaitable(value) else value
 
-    __slots__ = ("_coro", "_obj")
+
+class CoroContextManager(Coroutine[Any, Any, _TObj], Generic[_TObj]):
+    """Wrap an awaitable resource for use with ``async with``."""
+
+    __slots__ = ("_coro", "_obj", "_entered_obj", "_aexit", "_preserve_active_error")
 
     def __init__(
         self,
         coro: Coroutine[Any, Any, _TObj],
         obj: _TObj = None,
+        *,
+        preserve_active_error: bool = False,
     ):
         self._coro = coro
         self._obj = obj
+        self._entered_obj = obj
+        self._aexit = None
+        self._preserve_active_error = preserve_active_error
 
     def send(self, value: Any) -> "Any":  # pragma: no cover
         return self._coro.send(value)
@@ -48,31 +58,26 @@ class CoroContextManager(Coroutine[Any, Any, _TObj], Generic[_TObj]):
     async def __aenter__(self) -> _TObj:
         if self._obj is None:  # pragma: no branch
             self._obj = await self._coro
+
         enter = getattr(type(self._obj), "__aenter__", None)
-        exit = getattr(type(self._obj), "__aexit__", None)
-        if callable(enter) and callable(exit):  # pragma: no branch
-            entered_obj = enter(self._obj)
-            self._obj = await entered_obj if isawaitable(entered_obj) else entered_obj
-        return self._obj
+        aexit = getattr(type(self._obj), "__aexit__", None)
+        self._aexit = None
+        if callable(enter) and callable(aexit):  # pragma: no branch
+            self._entered_obj = await _await_if_needed(enter(self._obj))
+            self._aexit = aexit
+        else:
+            self._entered_obj = self._obj
+        return self._entered_obj
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        exit = getattr(type(self._obj), "__aexit__", None)
-        if callable(exit):  # pragma: no branch
-            try:
-                result = exit(self._obj, exc_type, exc_val, exc_tb)
-                return await result if isawaitable(result) else result
-            except BaseException:
-                if exc_type is not None:
-                    return False
-                raise
+        try:
+            if self._aexit is not None:
+                return await _await_if_needed(self._aexit(self._obj, exc_type, exc_val, exc_tb))
 
-        close = getattr(self._obj, "close", None)
-        if callable(close):
-            try:
-                result = close()
-                if isawaitable(result):
-                    await result
-            except BaseException:
-                if exc_type is not None:
-                    return False
-                raise
+            close = getattr(self._obj, "close", None)
+            if callable(close):
+                await _await_if_needed(close())
+        except BaseException:
+            if self._preserve_active_error and exc_type is not None:
+                return False
+            raise

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1492,7 +1492,7 @@ class CommandsAsync(BaseCommands, ABC):
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync": ...
 
     def cursor(self, *args, **kwargs) -> "CoroContextManager[AsyncCursorType]":
-        return CoroContextManager(self.connection.cursor(*args, **kwargs))
+        return CoroContextManager(self.connection.cursor(*args, **kwargs), preserve_active_error=True)
 
     @overload
     async def execute_async(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1,8 +1,8 @@
+import sys
 import typing
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Mapping
-from contextlib import ExitStack
 from contextlib import contextmanager
 from dataclasses import is_dataclass
 from functools import cached_property
@@ -334,12 +334,40 @@ class Commands(BaseCommands, ABC):
     @contextmanager
     def _cursor_context_proxy(self):
         """Not all dbapis implement the cursor as a context manager.  This function handles that polymorphism."""
-        with ExitStack() as stack:
+        cursor = self.cursor()
+        enter = getattr(type(cursor), "__enter__", None)
+        exit = getattr(type(cursor), "__exit__", None)
+
+        if callable(enter) and callable(exit):
+            entered_cursor = enter(cursor)
             try:
-                cursor = stack.enter_context(self.cursor())  # type: ignore
-            except (AttributeError, TypeError):
-                cursor = self.cursor()
+                yield entered_cursor
+            except BaseException:
+                exc_type, exc_val, exc_tb = sys.exc_info()
+                try:
+                    if exit(cursor, exc_type, exc_val, exc_tb):
+                        return
+                except BaseException:
+                    pass
+                raise
+            else:
+                exit(cursor, None, None, None)
+            return
+
+        try:
             yield cursor
+        except BaseException:
+            try:
+                close = getattr(cursor, "close", None)
+                if callable(close):
+                    close()
+            except BaseException:
+                pass
+            raise
+        else:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
 
     def cursor(self, *args, **kwargs) -> "CursorType":
         return self.connection.cursor(*args, **kwargs)

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -47,4 +47,4 @@ class Psycopg3CommandsAsync(CommandsAsync):
         async def cursor_proxy():
             return self.connection.cursor(*args, **kwargs)
 
-        return CoroContextManager(cursor_proxy())
+        return CoroContextManager(cursor_proxy(), preserve_active_error=True)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1210,6 +1210,37 @@ class TestCommands:
         assert records == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
         assert connection.cursor_calls == 1
 
+    def test_cursor_context_proxy_allows_cursor_to_suppress_error(self):
+        class SuppressingCursor:
+            def __init__(self):
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_args = exc_type, exc_val, exc_tb
+                return True
+
+        cursor = SuppressingCursor()
+
+        with MockCommands(_CursorConnection(cursor))._cursor_context_proxy():
+            raise RuntimeError("query failed")
+
+        assert cursor.exit_args[0] is RuntimeError
+
+    def test_cursor_context_proxy_preserves_error_when_cursor_exit_fails(self):
+        class FailingExitCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                raise RuntimeError("close failed")
+
+        with pytest.raises(ValueError, match="query failed"):
+            with MockCommands(_CursorConnection(FailingExitCursor()))._cursor_context_proxy():
+                raise ValueError("query failed")
+
     def test_execute(self, connection):
         with MockCommands(connection) as commands:
             affected_rows = commands.execute(

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -120,6 +120,78 @@ class _CursorConnection:
         return self.cursor_instance
 
 
+class _PlainQueryCursor:
+    description = ("id", "int"), ("name", "text")
+    rowcount = 0
+
+    def __init__(self, rows=((1, "Zach"), (2, "Bob"))):
+        self.rows = list(rows)
+        self.close_calls = 0
+        self.execute_error = None
+        self.fetchall_error = None
+        self.fetchone_error = None
+        self.close_error = None
+
+    def execute(self, sql, parameters=None):
+        if self.execute_error:
+            raise self.execute_error
+
+    def fetchall(self):
+        if self.fetchall_error:
+            raise self.fetchall_error
+        return tuple(self.rows)
+
+    def fetchone(self):
+        if self.fetchone_error:
+            raise self.fetchone_error
+        return self.rows.pop(0) if self.rows else None
+
+    def close(self):
+        self.close_calls += 1
+        if self.close_error:
+            raise self.close_error
+
+
+class _PlainAsyncQueryCursor:
+    description = ("id", "int"), ("name", "text")
+    rowcount = 0
+
+    def __init__(self, rows=((1, "Zach"), (2, "Bob"))):
+        self.rows = list(rows)
+        self.close_calls = 0
+        self.execute_error = None
+        self.fetchall_error = None
+        self.fetchone_error = None
+        self.close_error = None
+
+    async def execute(self, sql, parameters=None):
+        if self.execute_error:
+            raise self.execute_error
+
+    async def fetchall(self):
+        if self.fetchall_error:
+            raise self.fetchall_error
+        return tuple(self.rows)
+
+    async def fetchone(self):
+        if self.fetchone_error:
+            raise self.fetchone_error
+        return self.rows.pop(0) if self.rows else None
+
+    async def close(self):
+        self.close_calls += 1
+        if self.close_error:
+            raise self.close_error
+
+
+class _PlainAsyncQueryConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+
+    async def cursor(self, *args, **kwargs):
+        return self.cursor_instance
+
+
 class _TrackingContextCursor:
     rowcount = 0
     description = ("id", "int"), ("name", "text")
@@ -1136,7 +1208,7 @@ class TestCommands:
         records = MockCommands(connection).query("select id, name from some_table")
 
         assert records == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
-        assert connection.cursor_calls == 2
+        assert connection.cursor_calls == 1
 
     def test_execute(self, connection):
         with MockCommands(connection) as commands:
@@ -1782,6 +1854,83 @@ class TestCommands:
 
         assert cursor.entered is True
         assert cursor.exited is True
+
+    def test_plain_cursor_is_closed_after_buffered_query(self):
+        cursor = _PlainQueryCursor()
+
+        assert MockCommands(_CursorConnection(cursor)).query("select id, name from some_table") == [
+            {"id": 1, "name": "Zach"},
+            {"id": 2, "name": "Bob"},
+        ]
+        assert cursor.close_calls == 1
+
+    def test_plain_cursor_cleanup_preserves_buffered_failure(self):
+        cursor = _PlainQueryCursor()
+        cursor.fetchall_error = RuntimeError("fetch failed")
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            MockCommands(_CursorConnection(cursor)).query("select id, name from some_table")
+
+        assert cursor.close_calls == 1
+
+    def test_plain_cursor_cleanup_failure_does_not_mask_buffered_failure(self):
+        cursor = _PlainQueryCursor()
+        cursor.fetchall_error = RuntimeError("fetch failed")
+        cursor.close_error = RuntimeError("close failed")
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            MockCommands(_CursorConnection(cursor)).query("select id, name from some_table")
+
+    def test_plain_cursor_is_closed_when_projection_fails(self):
+        cursor = _PlainQueryCursor()
+
+        with pytest.raises(RuntimeError, match="projection failed"):
+            MockCommands(_CursorConnection(cursor)).query(
+                "select id, name from some_table",
+                mapper=lambda row: (_ for _ in ()).throw(RuntimeError("projection failed")),
+            )
+
+        assert cursor.close_calls == 1
+
+    def test_plain_cursor_is_closed_by_unbuffered_generator_close(self):
+        cursor = _PlainQueryCursor()
+        rows = MockCommands(_CursorConnection(cursor)).query("select id, name from some_table", buffered=False)
+
+        assert next(rows) == {"id": 1, "name": "Zach"}
+        rows.close()
+        assert cursor.close_calls == 1
+
+    def test_plain_cursor_is_closed_after_unbuffered_exhaustion(self):
+        cursor = _PlainQueryCursor()
+        rows = MockCommands(_CursorConnection(cursor)).query("select id, name from some_table", buffered=False)
+
+        assert list(rows) == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
+        assert cursor.close_calls == 1
+
+    def test_plain_cursor_cleanup_preserves_unbuffered_failure(self):
+        cursor = _PlainQueryCursor()
+        cursor.fetchone_error = RuntimeError("fetch failed")
+        rows = MockCommands(_CursorConnection(cursor)).query("select id, name from some_table", buffered=False)
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            next(rows)
+
+        assert cursor.close_calls == 1
+
+    def test_cursor_context_error_is_not_mistaken_for_plain_cursor(self):
+        class FailingContextCursor(_PlainQueryCursor):
+            def __enter__(self):
+                raise AttributeError("query context failed")
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.close()
+
+        cursor = FailingContextCursor()
+
+        with pytest.raises(AttributeError, match="query context failed"):
+            MockCommands(_CursorConnection(cursor)).query("select id, name from some_table")
+
+        assert cursor.close_calls == 0
 
     def test_query_rejects_model_and_mapper(self, connection):
         with MockCommands(connection) as commands:
@@ -2581,6 +2730,80 @@ class TestCommandsAsync:
             )
 
             assert [row async for row in generator] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_is_closed_after_buffered_query(self):
+        cursor = _PlainAsyncQueryCursor()
+
+        assert await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async(
+            "select id, name from some_table"
+        ) == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_cleanup_preserves_buffered_failure(self):
+        cursor = _PlainAsyncQueryCursor()
+        cursor.fetchall_error = RuntimeError("fetch failed")
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async("select id, name from some_table")
+
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_cleanup_failure_does_not_mask_buffered_failure(self):
+        cursor = _PlainAsyncQueryCursor()
+        cursor.fetchall_error = RuntimeError("fetch failed")
+        cursor.close_error = RuntimeError("close failed")
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async("select id, name from some_table")
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_is_closed_when_projection_fails(self):
+        cursor = _PlainAsyncQueryCursor()
+
+        with pytest.raises(RuntimeError, match="projection failed"):
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async(
+                "select id, name from some_table",
+                mapper=lambda row: (_ for _ in ()).throw(RuntimeError("projection failed")),
+            )
+
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_is_closed_by_unbuffered_generator_aclose(self):
+        cursor = _PlainAsyncQueryCursor()
+        rows = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async(
+            "select id, name from some_table", buffered=False
+        )
+
+        assert await rows.__anext__() == {"id": 1, "name": "Zach"}
+        await rows.aclose()
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_is_closed_after_unbuffered_exhaustion(self):
+        cursor = _PlainAsyncQueryCursor()
+        rows = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async(
+            "select id, name from some_table", buffered=False
+        )
+
+        assert [row async for row in rows] == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_plain_cursor_cleanup_preserves_unbuffered_failure(self):
+        cursor = _PlainAsyncQueryCursor()
+        cursor.fetchone_error = RuntimeError("fetch failed")
+        rows = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async(
+            "select id, name from some_table", buffered=False
+        )
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            await rows.__anext__()
+
+        assert cursor.close_calls == 1
 
     @pytest.mark.asyncio
     async def test_query_rejects_model_and_mapper(self, connection):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2760,6 +2760,20 @@ class TestCommandsAsync:
             await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async("select id, name from some_table")
 
     @pytest.mark.asyncio
+    async def test_context_managed_cursor_cleanup_failure_does_not_mask_buffered_failure(self):
+        class FailingExitCursor(MockAsyncCursor):
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                raise RuntimeError("close failed")
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError, match="projection failed"):
+            await MockAsyncCommands(_AsyncCursorConnection(cursor)).query_async(
+                "select id, name from some_table",
+                mapper=lambda row: (_ for _ in ()).throw(RuntimeError("projection failed")),
+            )
+
+    @pytest.mark.asyncio
     async def test_plain_cursor_is_closed_when_projection_fails(self):
         cursor = _PlainAsyncQueryCursor()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -34,6 +34,26 @@ class PlainObject:
         return self.close_result
 
 
+class ProxyContextManager:
+    def __init__(self):
+        self.entered_obj = object()
+        self.exited = False
+
+    async def __aenter__(self):
+        return self.entered_obj
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.exited = True
+
+
+class FailingContextManager:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        raise RuntimeError("exit failed")
+
+
 @pytest.mark.asyncio
 class TestCoroContextManager:
     async def test__init__(self):
@@ -49,6 +69,23 @@ class TestCoroContextManager:
             assert isinstance(myobj, MyObject)
             assert myobj.some_value == 1
         assert myobj.some_value == 0
+
+    async def test_context_manager_exits_original_object_when_enter_returns_proxy(self):
+        obj = ProxyContextManager()
+
+        async with CoroContextManager(asyncio.sleep(0, result=obj)) as entered:
+            assert entered is obj.entered_obj
+
+        assert obj.exited is True
+
+    async def test_context_manager_cleanup_failure_is_not_suppressed(self):
+        obj = FailingContextManager()
+
+        with pytest.raises(RuntimeError, match="exit failed") as exc_info:
+            async with CoroContextManager(asyncio.sleep(0, result=obj)):
+                raise ValueError("body failed")
+
+        assert isinstance(exc_info.value.__context__, ValueError)
 
     async def test_plain_object_is_closed(self):
         obj = PlainObject()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -24,6 +24,16 @@ class MyObject:
         return cls()
 
 
+class PlainObject:
+    def __init__(self, close_result=None):
+        self.closed = False
+        self.close_result = close_result
+
+    def close(self):
+        self.closed = True
+        return self.close_result
+
+
 @pytest.mark.asyncio
 class TestCoroContextManager:
     async def test__init__(self):
@@ -39,3 +49,26 @@ class TestCoroContextManager:
             assert isinstance(myobj, MyObject)
             assert myobj.some_value == 1
         assert myobj.some_value == 0
+
+    async def test_plain_object_is_closed(self):
+        obj = PlainObject()
+
+        async with CoroContextManager(asyncio.sleep(0, result=obj)) as entered:
+            assert entered is obj
+
+        assert obj.closed is True
+
+    async def test_plain_object_awaits_close(self):
+        closed = False
+
+        async def close():
+            nonlocal closed
+            closed = True
+
+        obj = PlainObject(close())
+
+        async with CoroContextManager(asyncio.sleep(0, result=obj)):
+            pass
+
+        assert obj.closed is True
+        assert closed is True

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,6 +4,8 @@ import pytest
 
 from pydapper._context import CoroContextManager
 
+pytestmark = pytest.mark.core
+
 
 class MyObject:
     def __init__(self):


### PR DESCRIPTION
## What changed

Guarantees deterministic cursor cleanup across buffered and unbuffered sync and async queries. Plain cursors are acquired once and closed on success, exhaustion, explicit generator shutdown, and error paths. Cleanup failures do not mask the original query error, while existing cursor context-manager behavior and adapter cleanup hooks are preserved.

Documentation now explains that breaking from a referenced generator does not guarantee immediate cleanup and shows explicit close()/aclose() patterns.

Closes #462

## Verification

- poetry run pytest tests/test_commands_interface.py — 323 passed
- poetry run pytest tests/test_context.py — 4 passed
- poetry run pytest -m core — 425 passed, 212 deselected
- poetry run pytest -m sqlite — 29 passed, 608 deselected
- poetry run mypy pydapper — passed
- poetry run mypy tests/type_tests.py — passed
- poetry run black --check . — passed
- poetry run isort --check . — passed
- poetry run mkdocs build --strict — passed

Post-change focused verification: 327 passed across tests/test_commands_interface.py and tests/test_context.py.

Driver-specific PostgreSQL, MSSQL, MySQL, Oracle, and BigQuery suites were skipped because optional extras and external integrations were not installed or started.

No dependencies, lockfiles, transaction behavior, command options, or public query return types were changed.