### PR TITLE
feat: add command options model

### DIFF
--- a/docs/async_methods/execute_async.md
+++ b/docs/async_methods/execute_async.md
@@ -4,6 +4,7 @@ to execute insert, update or delete operations.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/async_methods/execute_async.md
+++ b/docs/async_methods/execute_async.md
@@ -3,6 +3,7 @@
 to execute insert, update or delete operations.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -5,6 +5,7 @@ the query.  The additional columns or rows are ignored.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -4,6 +4,7 @@ the query.  The additional columns or rows are ignored.
 
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -9,7 +9,7 @@
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
 | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
-| options  | `CommandOptions | None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
+| options  | `CommandOptions` or `None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -8,7 +8,8 @@
 | params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
- | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
+| buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
+| options  | `CommandOptions | None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -2,6 +2,7 @@
 `query_first_async` can execute a query and map the first result.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -3,6 +3,7 @@
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -3,6 +3,7 @@
 set contains no records.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -4,6 +4,7 @@ set contains no records.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -4,6 +4,7 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 does not match the number of queries. A single mapper function applies to every result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | queries | `tuple[str, ...]` | the sql query strings to execute in order                                                | :thumbsdown: |         |

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -5,6 +5,7 @@ does not match the number of queries. A single mapper function applies to every 
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | queries | `tuple[str, ...]` | the sql query strings to execute in order                                                | :thumbsdown: |         |

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -3,6 +3,7 @@
 record in the result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -4,6 +4,7 @@ record in the result set.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -4,6 +4,7 @@ set is empty; this method throws an exception if there is more than one element 
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -3,6 +3,7 @@
 set is empty; this method throws an exception if there is more than one element in the result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/command_options.md
+++ b/docs/command_options.md
@@ -1,0 +1,34 @@
+# Command options
+
+Normal command methods accept a keyword-only `options=` argument. SQL, `params=`
+(`param=` remains a compatibility alias), `model=`, `mapper=`, and `buffered=`
+remain direct method arguments.
+
+```python
+rows = db.query("select id, description from task", options=pydapper.CommandOptions())
+```
+
+`CommandOptions` is immutable and has these fields:
+
+| field | default | meaning |
+|---|---|---|
+| `timeout` | `None` | Per-command timeout in seconds. |
+| `command_kind` | `CommandKind.TEXT` | Text SQL or a stored procedure. |
+| `readonly` | `None` | Per-command read-only request. |
+| `max_rows` | `None` | Positive maximum number of returned rows. |
+
+`CommandOptions()` is currently the supported option set and is equivalent to
+`options=None`. Valid non-default values are modeled for the v1 API but are not
+yet implemented. They raise `UnsupportedFeatureError` loudly instead of being
+ignored. Timeout enforcement belongs to [#482](https://github.com/zschumacher/pydapper/issues/482);
+read-only and row-limit enforcement belong to [#475](https://github.com/zschumacher/pydapper/issues/475);
+stored procedures belong to [#481](https://github.com/zschumacher/pydapper/issues/481).
+
+```python
+db.query("select 1", options=pydapper.CommandOptions(timeout=5))
+# raises UnsupportedFeatureError until timeout support lands
+```
+
+Python async callers use normal task cancellation. pydapper does not add a
+.NET-style cancellation token. `asyncio.timeout()` may be used on Python 3.11+
+and newer; pydapper continues to support Python 3.10.

--- a/docs/methods/execute.md
+++ b/docs/methods/execute.md
@@ -4,6 +4,7 @@ to execute insert, update or delete operations.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/methods/execute.md
+++ b/docs/methods/execute.md
@@ -3,6 +3,7 @@
 to execute insert, update or delete operations.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type                       | description                       | optional     | default |
 |-------|----------------------------|-----------------------------------|--------------|---------|
  | sql   | `str`                      | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -5,6 +5,7 @@ the query.  The additional columns or rows are ignored.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -4,6 +4,7 @@ the query.  The additional columns or rows are ignored.
 
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                       | optional     | default |
 |-------|-------------|-----------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute      | :thumbsdown: |         |

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -9,7 +9,7 @@
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
 | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
-| options  | `CommandOptions | None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
+| options  | `CommandOptions` or `None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -8,7 +8,8 @@
 | params    | `ParamType` | params to substitute in the query                                                             | :thumbsup:   | `None`  |
  | model    | `Any`       | the callable to serialize the model;  callable must be able to accept column names as kwargs. | :thumbsup:   | `dict`  |
  | mapper   | `Callable[[RawRow], Any]` | callable that receives a `RawRow` and returns a projected value. Mutually exclusive with `model`. | :thumbsup: | `None` |
- | buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
+| buffered | `bool`      | whether to buffer reading the results of the query                                            | :thumbsup:   | `True`  |
+| options  | `CommandOptions | None` | command execution options; see [Command options](../command_options.md) | :thumbsup: | `None` |
 
 
 `param=` remains accepted as a 1.x compatibility alias for `params=`. Pass only one of the two names.

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -3,6 +3,7 @@
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -2,6 +2,7 @@
 `query_first` can execute a query and map the first result.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -3,6 +3,7 @@
 set contains no records.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -4,6 +4,7 @@ set contains no records.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -4,6 +4,7 @@ will throw a `ValueError` if you don't supply the same number of queries and mod
 does not match the number of queries. A single mapper function applies to every result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | queries | `tuple[str, ...]` | the sql query strings to execute in order                                                | :thumbsdown: |         |

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -5,6 +5,7 @@ does not match the number of queries. A single mapper function applies to every 
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | queries | `tuple[str, ...]` | the sql query strings to execute in order                                                | :thumbsdown: |         |

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -3,6 +3,7 @@
 record in the result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -4,6 +4,7 @@ record in the result set.
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name  | type        | description                                                                                   | optional     | default |
 |-------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql   | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -4,6 +4,7 @@ set is empty; this method throws an exception if there is more than one element 
 
 ## Parameters
 All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
+
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -3,6 +3,7 @@
 set is empty; this method throws an exception if there is more than one element in the result set.
 
 ## Parameters
+All command methods also accept keyword-only `options=`; see [Command options](../command_options.md).
 | name    | type        | description                                                                                   | optional     | default |
 |---------|-------------|-----------------------------------------------------------------------------------------------|--------------|---------|
 | sql     | `str`       | the sql query str to execute                                                                  | :thumbsdown: |         |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: pydapper
 nav:
   - Overview: index.md
   - Compatibility Policy: compatibility.md
+  - Command options: command_options.md
   - Database Support:
       - Intro - Database Support: database_support/intro.md
       - Google BigQuery: database_support/bigquery.md

--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -1,4 +1,6 @@
 from .bigquery import GoogleBigqueryClientCommands as _GoogleBigqueryClientCommands
+from .command_options import CommandKind
+from .command_options import CommandOptions
 from .main import connect
 from .main import connect_async
 from .main import register

--- a/pydapper/command_options.py
+++ b/pydapper/command_options.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from enum import Enum
+from math import isfinite
+from numbers import Real
+from typing import Optional
+
+
+class CommandKind(str, Enum):
+    TEXT = "text"
+    STORED_PROCEDURE = "stored_procedure"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandOptions:
+    timeout: Optional[float] = None
+    command_kind: CommandKind = CommandKind.TEXT
+    readonly: Optional[bool] = None
+    max_rows: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.timeout is not None:
+            if isinstance(self.timeout, bool) or not isinstance(self.timeout, Real):
+                raise TypeError("timeout must be a positive finite number or None")
+            if self.timeout <= 0 or not isfinite(self.timeout):
+                raise ValueError("timeout must be a positive finite number or None")
+
+        if not isinstance(self.command_kind, CommandKind):
+            raise TypeError("command_kind must be a CommandKind")
+
+        if self.readonly is not None and not isinstance(self.readonly, bool):
+            raise TypeError("readonly must be True, False, or None")
+
+        if self.max_rows is not None:
+            if isinstance(self.max_rows, bool) or not isinstance(self.max_rows, int):
+                raise TypeError("max_rows must be a positive integer or None")
+            if self.max_rows <= 0:
+                raise ValueError("max_rows must be a positive integer or None")

--- a/pydapper/command_options.py
+++ b/pydapper/command_options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from math import isfinite
+from math import inf
 from numbers import Real
 from typing import Optional
 
@@ -21,7 +21,11 @@ class CommandOptions:
         if self.timeout is not None:
             if isinstance(self.timeout, bool) or not isinstance(self.timeout, Real):
                 raise TypeError("timeout must be a positive finite number or None")
-            if self.timeout <= 0 or not isfinite(self.timeout):
+            try:
+                valid_timeout = self.timeout > 0 and -inf < self.timeout < inf
+            except (OverflowError, TypeError, ValueError):
+                valid_timeout = False
+            if not valid_timeout:
                 raise ValueError("timeout must be a positive finite number or None")
 
         if not isinstance(self.command_kind, CommandKind):

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -333,6 +333,15 @@ class BaseCommands(ABC):
             raise UnsupportedFeatureError("Command option 'max_rows' is not supported")
         return options
 
+    @staticmethod
+    def _is_default_options(options: CommandOptions) -> bool:
+        return (
+            options.timeout is None
+            and options.command_kind is CommandKind.TEXT
+            and options.readonly is None
+            and options.max_rows is None
+        )
+
 
 class Commands(BaseCommands, ABC):
     def __init__(self, connection: "ConnectionType"):
@@ -475,44 +484,11 @@ class Commands(BaseCommands, ABC):
     def query(
         self,
         sql: str,
-        *,
-        options: Optional[CommandOptions],
-    ) -> List[Dict[str, Any]]: ...
-
-    @overload
-    def query(
-        self,
-        sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        buffered: Literal[True] = True,
-        options: Optional[CommandOptions],
-    ) -> List["_T"]: ...
-
-    @overload
-    def query(
-        self,
-        sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        buffered: Literal[False],
-        options: Optional[CommandOptions],
-    ) -> Generator["_T", None, None]: ...
-
-    @overload
-    def query(
-        self,
-        sql: str,
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List[Dict[str, Any]]: ...
 
     @overload
@@ -523,6 +499,7 @@ class Commands(BaseCommands, ABC):
         *,
         buffered: "Literal[True]" = True,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> List[Dict[str, Any]]: ...
 
     @overload
@@ -533,6 +510,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> typing.Generator[Dict[str, Any], None, None]: ...
 
     @overload
@@ -543,6 +521,7 @@ class Commands(BaseCommands, ABC):
         *,
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> typing.Generator[Dict[str, Any], None, None]: ...
 
     @overload
@@ -552,6 +531,7 @@ class Commands(BaseCommands, ABC):
         *,
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List[Dict[str, Any]], typing.Generator[Dict[str, Any], None, None]]: ...
 
     @overload
@@ -561,6 +541,7 @@ class Commands(BaseCommands, ABC):
         *,
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List[Dict[str, Any]], typing.Generator[Dict[str, Any], None, None]]: ...
 
     @overload
@@ -571,6 +552,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -581,6 +563,7 @@ class Commands(BaseCommands, ABC):
         *,
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -591,6 +574,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_T", None, None]: ...
 
     @overload
@@ -601,6 +585,7 @@ class Commands(BaseCommands, ABC):
         *,
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_T", None, None]: ...
 
     @overload
@@ -611,6 +596,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], Generator["_T", None, None]]: ...
 
     @overload
@@ -621,6 +607,7 @@ class Commands(BaseCommands, ABC):
         *,
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], Generator["_T", None, None]]: ...
 
     @overload
@@ -631,6 +618,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -641,6 +629,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -651,6 +640,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_T", None, None]: ...
 
     @overload
@@ -661,6 +651,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_T", None, None]: ...
 
     @overload
@@ -671,6 +662,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], Generator["_T", None, None]]: ...
 
     @overload
@@ -681,6 +673,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], Generator["_T", None, None]]: ...
 
     @overload
@@ -691,6 +684,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -701,6 +695,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -711,6 +706,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_MapperT", None, None]: ...
 
     @overload
@@ -721,6 +717,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Generator["_MapperT", None, None]: ...
 
     @overload
@@ -731,6 +728,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_MapperT"], Generator["_MapperT", None, None]]: ...
 
     @overload
@@ -741,6 +739,7 @@ class Commands(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_MapperT"], Generator["_MapperT", None, None]]: ...
 
     def query(
@@ -772,19 +771,17 @@ class Commands(BaseCommands, ABC):
         models: Tuple[Any, ...] = None,
         param: Optional["ParamType"] = None,
         *,
+        options: Optional[CommandOptions] = None,
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        *,
         params: Optional["ParamType"] = None,
-        mapper: Union[Callable[[RawRow], "_T"], Tuple[Callable[[RawRow], Any], ...]] = None,
-        options: Optional[CommandOptions],
-    ) -> Tuple[List[Any], ...]: ...
-
-    @overload
-    def query_multiple(
-        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, param: Optional["ParamType"] = None
-    ) -> Tuple[List[Any], ...]: ...
-
-    @overload
-    def query_multiple(
-        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -795,6 +792,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"]]: ...
 
     @overload
@@ -805,6 +803,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -815,6 +814,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -825,6 +825,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"]]: ...
 
     @overload
@@ -835,6 +836,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -845,6 +847,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -855,6 +858,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"]]: ...
 
     @overload
@@ -865,6 +869,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
 
     @overload
@@ -877,6 +882,7 @@ class Commands(BaseCommands, ABC):
         mapper: Tuple[
             Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
         ],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
 
     @overload
@@ -887,6 +893,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"]]: ...
 
     @overload
@@ -897,6 +904,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
 
     @overload
@@ -909,6 +917,7 @@ class Commands(BaseCommands, ABC):
             Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
         ],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
 
     @overload
@@ -919,6 +928,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], ...]: ...
 
     @overload
@@ -929,6 +939,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], ...]: ...
 
     @overload
@@ -939,6 +950,7 @@ class Commands(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], Any], ...],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -949,6 +961,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], Any], ...],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     def query_multiple(
@@ -1006,31 +1019,30 @@ class Commands(BaseCommands, ABC):
     def query_first(
         self,
         sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> "_T": ...
+        options: Optional[CommandOptions] = None,
+    ) -> Dict[str, Any]: ...
 
     @overload
     def query_first(
         self,
         sql: str,
         model: Type[Dict] = dict,
-        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Dict[str, Any]: ...
 
     @overload
-    def query_first(self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]) -> Dict[str, Any]: ...
-
-    @overload
     def query_first(
         self,
         sql: str,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1040,6 +1052,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1049,6 +1062,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1058,6 +1072,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1067,6 +1082,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     @overload
@@ -1076,6 +1092,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     def query_first(
@@ -1108,22 +1125,11 @@ class Commands(BaseCommands, ABC):
     def query_first_or_default(
         self,
         sql: str,
-        default: Union["_Default", Callable[[], "_Default"]],
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> Union["_Default", "_T"]: ...
-
-    @overload
-    def query_first_or_default(
-        self,
-        sql: str,
         default: Callable[[], "_Default"],
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1134,6 +1140,7 @@ class Commands(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1143,6 +1150,8 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1153,6 +1162,7 @@ class Commands(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1162,6 +1172,8 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1172,6 +1184,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1182,6 +1195,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1192,6 +1206,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1201,6 +1216,8 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1211,6 +1228,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1221,6 +1239,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1231,6 +1250,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1241,6 +1261,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1251,6 +1272,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1261,6 +1283,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1271,6 +1294,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     def query_first_or_default(
@@ -1284,7 +1308,9 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        options = self._resolve_options(options)
+        if self._is_default_options(options):
+            options = None
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
@@ -1306,31 +1332,30 @@ class Commands(BaseCommands, ABC):
     def query_single(
         self,
         sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> "_T": ...
+        options: Optional[CommandOptions] = None,
+    ) -> Dict[str, Any]: ...
 
     @overload
     def query_single(
         self,
         sql: str,
         model: Type[Dict] = dict,
-        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Dict[str, Any]: ...
 
     @overload
-    def query_single(self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]) -> Dict[str, Any]: ...
-
-    @overload
     def query_single(
         self,
         sql: str,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1340,6 +1365,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1349,6 +1375,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1358,6 +1385,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -1367,6 +1395,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     @overload
@@ -1376,6 +1405,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     def query_single(
@@ -1415,22 +1445,11 @@ class Commands(BaseCommands, ABC):
     def query_single_or_default(
         self,
         sql: str,
-        default: Union["_Default", Callable[[], "_Default"]],
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> Union["_Default", "_T"]: ...
-
-    @overload
-    def query_single_or_default(
-        self,
-        sql: str,
         default: Callable[[], "_Default"],
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1441,6 +1460,7 @@ class Commands(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1450,6 +1470,8 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1460,6 +1482,7 @@ class Commands(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -1469,6 +1492,8 @@ class Commands(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1479,6 +1504,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1489,6 +1515,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1499,6 +1526,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1508,6 +1536,8 @@ class Commands(BaseCommands, ABC):
         default: "_Default",
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1518,6 +1548,7 @@ class Commands(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1528,6 +1559,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1538,6 +1570,7 @@ class Commands(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -1548,6 +1581,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1558,6 +1592,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1568,6 +1603,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -1578,6 +1614,7 @@ class Commands(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     def query_single_or_default(
@@ -1591,7 +1628,9 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        options = self._resolve_options(options)
+        if self._is_default_options(options):
+            options = None
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
@@ -1735,44 +1774,11 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_async(
         self,
         sql: str,
-        *,
-        options: Optional[CommandOptions],
-    ) -> List[Dict[str, Any]]: ...
-
-    @overload
-    async def query_async(
-        self,
-        sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        buffered: Literal[True] = True,
-        options: Optional[CommandOptions],
-    ) -> List["_T"]: ...
-
-    @overload
-    async def query_async(
-        self,
-        sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        buffered: Literal[False],
-        options: Optional[CommandOptions],
-    ) -> AsyncGenerator["_T", None]: ...
-
-    @overload
-    async def query_async(
-        self,
-        sql: str,
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List[Dict[str, Any]]: ...
 
     @overload
@@ -1783,6 +1789,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         buffered: "Literal[True]" = True,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> List[Dict[str, Any]]: ...
 
     @overload
@@ -1793,6 +1800,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]: ...
 
     @overload
@@ -1803,6 +1811,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]: ...
 
     @overload
@@ -1812,6 +1821,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]]: ...
 
     @overload
@@ -1821,6 +1831,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]]: ...
 
     @overload
@@ -1831,6 +1842,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -1841,6 +1853,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -1851,6 +1864,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_T", None]: ...
 
     @overload
@@ -1861,6 +1875,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_T", None]: ...
 
     @overload
@@ -1871,6 +1886,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = ...,
         *,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
 
     @overload
@@ -1881,6 +1897,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
 
     @overload
@@ -1891,6 +1908,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -1901,6 +1919,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_T"]: ...
 
     @overload
@@ -1911,6 +1930,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_T", None]: ...
 
     @overload
@@ -1921,6 +1941,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_T", None]: ...
 
     @overload
@@ -1931,6 +1952,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
 
     @overload
@@ -1941,6 +1963,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_T"], AsyncGenerator["_T", None]]: ...
 
     @overload
@@ -1951,6 +1974,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -1961,6 +1985,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
         buffered: "Literal[True]" = True,
+        options: Optional[CommandOptions] = None,
     ) -> List["_MapperT"]: ...
 
     @overload
@@ -1971,6 +1996,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: "Literal[False]",
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_MapperT", None]: ...
 
     @overload
@@ -1981,6 +2007,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         buffered: "Literal[False]",
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> AsyncGenerator["_MapperT", None]: ...
 
     @overload
@@ -1991,6 +2018,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
         buffered: bool,
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_MapperT"], AsyncGenerator["_MapperT", None]]: ...
 
     @overload
@@ -2001,6 +2029,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Callable[[RawRow], "_MapperT"],
         buffered: bool,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union[List["_MapperT"], AsyncGenerator["_MapperT", None]]: ...
 
     async def query_async(
@@ -2031,19 +2060,17 @@ class CommandsAsync(BaseCommands, ABC):
         models: Tuple[Any, ...] = None,
         param: Optional["ParamType"] = None,
         *,
+        options: Optional[CommandOptions] = None,
+    ) -> Tuple[List[Any], ...]: ...
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        *,
         params: Optional["ParamType"] = None,
-        mapper: Union[Callable[[RawRow], "_T"], Tuple[Callable[[RawRow], Any], ...]] = None,
-        options: Optional[CommandOptions],
-    ) -> Tuple[List[Any], ...]: ...
-
-    @overload
-    async def query_multiple_async(
-        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, param: Optional["ParamType"] = None
-    ) -> Tuple[List[Any], ...]: ...
-
-    @overload
-    async def query_multiple_async(
-        self, queries: Tuple[str, ...], models: Tuple[Any, ...] = None, *, params: Optional["ParamType"] = None
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -2054,6 +2081,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"]]: ...
 
     @overload
@@ -2064,6 +2092,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -2074,6 +2103,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -2084,6 +2114,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"]]: ...
 
     @overload
@@ -2094,6 +2125,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -2104,6 +2136,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], List["_MapperT"], List["_MapperT"]]: ...
 
     @overload
@@ -2114,6 +2147,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"]]: ...
 
     @overload
@@ -2124,6 +2158,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
 
     @overload
@@ -2136,6 +2171,7 @@ class CommandsAsync(BaseCommands, ABC):
         mapper: Tuple[
             Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
         ],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
 
     @overload
@@ -2146,6 +2182,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"]],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"]]: ...
 
     @overload
@@ -2156,6 +2193,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"]],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"]]: ...
 
     @overload
@@ -2168,6 +2206,7 @@ class CommandsAsync(BaseCommands, ABC):
             Callable[[RawRow], "_MapperT1"], Callable[[RawRow], "_MapperT2"], Callable[[RawRow], "_MapperT3"]
         ],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT1"], List["_MapperT2"], List["_MapperT3"]]: ...
 
     @overload
@@ -2178,6 +2217,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Callable[[RawRow], "_MapperT"],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], ...]: ...
 
     @overload
@@ -2188,6 +2228,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List["_MapperT"], ...]: ...
 
     @overload
@@ -2198,6 +2239,7 @@ class CommandsAsync(BaseCommands, ABC):
         param: Optional["ParamType"] = None,
         *,
         mapper: Tuple[Callable[[RawRow], Any], ...],
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     @overload
@@ -2208,6 +2250,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Tuple[Callable[[RawRow], Any], ...],
         params: Optional["ParamType"] = None,
+        options: Optional[CommandOptions] = None,
     ) -> Tuple[List[Any], ...]: ...
 
     async def query_multiple_async(
@@ -2265,25 +2308,20 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_async(
         self,
         sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> "_T": ...
+        options: Optional[CommandOptions] = None,
+    ) -> Dict[str, Any]: ...
 
     @overload
     async def query_first_async(
         self,
         sql: str,
         model: Type[Dict] = dict,
-        param: Optional["ParamType"] = ...,
-    ) -> Dict[str, Any]: ...
-
-    @overload
-    async def query_first_async(
-        self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]
+        *,
+        params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Dict[str, Any]: ...
 
     @overload
@@ -2292,6 +2330,8 @@ class CommandsAsync(BaseCommands, ABC):
         sql: str,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2301,6 +2341,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2310,6 +2351,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2319,6 +2361,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2328,6 +2371,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     @overload
@@ -2337,6 +2381,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     async def query_first_async(
@@ -2369,22 +2414,11 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_or_default_async(
         self,
         sql: str,
-        default: Union["_Default", Callable[[], "_Default"]],
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> Union["_Default", "_T"]: ...
-
-    @overload
-    async def query_first_or_default_async(
-        self,
-        sql: str,
         default: Callable[[], "_Default"],
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2395,6 +2429,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2404,6 +2439,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2414,6 +2451,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2423,6 +2461,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2433,6 +2473,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2443,6 +2484,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2453,6 +2495,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2462,6 +2505,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2472,6 +2517,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2482,6 +2528,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2492,6 +2539,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2502,6 +2550,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2512,6 +2561,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2522,6 +2572,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2532,6 +2583,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     async def query_first_or_default_async(
@@ -2545,7 +2597,9 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        options = self._resolve_options(options)
+        if self._is_default_options(options):
+            options = None
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
@@ -2567,25 +2621,20 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_async(
         self,
         sql: str,
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
         *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> "_T": ...
+        options: Optional[CommandOptions] = None,
+    ) -> Dict[str, Any]: ...
 
     @overload
     async def query_single_async(
         self,
         sql: str,
         model: Type[Dict] = dict,
-        param: Optional["ParamType"] = ...,
-    ) -> Dict[str, Any]: ...
-
-    @overload
-    async def query_single_async(
-        self, sql: str, model: Type[Dict] = dict, *, params: Optional["ParamType"]
+        *,
+        params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Dict[str, Any]: ...
 
     @overload
@@ -2594,6 +2643,8 @@ class CommandsAsync(BaseCommands, ABC):
         sql: str,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2603,6 +2654,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2612,6 +2664,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2621,6 +2674,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_T": ...
 
     @overload
@@ -2630,6 +2684,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     @overload
@@ -2639,6 +2694,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> "_MapperT": ...
 
     async def query_single_async(
@@ -2676,22 +2732,11 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_or_default_async(
         self,
         sql: str,
-        default: Union["_Default", Callable[[], "_Default"]],
-        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
-        param: Optional["ParamType"] = ...,
-        *,
-        params: Optional["ParamType"] = None,
-        mapper: Callable[[RawRow], "_T"] = None,
-        options: Optional[CommandOptions],
-    ) -> Union["_Default", "_T"]: ...
-
-    @overload
-    async def query_single_or_default_async(
-        self,
-        sql: str,
         default: Callable[[], "_Default"],
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2702,6 +2747,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2711,6 +2757,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2721,6 +2769,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Type[Dict] = dict,
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", Dict[str, Any]]: ...
 
     @overload
@@ -2730,6 +2779,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: Callable[[], "_Default"],
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2740,6 +2791,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2750,6 +2802,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2760,6 +2813,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2769,6 +2823,8 @@ class CommandsAsync(BaseCommands, ABC):
         default: "_Default",
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        *,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2779,6 +2835,7 @@ class CommandsAsync(BaseCommands, ABC):
         model: Union[Type["_T"], Callable[..., "_T"]],
         *,
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2789,6 +2846,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2799,6 +2857,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         model: Union[Type["_T"], Callable[..., "_T"]],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_T"]: ...
 
     @overload
@@ -2809,6 +2868,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2819,6 +2879,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2829,6 +2890,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         param: Optional["ParamType"] = ...,
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     @overload
@@ -2839,6 +2901,7 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         mapper: Callable[[RawRow], "_MapperT"],
         params: Optional["ParamType"],
+        options: Optional[CommandOptions] = None,
     ) -> Union["_Default", "_MapperT"]: ...
 
     async def query_single_or_default_async(
@@ -2852,7 +2915,9 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        options = self._resolve_options(options)
+        if self._is_default_options(options):
+            options = None
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -333,15 +333,6 @@ class BaseCommands(ABC):
             raise UnsupportedFeatureError("Command option 'max_rows' is not supported")
         return options
 
-    @staticmethod
-    def _is_default_options(options: CommandOptions) -> bool:
-        return (
-            options.timeout is None
-            and options.command_kind is CommandKind.TEXT
-            and options.readonly is None
-            and options.max_rows is None
-        )
-
 
 class Commands(BaseCommands, ABC):
     def __init__(self, connection: "ConnectionType"):
@@ -1308,23 +1299,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        options = self._resolve_options(options)
-        if self._is_default_options(options):
-            options = None
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                if options is None:
-                    return self.query_first(sql, param=resolved_params, mapper=mapper)
-                return self.query_first(sql, param=resolved_params, mapper=mapper, options=options)
+                return self.query_first(sql, param=resolved_params, mapper=mapper)
             if model is _MODEL_UNSET:
-                if options is None:
-                    return self.query_first(sql, param=resolved_params)
-                return self.query_first(sql, param=resolved_params, options=options)
-            if options is None:
-                return self.query_first(sql, model=model, param=resolved_params)
-            return self.query_first(sql, model=model, param=resolved_params, options=options)
+                return self.query_first(sql, param=resolved_params)
+            return self.query_first(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -1628,23 +1611,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        options = self._resolve_options(options)
-        if self._is_default_options(options):
-            options = None
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                if options is None:
-                    return self.query_single(sql, param=resolved_params, mapper=mapper)
-                return self.query_single(sql, param=resolved_params, mapper=mapper, options=options)
+                return self.query_single(sql, param=resolved_params, mapper=mapper)
             if model is _MODEL_UNSET:
-                if options is None:
-                    return self.query_single(sql, param=resolved_params)
-                return self.query_single(sql, param=resolved_params, options=options)
-            if options is None:
-                return self.query_single(sql, model=model, param=resolved_params)
-            return self.query_single(sql, model=model, param=resolved_params, options=options)
+                return self.query_single(sql, param=resolved_params)
+            return self.query_single(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -2597,23 +2572,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        options = self._resolve_options(options)
-        if self._is_default_options(options):
-            options = None
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                if options is None:
-                    return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
-                return await self.query_first_async(sql, param=resolved_params, mapper=mapper, options=options)
+                return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
             if model is _MODEL_UNSET:
-                if options is None:
-                    return await self.query_first_async(sql, param=resolved_params)
-                return await self.query_first_async(sql, param=resolved_params, options=options)
-            if options is None:
-                return await self.query_first_async(sql, model=model, param=resolved_params)
-            return await self.query_first_async(sql, model=model, param=resolved_params, options=options)
+                return await self.query_first_async(sql, param=resolved_params)
+            return await self.query_first_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -2915,23 +2882,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        options = self._resolve_options(options)
-        if self._is_default_options(options):
-            options = None
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                if options is None:
-                    return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
-                return await self.query_single_async(sql, param=resolved_params, mapper=mapper, options=options)
+                return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
             if model is _MODEL_UNSET:
-                if options is None:
-                    return await self.query_single_async(sql, param=resolved_params)
-                return await self.query_single_async(sql, param=resolved_params, options=options)
-            if options is None:
-                return await self.query_single_async(sql, model=model, param=resolved_params)
-            return await self.query_single_async(sql, model=model, param=resolved_params, options=options)
+                return await self.query_single_async(sql, param=resolved_params)
+            return await self.query_single_async(sql, model=model, param=resolved_params)
         except NoResultException:
             return _resolve_default_value(default)
 

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -26,11 +26,14 @@ from typing import overload
 from ._context import CoroContextManager
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
+from .command_options import CommandKind
+from .command_options import CommandOptions
 from .exceptions import DuplicateColumnException
 from .exceptions import InvalidParameterShapeException
 from .exceptions import MissingParameterException
 from .exceptions import MoreThanOneResultException
 from .exceptions import NoResultException
+from .exceptions import UnsupportedFeatureError
 from .rows import RawRow
 from .utils import database_row_to_dict
 from .utils import get_col_names
@@ -313,6 +316,23 @@ class BaseCommands(ABC):
     def _resolve_params(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):
         return _resolve_param_aliases(param, params)
 
+    @staticmethod
+    def _resolve_options(options: Optional[CommandOptions] = None) -> CommandOptions:
+        if options is None:
+            options = CommandOptions()
+        elif not isinstance(options, CommandOptions):
+            raise TypeError("options must be a CommandOptions or None")
+
+        if options.timeout is not None:
+            raise UnsupportedFeatureError("Command option 'timeout' is not supported")
+        if options.command_kind is not CommandKind.TEXT:
+            raise UnsupportedFeatureError("Command option 'command_kind' is not supported")
+        if options.readonly is not None:
+            raise UnsupportedFeatureError("Command option 'readonly' is not supported")
+        if options.max_rows is not None:
+            raise UnsupportedFeatureError("Command option 'max_rows' is not supported")
+        return options
+
 
 class Commands(BaseCommands, ABC):
     def __init__(self, connection: "ConnectionType"):
@@ -378,7 +398,18 @@ class Commands(BaseCommands, ABC):
     @overload
     def execute(self, sql: str, *, param: Union["ParamType", "ListParamType"] = None) -> int: ...
 
-    def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+    @overload
+    def execute(
+        self,
+        sql: str,
+        params: Union["ParamType", "ListParamType"] = None,
+        *,
+        param: Union["ParamType", "ListParamType"] = None,
+        options: Optional[CommandOptions],
+    ) -> int: ...
+
+    def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         if _is_empty_executemany_params(resolved_params):
             return 0
@@ -439,6 +470,40 @@ class Commands(BaseCommands, ABC):
 
     def _on_query_single_more_than_one_result(self, cursor: "CursorType") -> None:
         pass
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        *,
+        options: Optional[CommandOptions],
+    ) -> List[Dict[str, Any]]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        buffered: Literal[True] = True,
+        options: Optional[CommandOptions],
+    ) -> List["_T"]: ...
+
+    @overload
+    def query(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        buffered: Literal[False],
+        options: Optional[CommandOptions],
+    ) -> Generator["_T", None, None]: ...
 
     @overload
     def query(
@@ -687,7 +752,9 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -697,6 +764,18 @@ class Commands(BaseCommands, ABC):
         return self._unbuffered_query(handler, projector, maps_raw_row)
 
     # endregion
+
+    @overload
+    def query_multiple(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        param: Optional["ParamType"] = None,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Union[Callable[[RawRow], "_T"], Tuple[Callable[[RawRow], Any], ...]] = None,
+        options: Optional[CommandOptions],
+    ) -> Tuple[List[Any], ...]: ...
 
     @overload
     def query_multiple(
@@ -880,11 +959,13 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
@@ -920,6 +1001,18 @@ class Commands(BaseCommands, ABC):
                 results.append(serialized_data)
 
         return tuple(results)
+
+    @overload
+    def query_first(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> "_T": ...
 
     @overload
     def query_first(
@@ -993,7 +1086,9 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -1008,6 +1103,19 @@ class Commands(BaseCommands, ABC):
             if not maps_raw_row:
                 validate_no_duplicate_columns(headers)
         return _project_row(projector, maps_raw_row, headers, row)
+
+    @overload
+    def query_first_or_default(
+        self,
+        sql: str,
+        default: Union["_Default", Callable[[], "_Default"]],
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> Union["_Default", "_T"]: ...
 
     @overload
     def query_first_or_default(
@@ -1174,17 +1282,37 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return self.query_first(sql, param=resolved_params, mapper=mapper)
+                if options is None:
+                    return self.query_first(sql, param=resolved_params, mapper=mapper)
+                return self.query_first(sql, param=resolved_params, mapper=mapper, options=options)
             if model is _MODEL_UNSET:
-                return self.query_first(sql, param=resolved_params)
-            return self.query_first(sql, model=model, param=resolved_params)
+                if options is None:
+                    return self.query_first(sql, param=resolved_params)
+                return self.query_first(sql, param=resolved_params, options=options)
+            if options is None:
+                return self.query_first(sql, model=model, param=resolved_params)
+            return self.query_first(sql, model=model, param=resolved_params, options=options)
         except NoResultException:
             return _resolve_default_value(default)
+
+    @overload
+    def query_single(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> "_T": ...
 
     @overload
     def query_single(
@@ -1258,7 +1386,9 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -1280,6 +1410,19 @@ class Commands(BaseCommands, ABC):
                 validate_no_duplicate_columns(headers)
 
         return _project_row(projector, maps_raw_row, headers, data[0])
+
+    @overload
+    def query_single_or_default(
+        self,
+        sql: str,
+        default: Union["_Default", Callable[[], "_Default"]],
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> Union["_Default", "_T"]: ...
 
     @overload
     def query_single_or_default(
@@ -1446,15 +1589,23 @@ class Commands(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return self.query_single(sql, param=resolved_params, mapper=mapper)
+                if options is None:
+                    return self.query_single(sql, param=resolved_params, mapper=mapper)
+                return self.query_single(sql, param=resolved_params, mapper=mapper, options=options)
             if model is _MODEL_UNSET:
-                return self.query_single(sql, param=resolved_params)
-            return self.query_single(sql, model=model, param=resolved_params)
+                if options is None:
+                    return self.query_single(sql, param=resolved_params)
+                return self.query_single(sql, param=resolved_params, options=options)
+            if options is None:
+                return self.query_single(sql, model=model, param=resolved_params)
+            return self.query_single(sql, model=model, param=resolved_params, options=options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -1464,7 +1615,18 @@ class Commands(BaseCommands, ABC):
     @overload
     def execute_scalar(self, sql: str, *, param: Optional["ParamType"] = None) -> Any: ...
 
-    def execute_scalar(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+    @overload
+    def execute_scalar(
+        self,
+        sql: str,
+        params: Optional["ParamType"] = None,
+        *,
+        param: Optional["ParamType"] = None,
+        options: Optional[CommandOptions],
+    ) -> Any: ...
+
+    def execute_scalar(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
@@ -1500,7 +1662,18 @@ class CommandsAsync(BaseCommands, ABC):
     @overload
     async def execute_async(self, sql: str, *, param: Union["ParamType", "ListParamType"] = None) -> int: ...
 
-    async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+    @overload
+    async def execute_async(
+        self,
+        sql: str,
+        params: Union["ParamType", "ListParamType"] = None,
+        *,
+        param: Union["ParamType", "ListParamType"] = None,
+        options: Optional[CommandOptions],
+    ) -> int: ...
+
+    async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         if _is_empty_executemany_params(resolved_params):
             return 0
@@ -1557,6 +1730,40 @@ class CommandsAsync(BaseCommands, ABC):
 
     async def _on_duplicate_columns_async(self, cursor: "AsyncCursorType") -> None:
         pass
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        *,
+        options: Optional[CommandOptions],
+    ) -> List[Dict[str, Any]]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        buffered: Literal[True] = True,
+        options: Optional[CommandOptions],
+    ) -> List["_T"]: ...
+
+    @overload
+    async def query_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        buffered: Literal[False],
+        options: Optional[CommandOptions],
+    ) -> AsyncGenerator["_T", None]: ...
 
     @overload
     async def query_async(
@@ -1805,7 +2012,9 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -1814,6 +2023,18 @@ class CommandsAsync(BaseCommands, ABC):
             records = await self._buffered_query(handler, projector, maps_raw_row)
             return records
         return self._unbuffered_query(handler, projector, maps_raw_row)
+
+    @overload
+    async def query_multiple_async(
+        self,
+        queries: Tuple[str, ...],
+        models: Tuple[Any, ...] = None,
+        param: Optional["ParamType"] = None,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Union[Callable[[RawRow], "_T"], Tuple[Callable[[RawRow], Any], ...]] = None,
+        options: Optional[CommandOptions],
+    ) -> Tuple[List[Any], ...]: ...
 
     @overload
     async def query_multiple_async(
@@ -1997,11 +2218,13 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ) -> Tuple[List[Any], ...]:
         """
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
@@ -2042,6 +2265,18 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_first_async(
         self,
         sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> "_T": ...
+
+    @overload
+    async def query_first_async(
+        self,
+        sql: str,
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
     ) -> Dict[str, Any]: ...
@@ -2112,7 +2347,9 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -2127,6 +2364,19 @@ class CommandsAsync(BaseCommands, ABC):
             if not maps_raw_row:
                 validate_no_duplicate_columns(headers)
             return _project_row(projector, maps_raw_row, headers, row)
+
+    @overload
+    async def query_first_or_default_async(
+        self,
+        sql: str,
+        default: Union["_Default", Callable[[], "_Default"]],
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> Union["_Default", "_T"]: ...
 
     @overload
     async def query_first_or_default_async(
@@ -2293,17 +2543,37 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
+                if options is None:
+                    return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
+                return await self.query_first_async(sql, param=resolved_params, mapper=mapper, options=options)
             if model is _MODEL_UNSET:
-                return await self.query_first_async(sql, param=resolved_params)
-            return await self.query_first_async(sql, model=model, param=resolved_params)
+                if options is None:
+                    return await self.query_first_async(sql, param=resolved_params)
+                return await self.query_first_async(sql, param=resolved_params, options=options)
+            if options is None:
+                return await self.query_first_async(sql, model=model, param=resolved_params)
+            return await self.query_first_async(sql, model=model, param=resolved_params, options=options)
         except NoResultException:
             return _resolve_default_value(default)
+
+    @overload
+    async def query_single_async(
+        self,
+        sql: str,
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> "_T": ...
 
     @overload
     async def query_single_async(
@@ -2379,7 +2649,9 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
@@ -2404,6 +2676,19 @@ class CommandsAsync(BaseCommands, ABC):
     async def query_single_or_default_async(
         self,
         sql: str,
+        default: Union["_Default", Callable[[], "_Default"]],
+        model: Union[Type["_T"], Callable[..., "_T"]] = cast(Any, dict),
+        param: Optional["ParamType"] = ...,
+        *,
+        params: Optional["ParamType"] = None,
+        mapper: Callable[[RawRow], "_T"] = None,
+        options: Optional[CommandOptions],
+    ) -> Union["_Default", "_T"]: ...
+
+    @overload
+    async def query_single_or_default_async(
+        self,
+        sql: str,
         default: Callable[[], "_Default"],
         model: Type[Dict] = dict,
         param: Optional["ParamType"] = ...,
@@ -2565,15 +2850,23 @@ class CommandsAsync(BaseCommands, ABC):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
+                if options is None:
+                    return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
+                return await self.query_single_async(sql, param=resolved_params, mapper=mapper, options=options)
             if model is _MODEL_UNSET:
-                return await self.query_single_async(sql, param=resolved_params)
-            return await self.query_single_async(sql, model=model, param=resolved_params)
+                if options is None:
+                    return await self.query_single_async(sql, param=resolved_params)
+                return await self.query_single_async(sql, param=resolved_params, options=options)
+            if options is None:
+                return await self.query_single_async(sql, model=model, param=resolved_params)
+            return await self.query_single_async(sql, model=model, param=resolved_params, options=options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -2583,7 +2876,18 @@ class CommandsAsync(BaseCommands, ABC):
     @overload
     async def execute_scalar_async(self, sql: str, *, param: Optional["ParamType"] = None) -> Any: ...
 
-    async def execute_scalar_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET):
+    @overload
+    async def execute_scalar_async(
+        self,
+        sql: str,
+        params: Optional["ParamType"] = None,
+        *,
+        param: Optional["ParamType"] = None,
+        options: Optional[CommandOptions],
+    ) -> Any: ...
+
+    async def execute_scalar_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -76,11 +76,13 @@ class MySqlConnectorPythonCommands(Commands):
         *,
         params=_PARAM_ALIAS_UNSET,
         mapper=_MAPPER_UNSET,
+        options=None,
     ):
         """
         the mysql connector throws an exception if you only read one row from a cursor.  Unfortunately, we have to
         fetchall to make the lib happy.
         """
+        self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -1,0 +1,101 @@
+from dataclasses import FrozenInstanceError
+from dataclasses import fields
+from math import inf
+
+import pytest
+
+import pydapper
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+from pydapper.exceptions import UnsupportedFeatureError
+
+pytestmark = pytest.mark.core
+
+
+class NoCursorConnection:
+    def cursor(self):
+        raise AssertionError("cursor should not be allocated")
+
+
+class OptionsCommands(Commands):
+    @classmethod
+    def connect(cls, parsed_dsn, **connect_kwargs):
+        return cls(NoCursorConnection())
+
+
+class OptionsCommandsAsync(CommandsAsync):
+    @classmethod
+    async def connect_async(cls, parsed_dsn, **connect_kwargs):
+        return cls(NoCursorConnection())
+
+
+def test_command_options_model():
+    options = pydapper.CommandOptions()
+    assert options == pydapper.CommandOptions()
+    assert (
+        repr(options)
+        == "CommandOptions(timeout=None, command_kind=<CommandKind.TEXT: 'text'>, readonly=None, max_rows=None)"
+    )
+    assert options.command_kind is pydapper.CommandKind.TEXT
+    assert [field.name for field in fields(options)] == ["timeout", "command_kind", "readonly", "max_rows"]
+    assert hasattr(type(options), "__slots__")
+    with pytest.raises(FrozenInstanceError):
+        options.timeout = 1
+
+
+@pytest.mark.parametrize("timeout", [0, -1, inf, float("nan"), True, "5"])
+def test_invalid_timeout(timeout):
+    with pytest.raises((TypeError, ValueError), match="timeout"):
+        pydapper.CommandOptions(timeout=timeout)
+
+
+@pytest.mark.parametrize("max_rows", [0, -1, 1.5, True, "5"])
+def test_invalid_max_rows(max_rows):
+    with pytest.raises((TypeError, ValueError), match="max_rows"):
+        pydapper.CommandOptions(max_rows=max_rows)
+
+
+def test_invalid_command_options_fields():
+    with pytest.raises(TypeError, match="command_kind"):
+        pydapper.CommandOptions(command_kind="text")
+    with pytest.raises(TypeError, match="readonly"):
+        pydapper.CommandOptions(readonly=1)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pydapper.CommandOptions(timeout=1),
+        pydapper.CommandOptions(command_kind=pydapper.CommandKind.STORED_PROCEDURE),
+        pydapper.CommandOptions(readonly=True),
+        pydapper.CommandOptions(max_rows=1),
+    ],
+)
+def test_unsupported_options_fail_before_cursor_use(options):
+    commands = OptionsCommands(NoCursorConnection())
+    with pytest.raises(UnsupportedFeatureError):
+        commands.execute("select 1", options=options)
+    with pytest.raises(UnsupportedFeatureError):
+        commands.execute("select 1", params=[], options=options)
+    with pytest.raises(UnsupportedFeatureError):
+        commands.query("select 1", buffered=False, options=options)
+
+
+def test_default_options_are_supported():
+    assert OptionsCommands(NoCursorConnection())._resolve_options(None) == pydapper.CommandOptions()
+    assert (
+        OptionsCommands(NoCursorConnection())._resolve_options(pydapper.CommandOptions()) == pydapper.CommandOptions()
+    )
+
+
+def test_non_options_value_fails_clearly():
+    with pytest.raises(TypeError, match="options"):
+        OptionsCommands(NoCursorConnection()).execute("select 1", options=object())
+
+
+@pytest.mark.asyncio
+async def test_async_unsupported_options_fail_before_cursor_use():
+    with pytest.raises(UnsupportedFeatureError):
+        await OptionsCommandsAsync(NoCursorConnection()).execute_async(
+            "select 1", options=pydapper.CommandOptions(max_rows=1)
+        )

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -1,5 +1,6 @@
 from dataclasses import FrozenInstanceError
 from dataclasses import fields
+from fractions import Fraction
 from math import inf
 
 import pytest
@@ -29,6 +30,51 @@ class OptionsCommandsAsync(CommandsAsync):
         return cls(NoCursorConnection())
 
 
+class DerivedOptions(pydapper.CommandOptions):
+    pass
+
+
+class OverflowingInfiniteReal(Fraction):
+    def __float__(self):
+        raise OverflowError
+
+    def __eq__(self, other):
+        return inf == other
+
+    def __lt__(self, other):
+        return inf < other
+
+    def __le__(self, other):
+        return inf <= other
+
+    def __gt__(self, other):
+        return inf > other
+
+    def __ge__(self, other):
+        return inf >= other
+
+
+class OverflowingFraction(Fraction):
+    def __float__(self):
+        raise OverflowError
+
+
+class LegacyDefaultCommands(OptionsCommands):
+    def query_first(self, sql, model=dict, param=None, *, mapper=None):
+        return "first"
+
+    def query_single(self, sql, model=dict, param=None, *, mapper=None):
+        return "single"
+
+
+class LegacyDefaultCommandsAsync(OptionsCommandsAsync):
+    async def query_first_async(self, sql, model=dict, param=None, *, mapper=None):
+        return "first"
+
+    async def query_single_async(self, sql, model=dict, param=None, *, mapper=None):
+        return "single"
+
+
 def test_command_options_model():
     options = pydapper.CommandOptions()
     assert options == pydapper.CommandOptions()
@@ -43,10 +89,36 @@ def test_command_options_model():
         options.timeout = 1
 
 
-@pytest.mark.parametrize("timeout", [0, -1, inf, float("nan"), True, "5"])
+@pytest.mark.parametrize("timeout", [0, -1, inf, -inf, float("nan"), True, "5"])
 def test_invalid_timeout(timeout):
     with pytest.raises((TypeError, ValueError), match="timeout"):
         pydapper.CommandOptions(timeout=timeout)
+
+
+@pytest.mark.parametrize("timeout", [10**1000, Fraction(10**1000, 1)])
+def test_arbitrarily_large_timeout_is_validated_as_supported_real(timeout):
+    options = pydapper.CommandOptions(timeout=timeout)
+
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        OptionsCommands(NoCursorConnection()).execute("select 1", options=options)
+
+
+@pytest.mark.parametrize("timeout", [-(10**1000), Fraction(-(10**1000), 1)])
+def test_arbitrarily_large_negative_timeout_is_invalid(timeout):
+    with pytest.raises(ValueError, match="timeout"):
+        pydapper.CommandOptions(timeout=timeout)
+
+
+def test_custom_infinite_real_with_overflowing_float_conversion_is_invalid():
+    with pytest.raises(ValueError, match="timeout"):
+        pydapper.CommandOptions(timeout=OverflowingInfiniteReal(1))
+
+
+def test_custom_finite_real_with_overflowing_float_conversion_is_valid():
+    options = pydapper.CommandOptions(timeout=OverflowingFraction(10**1000, 1))
+
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        OptionsCommands(NoCursorConnection()).execute("select 1", options=options)
 
 
 @pytest.mark.parametrize("max_rows", [0, -1, 1.5, True, "5"])
@@ -88,6 +160,24 @@ def test_default_options_are_supported():
     )
 
 
+@pytest.mark.parametrize("options", [None, pydapper.CommandOptions(), DerivedOptions()])
+def test_default_options_are_omitted_for_legacy_default_helper_overrides(options):
+    commands = LegacyDefaultCommands(NoCursorConnection())
+
+    assert commands.query_first_or_default("select 1", None, options=options) == "first"
+    assert commands.query_single_or_default("select 1", None, options=options) == "single"
+
+
+def test_unsupported_options_fail_before_legacy_default_helper_overrides():
+    commands = LegacyDefaultCommands(NoCursorConnection())
+    options = pydapper.CommandOptions(timeout=1)
+
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        commands.query_first_or_default("select 1", None, options=options)
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        commands.query_single_or_default("select 1", None, options=options)
+
+
 def test_non_options_value_fails_clearly():
     with pytest.raises(TypeError, match="options"):
         OptionsCommands(NoCursorConnection()).execute("select 1", options=object())
@@ -99,3 +189,23 @@ async def test_async_unsupported_options_fail_before_cursor_use():
         await OptionsCommandsAsync(NoCursorConnection()).execute_async(
             "select 1", options=pydapper.CommandOptions(max_rows=1)
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("options", [None, pydapper.CommandOptions(), DerivedOptions()])
+async def test_default_options_are_omitted_for_legacy_async_default_helper_overrides(options):
+    commands = LegacyDefaultCommandsAsync(NoCursorConnection())
+
+    assert await commands.query_first_or_default_async("select 1", None, options=options) == "first"
+    assert await commands.query_single_or_default_async("select 1", None, options=options) == "single"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_options_fail_before_legacy_async_default_helper_overrides():
+    commands = LegacyDefaultCommandsAsync(NoCursorConnection())
+    options = pydapper.CommandOptions(timeout=1)
+
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        await commands.query_first_or_default_async("select 1", None, options=options)
+    with pytest.raises(UnsupportedFeatureError, match="timeout"):
+        await commands.query_single_or_default_async("select 1", None, options=options)

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -59,6 +59,11 @@ class OverflowingFraction(Fraction):
         raise OverflowError
 
 
+class UnorderableFraction(Fraction):
+    def __gt__(self, other):
+        raise TypeError("comparison is not supported")
+
+
 class LegacyDefaultCommands(OptionsCommands):
     def query_first(self, sql, model=dict, param=None, *, mapper=None):
         return "first"
@@ -119,6 +124,11 @@ def test_custom_finite_real_with_overflowing_float_conversion_is_valid():
 
     with pytest.raises(UnsupportedFeatureError, match="timeout"):
         OptionsCommands(NoCursorConnection()).execute("select 1", options=options)
+
+
+def test_custom_real_with_failing_comparison_is_invalid():
+    with pytest.raises(ValueError, match="timeout must be a positive finite number or None"):
+        pydapper.CommandOptions(timeout=UnorderableFraction(1))
 
 
 @pytest.mark.parametrize("max_rows", [0, -1, 1.5, True, "5"])

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -110,6 +110,7 @@ class Commands:
     @staticmethod
     def execute(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
@@ -133,6 +134,29 @@ class Commands:
             assert_type(commands.execute_scalar(query, options=pydapper.CommandOptions()), Any)
             assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
             assert_type(commands.query_multiple((query,), params=params), Tuple[List[Any], ...])
+            assert_type(commands.query_multiple((query,), mapper=to_task, options=options), Tuple[List[Task]])
+            assert_type(
+                commands.query_multiple((query,), mapper=to_task, param=params, options=options), Tuple[List[Task]]
+            )
+            assert_type(
+                commands.query_multiple((query,), mapper=to_task, params=params, options=options), Tuple[List[Task]]
+            )
+            assert_type(
+                commands.query_multiple((query, query), mapper=to_task, options=options),
+                Tuple[List[Task], List[Task]],
+            )
+            assert_type(
+                commands.query_multiple((query, query, query), mapper=to_task, options=options),
+                Tuple[List[Task], List[Task], List[Task]],
+            )
+            assert_type(
+                commands.query_multiple((query, query), mapper=(to_id, to_description), options=options),
+                Tuple[List[int], List[str]],
+            )
+            assert_type(
+                commands.query_multiple((query, query), mapper=(to_id, to_description), param=params, options=options),
+                Tuple[List[int], List[str]],
+            )
             assert_type(commands.query_multiple((query,), mapper=to_task), Tuple[List[Task]])
             assert_type(commands.query_multiple((query, query), mapper=to_task), Tuple[List[Task], List[Task]])
             assert_type(
@@ -143,6 +167,7 @@ class Commands:
     @staticmethod
     def query(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
@@ -153,6 +178,14 @@ class Commands:
         with pydapper.connect() as commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
             assert_type(commands.query(query, options=pydapper.CommandOptions()), List[Dict[str, Any]])
+            assert_type(commands.query(query, buffered=True, options=options), List[Dict[str, Any]])
+            assert_type(commands.query(query, param=params, options=options), List[Dict[str, Any]])
+            assert_type(commands.query(query, params=params, options=options), List[Dict[str, Any]])
+            assert_type(
+                commands.query(query, buffered=buffered, options=options),
+                Union[List[Dict[str, Any]], Generator[Dict[str, Any], None, None]],
+            )
+            assert_type(commands.query(query, buffered=False, options=options), Generator[Dict[str, Any], None, None])
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
             assert_type(
                 commands.query(query, buffered=buffered),
@@ -183,6 +216,21 @@ class Commands:
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
             assert_type(commands.query(query, mapper=to_task), List[Task])
             assert_type(commands.query(query, model=Task, options=pydapper.CommandOptions()), List[Task])
+            assert_type(commands.query(query, model=Task, buffered=True, options=options), List[Task])
+            assert_type(
+                commands.query(query, model=Task, buffered=buffered, options=options),
+                Union[List[Task], Generator[Task, None, None]],
+            )
+            assert_type(commands.query(query, model=Task, buffered=False, options=options), Generator[Task, None, None])
+            assert_type(commands.query(query, mapper=to_task, options=options), List[Task])
+            assert_type(commands.query(query, mapper=to_task, buffered=True, options=options), List[Task])
+            assert_type(
+                commands.query(query, mapper=to_task, buffered=buffered, options=options),
+                Union[List[Task], Generator[Task, None, None]],
+            )
+            assert_type(
+                commands.query(query, mapper=to_task, buffered=False, options=options), Generator[Task, None, None]
+            )
             assert_type(commands.query(query, param=params, mapper=to_task), List[Task])
             assert_type(commands.query(query, params=params, mapper=to_task), List[Task])
             assert_type(
@@ -216,6 +264,7 @@ class Commands:
     @staticmethod
     def query_first(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         with pydapper.connect() as commands:
             assert_type(commands.query_first(query), Dict[str, Any])
@@ -228,10 +277,15 @@ class Commands:
             assert_type(commands.query_first(query, params=params), Dict[str, Any])
             assert_type(commands.query_first(query, params=params, model=Task), Task)
             assert_type(commands.query_first(query, params=params, mapper=to_task), Task)
+            assert_type(commands.query_first(query, options=options), Dict[str, Any])
+            assert_type(commands.query_first(query, param=params, options=options), Dict[str, Any])
+            assert_type(commands.query_first(query, model=Task, options=options), Task)
+            assert_type(commands.query_first(query, mapper=to_task, options=options), Task)
 
     @staticmethod
     def query_first_or_default(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
@@ -249,10 +303,21 @@ class Commands:
             assert_type(commands.query_first_or_default(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(commands.query_first_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
             assert_type(commands.query_first_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_first_or_default(query, default_callable, options=options), Union[str, Dict[str, Any]]
+            )
+            assert_type(commands.query_first_or_default(query, "hello", options=options), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_first_or_default(query, default_callable, model=Task, options=options), Union[str, Task]
+            )
+            assert_type(
+                commands.query_first_or_default(query, "hello", mapper=to_task, options=options), Union[str, Task]
+            )
 
     @staticmethod
     def query_single(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         with pydapper.connect() as commands:
             assert_type(commands.query_single(query), Dict[str, Any])
@@ -265,10 +330,15 @@ class Commands:
             assert_type(commands.query_single(query, params=params), Dict[str, Any])
             assert_type(commands.query_single(query, params=params, model=Task), Task)
             assert_type(commands.query_single(query, params=params, mapper=to_task), Task)
+            assert_type(commands.query_single(query, options=options), Dict[str, Any])
+            assert_type(commands.query_single(query, params=params, options=options), Dict[str, Any])
+            assert_type(commands.query_single(query, model=Task, options=options), Task)
+            assert_type(commands.query_single(query, mapper=to_task, options=options), Task)
 
     @staticmethod
     def query_single_or_default(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         with pydapper.connect() as commands:
             # passing a callable, the return type of the callable is part of the return type
@@ -286,12 +356,23 @@ class Commands:
             assert_type(commands.query_single_or_default(query, "hello"), Union[str, Dict[str, Any]])
             assert_type(commands.query_single_or_default(query, "hello", param=params), Union[str, Dict[str, Any]])
             assert_type(commands.query_single_or_default(query, "hello", params=params), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_single_or_default(query, default_callable, options=options), Union[str, Dict[str, Any]]
+            )
+            assert_type(commands.query_single_or_default(query, "hello", options=options), Union[str, Dict[str, Any]])
+            assert_type(
+                commands.query_single_or_default(query, default_callable, model=Task, options=options), Union[str, Task]
+            )
+            assert_type(
+                commands.query_single_or_default(query, "hello", mapper=to_task, options=options), Union[str, Task]
+            )
 
 
 class CommandsAsync:
     @staticmethod
     async def execute(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
@@ -313,6 +394,35 @@ class CommandsAsync:
             assert_type(await commands.execute_scalar_async(query, params=params), Any)
             assert_type(await commands.query_multiple_async((query,), param=params), Tuple[List[Any], ...])
             assert_type(await commands.query_multiple_async((query,), params=params), Tuple[List[Any], ...])
+            assert_type(
+                await commands.query_multiple_async((query,), mapper=to_task, options=options), Tuple[List[Task]]
+            )
+            assert_type(
+                await commands.query_multiple_async((query,), mapper=to_task, param=params, options=options),
+                Tuple[List[Task]],
+            )
+            assert_type(
+                await commands.query_multiple_async((query,), mapper=to_task, params=params, options=options),
+                Tuple[List[Task]],
+            )
+            assert_type(
+                await commands.query_multiple_async((query, query), mapper=to_task, options=options),
+                Tuple[List[Task], List[Task]],
+            )
+            assert_type(
+                await commands.query_multiple_async((query, query, query), mapper=to_task, options=options),
+                Tuple[List[Task], List[Task], List[Task]],
+            )
+            assert_type(
+                await commands.query_multiple_async((query, query), mapper=(to_id, to_description), options=options),
+                Tuple[List[int], List[str]],
+            )
+            assert_type(
+                await commands.query_multiple_async(
+                    (query, query), mapper=(to_id, to_description), params=params, options=options
+                ),
+                Tuple[List[int], List[str]],
+            )
             assert_type(await commands.query_multiple_async((query,), mapper=to_task), Tuple[List[Task]])
             assert_type(
                 await commands.query_multiple_async((query, query), mapper=to_task),
@@ -326,6 +436,7 @@ class CommandsAsync:
     @staticmethod
     async def query(query: str):
         params = {"id": 1}
+        options = pydapper.CommandOptions()
         mapping_subclass_params = ParamsDict({"id": 1})
         dataclass_params = Task(1, "task", datetime.date.today(), 1)
         object_params = SimpleNamespace(id=1)
@@ -335,6 +446,18 @@ class CommandsAsync:
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_async(query, buffered=True), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, options=options), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, buffered=True, options=options), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, param=params, options=options), List[Dict[str, Any]])
+            assert_type(await commands.query_async(query, params=params, options=options), List[Dict[str, Any]])
+            assert_type(
+                await commands.query_async(query, buffered=buffered, options=options),
+                Union[List[Dict[str, Any]], AsyncGenerator[Dict[str, Any], None]],
+            )
+            assert_type(
+                await commands.query_async(query, buffered=False, options=options),
+                AsyncGenerator[Dict[str, Any], None],
+            )
             assert_type(await commands.query_async(query, buffered=False), AsyncGenerator[Dict[str, Any], None])
             assert_type(
                 await commands.query_async(query, buffered=buffered),
@@ -354,6 +477,16 @@ class CommandsAsync:
                 Union[List[Task], AsyncGenerator[Task, None]],
             )
             assert_type(await commands.query_async(query, model=Task, buffered=True), List[Task])
+            assert_type(await commands.query_async(query, model=Task, options=options), List[Task])
+            assert_type(await commands.query_async(query, model=Task, buffered=True, options=options), List[Task])
+            assert_type(
+                await commands.query_async(query, model=Task, buffered=buffered, options=options),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
+            assert_type(
+                await commands.query_async(query, model=Task, buffered=False, options=options),
+                AsyncGenerator[Task, None],
+            )
             assert_type(await commands.query_async(query, model=Task, buffered=False), AsyncGenerator[Task, None])
             assert_type(
                 await commands.query_async(query, model=Task, buffered=buffered),
@@ -364,6 +497,16 @@ class CommandsAsync:
                 Union[List[Task], AsyncGenerator[Task, None]],
             )
             assert_type(await commands.query_async(query, mapper=to_task), List[Task])
+            assert_type(await commands.query_async(query, mapper=to_task, options=options), List[Task])
+            assert_type(await commands.query_async(query, mapper=to_task, buffered=True, options=options), List[Task])
+            assert_type(
+                await commands.query_async(query, mapper=to_task, buffered=buffered, options=options),
+                Union[List[Task], AsyncGenerator[Task, None]],
+            )
+            assert_type(
+                await commands.query_async(query, mapper=to_task, buffered=False, options=options),
+                AsyncGenerator[Task, None],
+            )
             assert_type(await commands.query_async(query, param=params, mapper=to_task), List[Task])
             assert_type(await commands.query_async(query, params=params, mapper=to_task), List[Task])
             assert_type(await commands.query_async(query, mapper=to_task, buffered=False), AsyncGenerator[Task, None])
@@ -392,6 +535,7 @@ class CommandsAsync:
     @staticmethod
     async def query_first(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_first_async(query), Dict[str, Any])
@@ -404,10 +548,15 @@ class CommandsAsync:
             assert_type(await commands.query_first_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_first_async(query, params=params, model=Task), Task)
             assert_type(await commands.query_first_async(query, params=params, mapper=to_task), Task)
+            assert_type(await commands.query_first_async(query, options=options), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, params=params, options=options), Dict[str, Any])
+            assert_type(await commands.query_first_async(query, model=Task, options=options), Task)
+            assert_type(await commands.query_first_async(query, mapper=to_task, options=options), Task)
 
     @staticmethod
     async def query_first_or_default(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         async with pydapper.connect_async() as commands:
             # passing a callable, the return type of the callable is part of the return type
@@ -435,10 +584,27 @@ class CommandsAsync:
             assert_type(
                 await commands.query_first_or_default_async(query, "hello", params=params), Union[str, Dict[str, Any]]
             )
+            assert_type(
+                await commands.query_first_or_default_async(query, default_callable, options=options),
+                Union[str, Dict[str, Any]],
+            )
+            assert_type(
+                await commands.query_first_or_default_async(query, "hello", options=options),
+                Union[str, Dict[str, Any]],
+            )
+            assert_type(
+                await commands.query_first_or_default_async(query, default_callable, model=Task, options=options),
+                Union[str, Task],
+            )
+            assert_type(
+                await commands.query_first_or_default_async(query, "hello", mapper=to_task, options=options),
+                Union[str, Task],
+            )
 
     @staticmethod
     async def query_single(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         async with pydapper.connect_async() as commands:
             assert_type(await commands.query_single_async(query), Dict[str, Any])
@@ -451,10 +617,15 @@ class CommandsAsync:
             assert_type(await commands.query_single_async(query, params=params), Dict[str, Any])
             assert_type(await commands.query_single_async(query, params=params, model=Task), Task)
             assert_type(await commands.query_single_async(query, params=params, mapper=to_task), Task)
+            assert_type(await commands.query_single_async(query, options=options), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, param=params, options=options), Dict[str, Any])
+            assert_type(await commands.query_single_async(query, model=Task, options=options), Task)
+            assert_type(await commands.query_single_async(query, mapper=to_task, options=options), Task)
 
     @staticmethod
     async def query_single_or_default(query: str) -> None:
         params = {"id": 1}
+        options = pydapper.CommandOptions()
 
         async with pydapper.connect_async() as commands:
             # passing a callable, the return type of the callable is part of the return type
@@ -481,4 +652,20 @@ class CommandsAsync:
             )
             assert_type(
                 await commands.query_single_or_default_async(query, "hello", params=params), Union[str, Dict[str, Any]]
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, default_callable, options=options),
+                Union[str, Dict[str, Any]],
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, "hello", options=options),
+                Union[str, Dict[str, Any]],
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, default_callable, model=Task, options=options),
+                Union[str, Task],
+            )
+            assert_type(
+                await commands.query_single_or_default_async(query, "hello", mapper=to_task, options=options),
+                Union[str, Task],
             )

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator
 from typing import Dict
 from typing import Generator
 from typing import List
+from typing import Literal
 from typing import Tuple
 from typing import Union
 
@@ -80,6 +81,8 @@ task_mapper: pydapper.Mapper[Task] = to_task
 
 
 def public_exceptions() -> None:
+    assert_type(pydapper.CommandKind.TEXT, Literal[pydapper.CommandKind.TEXT])
+    assert_type(pydapper.CommandOptions(), pydapper.CommandOptions)
     assert_type(task_mapper, pydapper.Mapper[Task])
     assert_type(pydapper.RawRow(("id",), (1,)), pydapper.RawRow)
     assert_type(pydapper.RawRow(("id",), (1,)).columns, Tuple[str, ...])
@@ -116,6 +119,7 @@ class Commands:
 
         with pydapper.connect() as commands:
             assert_type(commands.execute(query, param=params), int)
+            assert_type(commands.execute(query, options=pydapper.CommandOptions()), int)
             assert_type(commands.execute(query, params=params), int)
             assert_type(commands.execute(query, params=mapping_subclass_params), int)
             assert_type(commands.execute(query, params=dataclass_params), int)
@@ -126,6 +130,7 @@ class Commands:
             assert_type(commands.execute(query, params=batch_params), int)
             assert_type(commands.execute_scalar(query, param=params), Any)
             assert_type(commands.execute_scalar(query, params=params), Any)
+            assert_type(commands.execute_scalar(query, options=pydapper.CommandOptions()), Any)
             assert_type(commands.query_multiple((query,), param=params), Tuple[List[Any], ...])
             assert_type(commands.query_multiple((query,), params=params), Tuple[List[Any], ...])
             assert_type(commands.query_multiple((query,), mapper=to_task), Tuple[List[Task]])
@@ -147,6 +152,7 @@ class Commands:
 
         with pydapper.connect() as commands:
             assert_type(commands.query(query, buffered=True), List[Dict[str, Any]])
+            assert_type(commands.query(query, options=pydapper.CommandOptions()), List[Dict[str, Any]])
             assert_type(commands.query(query, buffered=False), Generator[Dict[str, Any], None, None])
             assert_type(
                 commands.query(query, buffered=buffered),
@@ -176,6 +182,7 @@ class Commands:
             )
             assert_type(commands.query(query, model=lambda **kwargs: Task(**kwargs)), List[Task])
             assert_type(commands.query(query, mapper=to_task), List[Task])
+            assert_type(commands.query(query, model=Task, options=pydapper.CommandOptions()), List[Task])
             assert_type(commands.query(query, param=params, mapper=to_task), List[Task])
             assert_type(commands.query(query, params=params, mapper=to_task), List[Task])
             assert_type(


### PR DESCRIPTION
## What changed

This PR introduces a public, immutable command-options model and threads it through the normal synchronous and asynchronous command APIs without changing pydapper's existing row mapping behavior.

- Adds `CommandOptions` and `CommandKind` to the public `pydapper` namespace.
- Adds keyword-only `options=` support to execute, scalar, query, query-multiple, first/single, and default-helper APIs, including async equivalents.
- Centralizes option validation in the shared command base class.
- Treats `CommandOptions()` exactly like `options=None` while rejecting valid but not-yet-supported non-default options with `UnsupportedFeatureError`.
- Preserves the existing overload matrix for default dictionaries, models, raw-row mappers, buffered/unbuffered reads, default values/factories, and homogeneous or heterogeneous result-set tuples.
- Documents the option fields and current support boundary in the centralized Command options page.

## Usage

Default options preserve the existing behavior:

```python
import pydapper

options = pydapper.CommandOptions()

with pydapper.connect("sqlite:///:memory:") as db:
    rows = db.query(
        "select id, description from task where id = :id",
        params={"id": 1},
        options=options,
    )
    # inferred as list[dict[str, Any]]
```

Model, mapper, and buffering inference remains precise:

```python
from collections.abc import Generator

tasks = db.query("select * from task", model=Task, options=options)
# list[Task]

stream = db.query(
    "select * from task",
    mapper=to_task,
    buffered=False,
    options=options,
)
# Generator[Task, None, None]

buffered: bool = choose_buffering()
result = db.query("select * from task", model=Task, buffered=buffered, options=options)
# list[Task] | Generator[Task, None, None]
```

Default factories and multi-result mapper tuples also retain their mapped types:

```python
task = db.query_first_or_default(
    "select * from task where id = :id",
    lambda: "missing",
    model=Task,
    params={"id": 1},
    options=options,
)
# str | Task

ids, descriptions = db.query_multiple(
    ("select id from task", "select description from task"),
    mapper=(to_id, to_description),
    options=options,
)
# tuple[list[int], list[str]]
```

Async methods provide the corresponding types, with unbuffered queries returning `AsyncGenerator`.

## Validation and compatibility

`CommandOptions()` is behaviorally equivalent to omitting `options`. In particular, the four `*_or_default` helpers do not forward an `options` keyword when delegating to legacy/custom `query_first` or `query_single` overrides that predate this API.

Positive finite `Real` timeout values are accepted by the model, including arbitrarily large integers. Because timeout execution is not implemented yet, using one reaches shared validation and raises clearly:

```python
options = pydapper.CommandOptions(timeout=10**1000)
db.execute("select 1", options=options)
# raises UnsupportedFeatureError: Command option 'timeout' is not supported
```

Invalid field values continue to raise `TypeError` or `ValueError` during `CommandOptions` construction. No dependency, lockfile, SQL parameter-substitution, cursor, or backend behavior changes are included.

## Verification

Passed locally on Python 3.10.19:

- `poetry run pytest -m "core"` — 458 passed, 208 deselected
- `poetry run pytest -m "sqlite"` — 29 passed, 637 deselected
- `poetry run mypy pydapper` — success, 25 source files
- `poetry run mypy tests/type_tests.py` — success, 1 source file
- `poetry run black --check .` — 118 files unchanged
- `poetry run isort --check .` — passed (`Skipped 1 files`)
- `poetry run mkdocs build --strict` — passed; all 14 repaired method pages render `<table>` elements
- `git diff --check` — passed

The expanded exact-type assertions were also run against the pre-fix commit `f046590`; they fail there with 42 errors, including `list[Never]`, missing runtime-`bool` overloads, `tuple[list[Any], ...]`, and rejected callable defaults.

PostgreSQL, MySQL, MSSQL, Oracle, and BigQuery integrations were skipped because this change does not alter backend-specific behavior and those suites require optional dependencies and/or external services.

## Scope and follow-up

This PR models but does not implement timeout enforcement, guarded/read-only execution, row limits, stored-procedure execution, or adapter capability infrastructure. Those remain tracked by #482, #475, #481, and #467.
