### PR TITLE
feat: stabilize adapter registration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,9 @@ coverage:
 codecov:
   max_report_age: off
   allow_coverage_offsets: True
+  notify:
+    # Seven test suites upload coverage for each of five Python versions.
+    after_n_builds: 35
+
+comment:
+  after_n_builds: 35

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -1,0 +1,124 @@
+# Adapter registration
+
+`pydapper.register_adapter()` is the single way to register a DB-API adapter. An adapter registration provides
+the command implementation for one or both modes and a synchronous predicate used to recognize connection objects.
+
+```python
+import pydapper
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+
+
+class AcmeCommands(Commands):
+    @classmethod
+    def connect(cls, parsed_dsn, **connect_kwargs):
+        raise NotImplementedError
+
+
+class AcmeCommandsAsync(CommandsAsync):
+    @classmethod
+    async def connect_async(cls, parsed_dsn, **connect_kwargs):
+        raise NotImplementedError
+
+
+def can_handle_connection(connection: object) -> bool:
+    module = type(connection).__module__
+    return module == "acmedb" or module.startswith("acmedb.")
+
+
+pydapper.register_adapter(
+    "acmedb",
+    commands=AcmeCommands,
+    async_commands=AcmeCommandsAsync,
+    can_handle_connection=can_handle_connection,
+)
+```
+
+`commands` must be a `Commands` subclass and `async_commands` must be a `CommandsAsync` subclass. Using the classes
+and predicate above, supply either one for a sync-only or async-only adapter, or both when the driver supports both
+modes:
+
+```python
+pydapper.register_adapter(
+    "acmedb-sync",
+    commands=AcmeCommands,
+    can_handle_connection=can_handle_connection,
+)
+
+pydapper.register_adapter(
+    "acmedb-async",
+    async_commands=AcmeCommandsAsync,
+    can_handle_connection=can_handle_connection,
+)
+```
+
+The registration name is exact and case-sensitive. It is also the DB-API part of a DSN, so registering `"acmedb"`
+allows `connect()` to route an `acme+acmedb://...` DSN to that adapter. Names must be non-empty strings without
+leading or trailing whitespace. A predicate is required and must be callable.
+
+Registration is atomic and permanent for the process: supplying no command class, an invalid command class, or an
+invalid predicate raises an error without changing the registry. A second registration of the same exact name always
+raises `ValueError`, even if it appears identical. There is no replacement, priority, alias, or unregister API.
+
+## Selecting an adapter for an existing connection
+
+When no adapter is named, `using()` and `using_async()` automatically consider the registrations that support the
+requested mode and run every eligible `can_handle_connection()` predicate. Exactly one matching predicate selects the
+adapter.
+
+```python
+commands = pydapper.using(connection)
+async_commands = pydapper.using_async(async_connection)
+```
+
+No matching predicate raises `ValueError` with guidance to register an adapter or pass `adapter=`. More than one
+match also raises `ValueError`, names the matching adapters, and asks the caller to choose explicitly. Registration
+order never resolves an ambiguous match. If a predicate raises an exception, selection raises `ValueError` identifying
+the adapter and preserves the original exception as its cause.
+
+Predicates should be synchronous and side-effect-free. In particular, they should inspect connection metadata without
+importing optional drivers. Built-in predicates inspect the class MRO so ordinary driver subclasses work, but arbitrary
+wrappers and proxies are intentionally not inferred.
+
+## Explicit selection
+
+For the `connection` and `async_connection` objects in the preceding example, pass a registered name to override
+automatic selection directly:
+
+```python
+commands = pydapper.using(connection, adapter="acmedb")
+async_commands = pydapper.using_async(async_connection, adapter="acmedb")
+```
+
+`adapter` is keyword-only. Explicit selection looks up the exact registration name, never calls its predicate, and
+returns the command class for the requested mode. It is the supported escape hatch for wrappers, proxies, ambiguous
+connections, and objects automatic detection cannot recognize. An unknown name or a registered adapter without the
+requested sync/async mode raises `ValueError`.
+
+## Migrating from decorator registration
+
+The following is the removed v0 decorator pattern, shown only to aid migration. Do not use it in v1:
+
+```python
+@register("acmedb")
+class AcmeCommands(Commands):
+    ...
+
+
+@register_async("acmedb")
+class AcmeCommandsAsync(CommandsAsync):
+    ...
+```
+
+In v1, register the `AcmeCommands`, `AcmeCommandsAsync`, and `can_handle_connection` names defined above in one call:
+
+```python
+pydapper.register_adapter(
+    "acmedb",
+    commands=AcmeCommands,
+    async_commands=AcmeCommandsAsync,
+    can_handle_connection=can_handle_connection,
+)
+```
+
+This single call makes the adapter name, both supported modes, and its detection rule explicit.

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -1,7 +1,8 @@
 # Adapter registration
 
 `pydapper.register_adapter()` is the single way to register a DB-API adapter. An adapter registration provides
-the command implementation for one or both modes and a synchronous predicate used to recognize connection objects.
+the command implementation for one or both modes and a synchronous `using_connection_predicate` used only for
+automatic adapter selection of externally supplied connections through `using()` and `using_async()`.
 
 ```python
 import pydapper
@@ -21,7 +22,7 @@ class AcmeCommandsAsync(CommandsAsync):
         raise NotImplementedError
 
 
-def can_handle_connection(connection: object) -> bool:
+def is_acme_connection(connection: object) -> bool:
     module = type(connection).__module__
     return module == "acmedb" or module.startswith("acmedb.")
 
@@ -30,27 +31,31 @@ pydapper.register_adapter(
     "acmedb",
     commands=AcmeCommands,
     async_commands=AcmeCommandsAsync,
-    can_handle_connection=can_handle_connection,
+    using_connection_predicate=is_acme_connection,
 )
 ```
 
 `commands` must be a `Commands` subclass and `async_commands` must be a `CommandsAsync` subclass. Using the classes
-and predicate above, supply either one for a sync-only or async-only adapter, or both when the driver supports both
-modes:
+and using connection predicate above, supply either one for a sync-only or async-only adapter, or both when the driver
+supports both modes:
 
 ```python
 pydapper.register_adapter(
     "acmedb-sync",
     commands=AcmeCommands,
-    can_handle_connection=can_handle_connection,
+    using_connection_predicate=is_acme_connection,
 )
 
 pydapper.register_adapter(
     "acmedb-async",
     async_commands=AcmeCommandsAsync,
-    can_handle_connection=can_handle_connection,
+    using_connection_predicate=is_acme_connection,
 )
 ```
+
+The using connection predicate receives the externally supplied connection object. Return `True` to make the adapter
+eligible for automatic `using()` or `using_async()` selection, or `False` to leave it out. It is not a connection
+health check and is not used by explicit `adapter=` selection or DSN-based `connect()` / `connect_async()` calls.
 
 The registration name is exact and case-sensitive. It is also the DB-API part of a DSN, so registering `"acmedb"`
 allows `connect()` to route an `acme+acmedb://...` DSN to that adapter. Names must be non-empty strings without
@@ -63,8 +68,7 @@ raises `ValueError`, even if it appears identical. There is no replacement, prio
 ## Selecting an adapter for an existing connection
 
 When no adapter is named, `using()` and `using_async()` automatically consider the registrations that support the
-requested mode and run every eligible `can_handle_connection()` predicate. Exactly one matching predicate selects the
-adapter.
+requested mode and run every eligible using connection predicate. Exactly one matching predicate selects the adapter.
 
 ```python
 commands = pydapper.using(connection)
@@ -76,9 +80,9 @@ match also raises `ValueError`, names the matching adapters, and asks the caller
 order never resolves an ambiguous match. If a predicate raises an exception, selection raises `ValueError` identifying
 the adapter and preserves the original exception as its cause.
 
-Predicates should be synchronous and side-effect-free. In particular, they should inspect connection metadata without
-importing optional drivers. Built-in predicates inspect the class MRO so ordinary driver subclasses work, but arbitrary
-wrappers and proxies are intentionally not inferred.
+Using connection predicates should be synchronous and side-effect-free. In particular, they should inspect connection
+metadata without importing optional drivers. Built-in predicates inspect the class MRO so ordinary driver subclasses
+work, but arbitrary wrappers and proxies are intentionally not inferred.
 
 ## Explicit selection
 
@@ -90,10 +94,10 @@ commands = pydapper.using(connection, adapter="acmedb")
 async_commands = pydapper.using_async(async_connection, adapter="acmedb")
 ```
 
-`adapter` is keyword-only. Explicit selection looks up the exact registration name, never calls its predicate, and
-returns the command class for the requested mode. It is the supported escape hatch for wrappers, proxies, ambiguous
-connections, and objects automatic detection cannot recognize. An unknown name or a registered adapter without the
-requested sync/async mode raises `ValueError`.
+`adapter` is keyword-only. Explicit selection looks up the exact registration name, never calls its using connection
+predicate, and returns the command class for the requested mode. It is the supported escape hatch for wrappers,
+proxies, ambiguous connections, and objects automatic detection cannot recognize. An unknown name or a registered
+adapter without the requested sync/async mode raises `ValueError`.
 
 ## Migrating from decorator registration
 
@@ -110,14 +114,14 @@ class AcmeCommandsAsync(CommandsAsync):
     ...
 ```
 
-In v1, register the `AcmeCommands`, `AcmeCommandsAsync`, and `can_handle_connection` names defined above in one call:
+In v1, register the `AcmeCommands`, `AcmeCommandsAsync`, and `is_acme_connection` names defined above in one call:
 
 ```python
 pydapper.register_adapter(
     "acmedb",
     commands=AcmeCommands,
     async_commands=AcmeCommandsAsync,
-    can_handle_connection=can_handle_connection,
+    using_connection_predicate=is_acme_connection,
 )
 ```
 

--- a/docs/database_support/intro.md
+++ b/docs/database_support/intro.md
@@ -18,8 +18,8 @@ There are four core concepts to understand about each dbapi *pydapper* supports:
 : The name of the driver that should be included in the dsn passed to the `connect` method (see examples).
 
 **Base connection class**
-: The class path of the connection class that must be passed or inherited from when passed into the `using` method 
-  (see examples).
+: The class path used by the built-in automatic-selection predicate. Ordinary subclasses are recognized through their
+  class MRO; wrappers and proxies should use explicit `adapter=` selection (see examples).
 
 
 
@@ -64,8 +64,9 @@ for this could be if you have a custom connection pool in your application and y
 to get in the way of using it.  Another example is reuse of connection objects from a framework like Django ORM
 or SQLAlchemy.
 
-In order to use this entry point, the connection object you are passing in must be an instance of or inherit from
-one of the dbapi connection objects that *pydapper* supports.
+Without an explicit adapter name, `using` runs the registered sync adapter predicates and requires exactly one match.
+Native DB-API connection objects and ordinary subclasses of the supported connection classes are recognized. Pass a
+registered adapter name with `adapter=` to override automatic selection when needed.
 
 Below is a generic example using *pydapper* with a connection managed by `django`.
 
@@ -85,9 +86,16 @@ What's going on here?
   connection proxy
 * pass the dbapi connection object into `pydapper.using` and get a pydapper `Commands` instance back
 
+To override automatic selection, select the adapter directly. Explicit selection bypasses all predicates:
+
+```python
+commands = pydapper.using(dbapi_connection_object, adapter="psycopg2")
+```
+
 ### `using_async`
-You should use the `using_async` method when you want to use your own connection.  The api is almost identical to that
-of the sync api.
+You should use the `using_async` method when you want to use your own asynchronous connection. The API is almost
+identical to the sync API: it automatically selects exactly one registered async adapter, or accepts `adapter=` to
+override automatic selection.
 
 ```python
 import pydapper
@@ -95,4 +103,7 @@ import pydapper
 some_pool = ConnectionPool()
 conn = await some_pool.acquire()
 commands = pydapper.using_async(conn)
+
+# Explicit adapter selection also works for async connections.
+commands = pydapper.using_async(conn, adapter="psycopg")
 ```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 ## Latest Changes
 
+### Breaking Changes
+
+* Adapter registration: `register` and `register_async` were removed. Use [`register_adapter`](adapter_registration.md) and explicit `adapter=` selection where needed.
+
+### Other Changes
+
 * feat: add command options model. PR [#531](https://github.com/zschumacher/pydapper/pull/531) by [@zschumacher](https://github.com/zschumacher).
 * docs: define v1 compatibility policy. PR [#530](https://github.com/zschumacher/pydapper/pull/530) by [@zschumacher](https://github.com/zschumacher).
 * fix: guarantee query cursor cleanup. PR [#529](https://github.com/zschumacher/pydapper/pull/529) by [@zschumacher](https://github.com/zschumacher).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Overview: index.md
   - Compatibility Policy: compatibility.md
   - Command options: command_options.md
+  - Adapter registration: adapter_registration.md
   - Database Support:
       - Intro - Database Support: database_support/intro.md
       - Google BigQuery: database_support/bigquery.md

--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -1,18 +1,10 @@
-from .bigquery import GoogleBigqueryClientCommands as _GoogleBigqueryClientCommands
+from . import _builtin_adapters as _builtin_adapters
 from .command_options import CommandKind
 from .command_options import CommandOptions
 from .main import connect
 from .main import connect_async
-from .main import register
-from .main import register_async
+from .main import register_adapter
 from .main import using
 from .main import using_async
-from .mssql import PymssqlCommands as _PymssqlCommands
-from .mysql import MySqlConnectorPythonCommands as _MySqlConnectorPythonCommands
-from .postgresql import AiopgCommands as _AioPgCommand
-from .postgresql import Psycopg2Commands as _Psycopg2Commands
-from .postgresql import Psycopg3Commands as _Psycopg3Commands
-from .postgresql import Psycopg3CommandsAsync as _Psycopg3CommandsAsync
 from .rows import Mapper
 from .rows import RawRow
-from .sqlite import Sqlite3Commands as _Sqlite3Commands

--- a/pydapper/_builtin_adapters.py
+++ b/pydapper/_builtin_adapters.py
@@ -24,43 +24,45 @@ def _register_builtin_adapters() -> None:
     register_adapter(
         "sqlite3",
         commands=Sqlite3Commands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "sqlite3"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "sqlite3"),
     )
     register_adapter(
         "psycopg2",
         commands=Psycopg2Commands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "psycopg2"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg2"),
     )
     register_adapter(
         "psycopg",
         commands=Psycopg3Commands,
         async_commands=Psycopg3CommandsAsync,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "psycopg"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg"),
     )
     register_adapter(
         "aiopg",
         async_commands=AiopgCommands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "aiopg"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "aiopg"),
     )
     register_adapter(
         "mysql",
         commands=MySqlConnectorPythonCommands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "mysql.connector"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "mysql.connector"),
     )
     register_adapter(
         "pymssql",
         commands=PymssqlCommands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "pymssql"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "pymssql"),
     )
     register_adapter(
         "oracledb",
         commands=OracledbCommands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "oracledb"),
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "oracledb"),
     )
     register_adapter(
         "google",
         commands=GoogleBigqueryClientCommands,
-        can_handle_connection=lambda connection: _connection_module_matches(connection, "google.cloud.bigquery.dbapi"),
+        using_connection_predicate=lambda connection: _connection_module_matches(
+            connection, "google.cloud.bigquery.dbapi"
+        ),
     )
 
 

--- a/pydapper/_builtin_adapters.py
+++ b/pydapper/_builtin_adapters.py
@@ -1,0 +1,67 @@
+from .bigquery import GoogleBigqueryClientCommands
+from .main import register_adapter
+from .mssql import PymssqlCommands
+from .mysql import MySqlConnectorPythonCommands
+from .oracle import OracledbCommands
+from .postgresql import AiopgCommands
+from .postgresql import Psycopg2Commands
+from .postgresql import Psycopg3Commands
+from .postgresql import Psycopg3CommandsAsync
+from .sqlite import Sqlite3Commands
+
+
+def _connection_module_matches(connection: object, *module_prefixes: str) -> bool:
+    for connection_class in type(connection).__mro__:
+        module = getattr(connection_class, "__module__", "")
+        if not isinstance(module, str):
+            continue
+        if any(module == prefix or module.startswith(f"{prefix}.") for prefix in module_prefixes):
+            return True
+    return False
+
+
+def _register_builtin_adapters() -> None:
+    register_adapter(
+        "sqlite3",
+        commands=Sqlite3Commands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "sqlite3"),
+    )
+    register_adapter(
+        "psycopg2",
+        commands=Psycopg2Commands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "psycopg2"),
+    )
+    register_adapter(
+        "psycopg",
+        commands=Psycopg3Commands,
+        async_commands=Psycopg3CommandsAsync,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "psycopg"),
+    )
+    register_adapter(
+        "aiopg",
+        async_commands=AiopgCommands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "aiopg"),
+    )
+    register_adapter(
+        "mysql",
+        commands=MySqlConnectorPythonCommands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "mysql.connector"),
+    )
+    register_adapter(
+        "pymssql",
+        commands=PymssqlCommands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "pymssql"),
+    )
+    register_adapter(
+        "oracledb",
+        commands=OracledbCommands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "oracledb"),
+    )
+    register_adapter(
+        "google",
+        commands=GoogleBigqueryClientCommands,
+        can_handle_connection=lambda connection: _connection_module_matches(connection, "google.cloud.bigquery.dbapi"),
+    )
+
+
+_register_builtin_adapters()

--- a/pydapper/bigquery/google_bigquery_client.py
+++ b/pydapper/bigquery/google_bigquery_client.py
@@ -2,14 +2,12 @@ from typing import TYPE_CHECKING
 
 from pydapper.commands import Commands
 
-from ..main import register
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
 
 
-@register("google")
 class GoogleBigqueryClientCommands(Commands):
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -2,100 +2,178 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING
-from typing import Dict
-from typing import Optional
-from typing import Type
-from typing import Union
-from typing import cast
+from collections.abc import Callable
+from dataclasses import dataclass
 
 from ._context import CoroContextManager
 from .commands import Commands
 from .commands import CommandsAsync
 from .dsn_parser import PydapperParseResult
-
-if TYPE_CHECKING:
-    from .commands import Commands
-    from .commands import CommandsAsync
-    from .types import AsyncConnectionType
-    from .types import ConnectionType
+from .types import AsyncConnectionType
+from .types import ConnectionType
 
 logger = logging.getLogger(__name__)
 
 
-def parse_dsn(dsn: Optional[str]) -> PydapperParseResult:
+@dataclass(frozen=True)
+class _AdapterRegistration:
+    name: str
+    commands: type[Commands] | None
+    async_commands: type[CommandsAsync] | None
+    can_handle_connection: Callable[[object], bool]
+
+
+_adapter_registry: dict[str, _AdapterRegistration] = {}
+
+
+def register_adapter(
+    name: str,
+    *,
+    commands: type[Commands] | None = None,
+    async_commands: type[CommandsAsync] | None = None,
+    can_handle_connection: Callable[[object], bool],
+) -> None:
+    """Register command implementations for a DB-API adapter.
+
+    Registration is intentionally one-way: an adapter name may only be registered
+    once so import order cannot silently replace a command implementation.
+    """
+    if not isinstance(name, str):
+        raise TypeError("Adapter name must be a string")
+    if not name or name != name.strip():
+        raise ValueError("Adapter name must be non-empty and have no surrounding whitespace")
+    if name in _adapter_registry:
+        raise ValueError(f"Adapter {name!r} is already registered")
+    if commands is None and async_commands is None:
+        raise ValueError("At least one sync or async command class is required")
+    if commands is not None and (not isinstance(commands, type) or not issubclass(commands, Commands)):
+        raise TypeError("commands must be a Commands subclass")
+    if async_commands is not None and (
+        not isinstance(async_commands, type) or not issubclass(async_commands, CommandsAsync)
+    ):
+        raise TypeError("async_commands must be a CommandsAsync subclass")
+    if not callable(can_handle_connection):
+        raise TypeError("can_handle_connection must be callable")
+
+    _adapter_registry[name] = _AdapterRegistration(
+        name=name,
+        commands=commands,
+        async_commands=async_commands,
+        can_handle_connection=can_handle_connection,
+    )
+
+
+def parse_dsn(dsn: str | None) -> PydapperParseResult:
     dsn = dsn or os.getenv("PYDAPPER_DSN")
     if dsn is None:  # pragma: no cover
         raise ValueError("dsn must be passed to connect or env var `PYDAPPER_DSN` must be set.")
     return PydapperParseResult(dsn)
 
 
-def find_command_class_in_registry_by_connection(
-    connection: Union["ConnectionType", "AsyncConnectionType"],
-    registry: Union[Dict[str, Type["Commands"]], Dict[str, Type["CommandsAsync"]]],
-) -> Union[Type["Commands"], Type["CommandsAsync"]]:
-    connection_base_modules = {str(klass.__module__).split(".")[0] for klass in connection.__class__.__bases__}
-    # this will happen if you have a connection that doesn't inherit from anything
-    if connection_base_modules == {"builtins"}:  # pragma: no branch
-        connection_base_modules = {connection.__class__.__module__.split(".")[0]}
-    registered_dbapi_modules = set(registry.keys())
-    intersection = connection_base_modules.intersection(registered_dbapi_modules)
+def _get_registration(name: str, mode: str) -> _AdapterRegistration:
+    try:
+        return _adapter_registry[name]
+    except KeyError:
+        raise ValueError(f"No adapter named {name!r} is registered for {mode} mode") from None
 
-    if not intersection:
-        raise ValueError(f"No command support registered for {connection}")
 
-    return registry[intersection.pop()]
+def _get_sync_commands_class(name: str) -> type[Commands]:
+    registration = _get_registration(name, "sync")
+    if registration.commands is None:
+        raise ValueError(f"Adapter {name!r} does not support sync mode")
+    return registration.commands
+
+
+def _get_async_commands_class(name: str) -> type[CommandsAsync]:
+    registration = _get_registration(name, "async")
+    if registration.async_commands is None:
+        raise ValueError(f"Adapter {name!r} does not support async mode")
+    return registration.async_commands
+
+
+def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
+    matches: list[_AdapterRegistration] = []
+
+    for registration in sorted(_adapter_registry.values(), key=lambda item: item.name):
+        if mode == "sync" and registration.commands is None:
+            continue
+        if mode == "async" and registration.async_commands is None:
+            continue
+
+        try:
+            matches_connection = registration.can_handle_connection(connection)
+        except Exception as exc:
+            raise ValueError(
+                f"Adapter {registration.name!r} failed while checking a connection for {mode} mode"
+            ) from exc
+
+        if matches_connection:
+            matches.append(registration)
+
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise ValueError(
+            f"No registered {mode} adapter can handle {connection!r}; "
+            "register an adapter or pass adapter= explicitly"
+        )
+
+    matching_names = ", ".join(registration.name for registration in matches)
+    raise ValueError(
+        f"Multiple registered {mode} adapters can handle {connection!r}: {matching_names}. Pass adapter= explicitly"
+    )
+
+
+def _select_sync_commands_class(connection: object) -> type[Commands]:
+    registration = _select_registration(connection, "sync")
+    assert registration.commands is not None
+    return registration.commands
+
+
+def _select_async_commands_class(connection: object) -> type[CommandsAsync]:
+    registration = _select_registration(connection, "async")
+    assert registration.async_commands is not None
+    return registration.async_commands
 
 
 class CommandFactory:
-    sync_registry: Dict[str, Type["Commands"]] = dict()
-    async_registry: Dict[str, Type["CommandsAsync"]] = dict()
-
     @classmethod
-    def from_dsn(cls, dsn: str = None, **connect_kwargs) -> "Commands":
+    def from_dsn(cls, dsn: str | None = None, **connect_kwargs) -> Commands:
         parsed_dsn = parse_dsn(dsn)
-        return cls.sync_registry[parsed_dsn.dbapi].connect(parsed_dsn, **connect_kwargs)
+        return _get_sync_commands_class(parsed_dsn.dbapi).connect(parsed_dsn, **connect_kwargs)
 
     @classmethod
-    def from_dsn_async(cls, dsn: str = None, **connect_kwargs) -> CoroContextManager["CommandsAsync"]:
+    def from_dsn_async(cls, dsn: str | None = None, **connect_kwargs) -> CoroContextManager[CommandsAsync]:
         parsed_dsn = parse_dsn(dsn)
-        return CoroContextManager(cls.async_registry[parsed_dsn.dbapi].connect_async(parsed_dsn, **connect_kwargs))
+        commands_class = _get_async_commands_class(parsed_dsn.dbapi)
+        return CoroContextManager(commands_class.connect_async(parsed_dsn, **connect_kwargs))
 
     @classmethod
-    def from_connection(cls, connection: "ConnectionType") -> "Commands":
-        commands_class = cast(
-            Type["Commands"], find_command_class_in_registry_by_connection(connection, cls.sync_registry)
+    def from_connection(cls, connection: ConnectionType, *, adapter: str | None = None) -> Commands:
+        commands_class = (
+            _get_sync_commands_class(adapter) if adapter is not None else _select_sync_commands_class(connection)
         )
         return commands_class(connection)
 
     @classmethod
-    def from_connection_async(cls, connection: AsyncConnectionType) -> "CommandsAsync":
-        commands_class = cast(
-            Type["CommandsAsync"],
-            find_command_class_in_registry_by_connection(connection, cls.async_registry),
+    def from_connection_async(cls, connection: AsyncConnectionType, *, adapter: str | None = None) -> CommandsAsync:
+        commands_class = (
+            _get_async_commands_class(adapter) if adapter is not None else _select_async_commands_class(connection)
         )
         return commands_class(connection)
 
-    @classmethod
-    def register(cls, name: str):
-        def inner_wrapper(wrapped_class: Type["Commands"]):
-            CommandFactory.sync_registry[name] = wrapped_class
-            return wrapped_class
 
-        return inner_wrapper
-
-    @classmethod
-    def register_async(cls, name: str):
-        def inner_wrapper(wrapped_class: Type["CommandsAsync"]):
-            CommandFactory.async_registry[name] = wrapped_class
-            return wrapped_class
-
-        return inner_wrapper
+def connect(dsn: str | None = None, **connect_kwargs) -> Commands:
+    return CommandFactory.from_dsn(dsn, **connect_kwargs)
 
 
-register = CommandFactory.register
-register_async = CommandFactory.register_async
-using = CommandFactory.from_connection
-using_async = CommandFactory.from_connection_async
-connect = CommandFactory.from_dsn
-connect_async = CommandFactory.from_dsn_async
+def connect_async(dsn: str | None = None, **connect_kwargs) -> CoroContextManager[CommandsAsync]:
+    return CommandFactory.from_dsn_async(dsn, **connect_kwargs)
+
+
+def using(connection: ConnectionType, *, adapter: str | None = None) -> Commands:
+    return CommandFactory.from_connection(connection, adapter=adapter)
+
+
+def using_async(connection: AsyncConnectionType, *, adapter: str | None = None) -> CommandsAsync:
+    return CommandFactory.from_connection_async(connection, adapter=adapter)

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -20,7 +20,7 @@ class _AdapterRegistration:
     name: str
     commands: type[Commands] | None
     async_commands: type[CommandsAsync] | None
-    can_handle_connection: Callable[[object], bool]
+    using_connection_predicate: Callable[[object], bool]
 
 
 _adapter_registry: dict[str, _AdapterRegistration] = {}
@@ -31,12 +31,13 @@ def register_adapter(
     *,
     commands: type[Commands] | None = None,
     async_commands: type[CommandsAsync] | None = None,
-    can_handle_connection: Callable[[object], bool],
+    using_connection_predicate: Callable[[object], bool],
 ) -> None:
     """Register command implementations for a DB-API adapter.
 
     Registration is intentionally one-way: an adapter name may only be registered
-    once so import order cannot silently replace a command implementation.
+    once so import order cannot silently replace a command implementation. The
+    using_connection_predicate is used only for automatic connection selection.
     """
     if not isinstance(name, str):
         raise TypeError("Adapter name must be a string")
@@ -52,14 +53,14 @@ def register_adapter(
         not isinstance(async_commands, type) or not issubclass(async_commands, CommandsAsync)
     ):
         raise TypeError("async_commands must be a CommandsAsync subclass")
-    if not callable(can_handle_connection):
-        raise TypeError("can_handle_connection must be callable")
+    if not callable(using_connection_predicate):
+        raise TypeError("using_connection_predicate must be callable")
 
     _adapter_registry[name] = _AdapterRegistration(
         name=name,
         commands=commands,
         async_commands=async_commands,
-        can_handle_connection=can_handle_connection,
+        using_connection_predicate=using_connection_predicate,
     )
 
 
@@ -101,7 +102,7 @@ def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
             continue
 
         try:
-            matches_connection = registration.can_handle_connection(connection)
+            matches_connection = registration.using_connection_predicate(connection)
         except Exception as exc:
             raise ValueError(
                 f"Adapter {registration.name!r} failed while checking a connection for {mode} mode"

--- a/pydapper/mssql/pymssql.py
+++ b/pydapper/mssql/pymssql.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from pydapper import register
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
 _PARAM_TYPE_LOOKUP = {float: "%d", int: "%d", str: "%s", Decimal: "%d"}
 
 
-@register("pymssql")
 class PymssqlCommands(Commands):
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from pydapper import register
 from pydapper.commands import _MAPPER_UNSET
 from pydapper.commands import _MODEL_UNSET
 from pydapper.commands import _PARAM_ALIAS_UNSET
@@ -53,7 +52,6 @@ def _discard_unread_result(cursor: "CursorType") -> None:
             pass
 
 
-@register("mysql")
 class MySqlConnectorPythonCommands(Commands):
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/oracle/oracledb.py
+++ b/pydapper/oracle/oracledb.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from pydapper import register
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -10,7 +9,6 @@ if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
 
 
-@register("oracledb")
 class OracledbCommands(Commands):
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/pydapper/postgresql/aiopg.py
+++ b/pydapper/postgresql/aiopg.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from pydapper.commands import CommandsAsync
 from pydapper.commands import DefaultSqlParamHandler
 
-from ..main import register_async
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
@@ -11,7 +10,6 @@ if TYPE_CHECKING:
     from ..types import AsyncCursorType
 
 
-@register_async("aiopg")
 class AiopgCommands(CommandsAsync):
     class SqlParamHandler(DefaultSqlParamHandler):
         async def execute_async(self, cursor: "AsyncCursorType"):

--- a/pydapper/postgresql/psycopg2.py
+++ b/pydapper/postgresql/psycopg2.py
@@ -2,14 +2,12 @@ from typing import TYPE_CHECKING
 
 from pydapper.commands import Commands
 
-from ..main import register
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
 
 
-@register("psycopg2")
 class Psycopg2Commands(Commands):
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -4,15 +4,12 @@ from pydapper.commands import Commands
 from pydapper.commands import CommandsAsync
 
 from .._context import CoroContextManager
-from ..main import register
-from ..main import register_async
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
 
 
-@register("psycopg")
 class Psycopg3Commands(Commands):
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
@@ -28,7 +25,6 @@ class Psycopg3Commands(Commands):
         return cls(conn)
 
 
-@register_async("psycopg")
 class Psycopg3CommandsAsync(CommandsAsync):
     @classmethod
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync":

--- a/pydapper/sqlite/sqlite3.py
+++ b/pydapper/sqlite/sqlite3.py
@@ -3,7 +3,6 @@ import sqlite3
 from sqlite3 import Cursor
 from typing import TYPE_CHECKING
 
-from pydapper import register
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -11,7 +10,6 @@ if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
 
 
-@register("sqlite3")
 class Sqlite3Commands(Commands):
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,18 @@
+import sqlite3
+
 import pytest
 
-from pydapper.main import CommandFactory
-from pydapper.main import connect
-from pydapper.main import connect_async
-from pydapper.main import register
-from pydapper.main import register_async
-from pydapper.main import using
-from pydapper.main import using_async
+import pydapper
+import pydapper.main as main
+from pydapper.bigquery import GoogleBigqueryClientCommands
+from pydapper.mssql import PymssqlCommands
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.oracle import OracledbCommands
+from pydapper.postgresql import AiopgCommands
+from pydapper.postgresql import Psycopg2Commands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.sqlite import Sqlite3Commands
 from tests.mocks import MockAsyncCommands
 from tests.mocks import MockAsyncConnection
 from tests.mocks import MockCommands
@@ -17,82 +23,414 @@ DSN = "some_db+tests://localhost"
 pytestmark = pytest.mark.core
 
 
-class TestCommandFactory:
-    @pytest.fixture
-    def register_mock_commands(self):
-        register("tests")(MockCommands)
-        yield
-        CommandFactory.sync_registry.pop("tests", None)
-
-    @pytest.fixture
-    def register_mock_async_commands(self):
-        register_async("tests")(MockAsyncCommands)
-        yield
-        CommandFactory.async_registry.pop("tests", None)
-
-    def test_from_dsn(self, register_mock_commands):
-        commands = CommandFactory.from_dsn(DSN)
-        assert isinstance(commands, MockCommands)
-
-    @pytest.mark.asyncio
-    async def test_from_dsn_async(self, register_mock_async_commands):
-        commands = await CommandFactory.from_dsn_async(DSN)
-        assert isinstance(commands, MockAsyncCommands)
-
-    def test_from_dsn_env_var(self, register_mock_commands, monkeypatch):
-        monkeypatch.setenv("PYDAPPER_DSN", DSN)
-        commands = CommandFactory.from_dsn()
-        assert isinstance(commands, MockCommands)
-
-    @pytest.mark.asyncio
-    async def test_from_dsn_async_env_var(self, register_mock_async_commands, monkeypatch):
-        monkeypatch.setenv("PYDAPPER_DSN", DSN)
-        commands = await CommandFactory.from_dsn_async()
-        assert isinstance(commands, MockAsyncCommands)
-
-    def test_register(self, register_mock_commands):
-        assert CommandFactory.sync_registry["tests"] is MockCommands
-
-    def test_register_async(self, register_mock_async_commands):
-        assert CommandFactory.async_registry["tests"] is MockAsyncCommands
-
-    def test_from_connection(self, register_mock_commands):
-        with CommandFactory.from_connection(MockConnection()) as commands:
-            assert isinstance(commands, MockCommands)
-
-    @pytest.mark.asyncio
-    async def test_from_connection_async(self, register_mock_async_commands):
-        async with CommandFactory.from_connection_async(MockAsyncConnection()) as commands:
-            assert isinstance(commands, MockAsyncCommands)
-
-    def test_from_connection_raises_when_missing_registry_entry(self):
-        with pytest.raises(ValueError):
-            CommandFactory.from_connection(MockConnection())
-
-    def test_from_connection_async_raises_when_missing_registry_entry(self):
-        with pytest.raises(ValueError):
-            CommandFactory.from_connection_async(MockAsyncConnection())
+@pytest.fixture
+def adapter_registry(monkeypatch):
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    return registry
 
 
-def test_register():
-    assert register == CommandFactory.register
+def never_matches(connection):
+    return False
 
 
-def test_register_async():
-    assert register_async == CommandFactory.register_async
+def test_register_adapter_sync_only(adapter_registry):
+    result = pydapper.register_adapter(
+        "sync-only",
+        commands=MockCommands,
+        can_handle_connection=never_matches,
+    )
+
+    assert result is None
+    registration = adapter_registry["sync-only"]
+    assert registration.name == "sync-only"
+    assert registration.commands is MockCommands
+    assert registration.async_commands is None
 
 
-def test_using():
-    assert using == CommandFactory.from_connection
+def test_register_adapter_async_only(adapter_registry):
+    pydapper.register_adapter(
+        "async-only",
+        async_commands=MockAsyncCommands,
+        can_handle_connection=never_matches,
+    )
+
+    registration = adapter_registry["async-only"]
+    assert registration.commands is None
+    assert registration.async_commands is MockAsyncCommands
 
 
-def test_using_async():
-    assert using_async == CommandFactory.from_connection_async
+def test_register_adapter_combined(adapter_registry):
+    pydapper.register_adapter(
+        "combined",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        can_handle_connection=never_matches,
+    )
+
+    registration = adapter_registry["combined"]
+    assert registration.commands is MockCommands
+    assert registration.async_commands is MockAsyncCommands
 
 
-def test_connect():
-    assert connect == CommandFactory.from_dsn
+@pytest.mark.parametrize("name", [None, 1, object()])
+def test_register_adapter_rejects_non_string_name(adapter_registry, name):
+    with pytest.raises(TypeError):
+        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=never_matches)
 
 
-def test_connect_async():
-    assert connect_async == CommandFactory.from_dsn_async
+@pytest.mark.parametrize("name", ["", " leading", "trailing ", "\tname", "name\n"])
+def test_register_adapter_rejects_blank_or_whitespace_padded_name(adapter_registry, name):
+    with pytest.raises(ValueError):
+        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=never_matches)
+
+
+def test_register_adapter_names_are_case_sensitive(adapter_registry):
+    pydapper.register_adapter("Adapter", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("adapter", commands=MockCommands, can_handle_connection=never_matches)
+
+    assert {"Adapter", "adapter"}.issubset(adapter_registry)
+
+
+def test_register_adapter_requires_a_command_class(adapter_registry):
+    with pytest.raises(ValueError):
+        pydapper.register_adapter("missing-commands", can_handle_connection=never_matches)
+
+
+@pytest.mark.parametrize("commands", [object, MockAsyncCommands])
+def test_register_adapter_rejects_invalid_sync_command_class(adapter_registry, commands):
+    with pytest.raises(TypeError):
+        pydapper.register_adapter("invalid-sync", commands=commands, can_handle_connection=never_matches)
+
+
+@pytest.mark.parametrize("async_commands", [object, MockCommands])
+def test_register_adapter_rejects_invalid_async_command_class(adapter_registry, async_commands):
+    with pytest.raises(TypeError):
+        pydapper.register_adapter("invalid-async", async_commands=async_commands, can_handle_connection=never_matches)
+
+
+def test_register_adapter_rejects_non_callable_predicate(adapter_registry):
+    with pytest.raises(TypeError):
+        pydapper.register_adapter("invalid-predicate", commands=MockCommands, can_handle_connection=None)
+
+
+def test_registration_validation_failure_is_atomic(adapter_registry):
+    before = adapter_registry.copy()
+
+    with pytest.raises(TypeError):
+        pydapper.register_adapter("invalid", commands=object, can_handle_connection=never_matches)
+
+    assert adapter_registry == before
+
+
+def test_duplicate_registration_is_rejected_without_mutating_the_original(adapter_registry):
+    pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+    original_registration = adapter_registry["duplicate"]
+    before = adapter_registry.copy()
+
+    with pytest.raises(ValueError):
+        pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+
+    assert adapter_registry == before
+    assert adapter_registry["duplicate"] is original_registration
+
+
+def test_duplicate_name_is_rejected_before_validating_a_second_payload(adapter_registry):
+    pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+
+    with pytest.raises(ValueError):
+        pydapper.register_adapter("duplicate", commands=object, can_handle_connection=None)
+
+
+def test_explicit_selection_bypasses_predicates_for_sync_and_async(adapter_registry):
+    def predicate(connection):
+        raise AssertionError("explicit selection must not call predicates")
+
+    pydapper.register_adapter(
+        "explicit",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        can_handle_connection=predicate,
+    )
+
+    assert isinstance(pydapper.using(MockConnection(), adapter="explicit"), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection(), adapter="explicit"), MockAsyncCommands)
+
+
+@pytest.mark.parametrize(
+    ("factory", "connection", "mode"),
+    [
+        (pydapper.using, MockConnection, "sync"),
+        (pydapper.using_async, MockAsyncConnection, "async"),
+    ],
+)
+def test_explicit_selection_rejects_unknown_adapter(adapter_registry, factory, connection, mode):
+    with pytest.raises(ValueError, match="unknown") as exc_info:
+        factory(connection(), adapter="unknown")
+
+    assert mode in str(exc_info.value)
+
+
+def test_explicit_selection_rejects_adapter_without_requested_mode(adapter_registry):
+    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+
+    with pytest.raises(ValueError, match="sync-only") as sync_exc_info:
+        pydapper.using_async(MockAsyncConnection(), adapter="sync-only")
+    with pytest.raises(ValueError, match="async-only") as async_exc_info:
+        pydapper.using(MockConnection(), adapter="async-only")
+
+    assert "async" in str(sync_exc_info.value)
+    assert "sync" in str(async_exc_info.value)
+
+
+def test_using_automatically_selects_the_single_matching_sync_adapter(adapter_registry):
+    pydapper.register_adapter(
+        "sync-match",
+        commands=MockCommands,
+        can_handle_connection=lambda connection: isinstance(connection, MockConnection),
+    )
+
+    assert isinstance(pydapper.using(MockConnection()), MockCommands)
+
+
+def test_using_async_automatically_selects_the_single_matching_async_adapter(adapter_registry):
+    pydapper.register_adapter(
+        "async-match",
+        async_commands=MockAsyncCommands,
+        can_handle_connection=lambda connection: isinstance(connection, MockAsyncConnection),
+    )
+
+    assert isinstance(pydapper.using_async(MockAsyncConnection()), MockAsyncCommands)
+
+
+@pytest.mark.parametrize(
+    ("factory", "connection", "mode"),
+    [
+        (pydapper.using, MockConnection, "sync"),
+        (pydapper.using_async, MockAsyncConnection, "async"),
+    ],
+)
+def test_automatic_selection_rejects_zero_matches(adapter_registry, factory, connection, mode):
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        factory(connection())
+
+    assert mode in str(exc_info.value)
+    assert "register an adapter" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("names", [("first", "second"), ("second", "first")])
+def test_automatic_selection_rejects_ambiguity_regardless_of_registration_order(adapter_registry, names):
+    predicate_calls = []
+
+    def matches(connection):
+        predicate_calls.append(connection)
+        return True
+
+    for name in names:
+        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=matches)
+
+    connection = MockConnection()
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        pydapper.using(connection)
+
+    message = str(exc_info.value)
+    assert "first" in message
+    assert "second" in message
+    assert message.index("first") < message.index("second")
+    assert predicate_calls == [connection, connection]
+
+
+def test_sync_selection_does_not_call_async_only_predicates(adapter_registry):
+    def must_not_run(connection):
+        raise AssertionError("mode-ineligible predicate was called")
+
+    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=must_not_run)
+    pydapper.register_adapter(
+        "sync-match",
+        commands=MockCommands,
+        can_handle_connection=lambda connection: isinstance(connection, MockConnection),
+    )
+
+    assert isinstance(pydapper.using(MockConnection()), MockCommands)
+
+
+def test_async_selection_does_not_call_sync_only_predicates(adapter_registry):
+    def must_not_run(connection):
+        raise AssertionError("mode-ineligible predicate was called")
+
+    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=must_not_run)
+    pydapper.register_adapter(
+        "async-match",
+        async_commands=MockAsyncCommands,
+        can_handle_connection=lambda connection: isinstance(connection, MockAsyncConnection),
+    )
+
+    assert isinstance(pydapper.using_async(MockAsyncConnection()), MockAsyncCommands)
+
+
+def test_automatic_selection_wraps_predicate_errors_with_the_original_cause(adapter_registry):
+    cause = RuntimeError("predicate failed")
+
+    def raises(connection):
+        raise cause
+
+    pydapper.register_adapter("failing", commands=MockCommands, can_handle_connection=raises)
+
+    with pytest.raises(ValueError, match="failing") as exc_info:
+        pydapper.using(MockConnection())
+
+    assert exc_info.value.__cause__ is cause
+
+
+def test_connect_routes_to_the_registered_sync_adapter(adapter_registry):
+    pydapper.register_adapter("tests", commands=MockCommands, can_handle_connection=never_matches)
+
+    assert isinstance(pydapper.connect(DSN), MockCommands)
+
+
+@pytest.mark.asyncio
+async def test_connect_async_routes_to_the_registered_async_adapter(adapter_registry):
+    pydapper.register_adapter("tests", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+
+    assert isinstance(await pydapper.connect_async(DSN), MockAsyncCommands)
+
+
+def test_connect_uses_the_environment_dsn_fallback(adapter_registry, monkeypatch):
+    pydapper.register_adapter("tests", commands=MockCommands, can_handle_connection=never_matches)
+    monkeypatch.setenv("PYDAPPER_DSN", DSN)
+
+    assert isinstance(pydapper.connect(), MockCommands)
+
+
+@pytest.mark.asyncio
+async def test_connect_async_uses_the_environment_dsn_fallback(adapter_registry, monkeypatch):
+    pydapper.register_adapter("tests", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+    monkeypatch.setenv("PYDAPPER_DSN", DSN)
+
+    assert isinstance(await pydapper.connect_async(), MockAsyncCommands)
+
+
+def test_connect_rejects_an_unknown_dsn_adapter(adapter_registry):
+    with pytest.raises(ValueError, match="unknown") as exc_info:
+        pydapper.connect("some_db+unknown://localhost")
+
+    assert "sync" in str(exc_info.value)
+
+
+def test_connect_async_rejects_an_unknown_dsn_adapter(adapter_registry):
+    with pytest.raises(ValueError, match="unknown") as exc_info:
+        pydapper.connect_async("some_db+unknown://localhost")
+
+    assert "async" in str(exc_info.value)
+
+
+def test_connect_async_rejects_an_adapter_without_async_support(adapter_registry):
+    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=never_matches)
+
+    with pytest.raises(ValueError, match="sync-only") as exc_info:
+        pydapper.connect_async("some_db+sync-only://localhost")
+
+    assert "async" in str(exc_info.value)
+
+
+def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
+    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+
+    with pytest.raises(ValueError, match="async-only") as exc_info:
+        pydapper.connect("some_db+async-only://localhost")
+
+    assert "sync" in str(exc_info.value)
+
+
+def test_builtin_adapter_name_and_command_class_mappings():
+    expected = {
+        "sqlite3": (Sqlite3Commands, None),
+        "psycopg2": (Psycopg2Commands, None),
+        "psycopg": (Psycopg3Commands, Psycopg3CommandsAsync),
+        "aiopg": (None, AiopgCommands),
+        "mysql": (MySqlConnectorPythonCommands, None),
+        "pymssql": (PymssqlCommands, None),
+        "oracledb": (OracledbCommands, None),
+        "google": (GoogleBigqueryClientCommands, None),
+    }
+
+    assert set(main._adapter_registry) == set(expected)
+    for name, (commands, async_commands) in expected.items():
+        registration = main._adapter_registry[name]
+        assert registration.commands is commands
+        assert registration.async_commands is async_commands
+
+
+@pytest.mark.parametrize(
+    ("module", "commands_class"),
+    [
+        ("psycopg2.extensions", Psycopg2Commands),
+        ("psycopg.connection", Psycopg3Commands),
+        ("mysql.connector.connection_cext", MySqlConnectorPythonCommands),
+        ("pymssql._pymssql", PymssqlCommands),
+        ("oracledb", OracledbCommands),
+        ("google.cloud.bigquery.dbapi.connection", GoogleBigqueryClientCommands),
+    ],
+)
+def test_builtin_sync_detection_uses_documented_connection_modules(module, commands_class):
+    connection_class = type("NativeConnection", (), {"__module__": module})
+
+    assert isinstance(pydapper.using(connection_class()), commands_class)
+
+
+@pytest.mark.parametrize(
+    ("module", "commands_class"),
+    [
+        ("psycopg.connection_async", Psycopg3CommandsAsync),
+        ("aiopg.connection", AiopgCommands),
+    ],
+)
+def test_builtin_async_detection_uses_documented_connection_modules(module, commands_class):
+    connection_class = type("NativeConnection", (), {"__module__": module})
+
+    assert isinstance(pydapper.using_async(connection_class()), commands_class)
+
+
+def test_builtin_detection_supports_sqlite_native_connections_and_subclasses():
+    class SubclassedConnection(sqlite3.Connection):
+        pass
+
+    native_connection = sqlite3.connect(":memory:")
+    subclassed_connection = sqlite3.connect(":memory:", factory=SubclassedConnection)
+    try:
+        assert isinstance(pydapper.using(native_connection), Sqlite3Commands)
+        assert isinstance(pydapper.using(subclassed_connection), Sqlite3Commands)
+    finally:
+        native_connection.close()
+        subclassed_connection.close()
+
+
+def test_builtin_detection_inspects_the_full_mro():
+    native_connection_class = type("NativeConnection", (), {"__module__": "mysql.connector.connection"})
+    wrapper_subclass = type("ConnectionSubclass", (native_connection_class,), {"__module__": "application.db"})
+
+    assert isinstance(pydapper.using(wrapper_subclass()), MySqlConnectorPythonCommands)
+
+
+def test_builtin_detection_uses_anchored_module_prefixes():
+    unrelated_connection_class = type("UnrelatedConnection", (), {"__module__": "application.sqlite3_proxy"})
+
+    with pytest.raises(ValueError, match="adapter="):
+        pydapper.using(unrelated_connection_class())
+
+
+def test_adapter_argument_is_keyword_only():
+    with pytest.raises(TypeError):
+        pydapper.using(MockConnection(), "sqlite3")
+    with pytest.raises(TypeError):
+        pydapper.using_async(MockAsyncConnection(), "psycopg")
+
+
+def test_legacy_registration_exports_are_absent():
+    assert not hasattr(pydapper, "register")
+    assert not hasattr(pydapper, "register_async")
+    assert not hasattr(main, "register")
+    assert not hasattr(main, "register_async")
+    assert not hasattr(main.CommandFactory, "sync_registry")
+    assert not hasattr(main.CommandFactory, "async_registry")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,7 @@ def test_register_adapter_sync_only(adapter_registry):
     result = pydapper.register_adapter(
         "sync-only",
         commands=MockCommands,
-        can_handle_connection=never_matches,
+        using_connection_predicate=never_matches,
     )
 
     assert result is None
@@ -52,7 +52,7 @@ def test_register_adapter_async_only(adapter_registry):
     pydapper.register_adapter(
         "async-only",
         async_commands=MockAsyncCommands,
-        can_handle_connection=never_matches,
+        using_connection_predicate=never_matches,
     )
 
     registration = adapter_registry["async-only"]
@@ -65,7 +65,7 @@ def test_register_adapter_combined(adapter_registry):
         "combined",
         commands=MockCommands,
         async_commands=MockAsyncCommands,
-        can_handle_connection=never_matches,
+        using_connection_predicate=never_matches,
     )
 
     registration = adapter_registry["combined"]
@@ -76,70 +76,79 @@ def test_register_adapter_combined(adapter_registry):
 @pytest.mark.parametrize("name", [None, 1, object()])
 def test_register_adapter_rejects_non_string_name(adapter_registry, name):
     with pytest.raises(TypeError):
-        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=never_matches)
+        pydapper.register_adapter(name, commands=MockCommands, using_connection_predicate=never_matches)
 
 
 @pytest.mark.parametrize("name", ["", " leading", "trailing ", "\tname", "name\n"])
 def test_register_adapter_rejects_blank_or_whitespace_padded_name(adapter_registry, name):
     with pytest.raises(ValueError):
-        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=never_matches)
+        pydapper.register_adapter(name, commands=MockCommands, using_connection_predicate=never_matches)
 
 
 def test_register_adapter_names_are_case_sensitive(adapter_registry):
-    pydapper.register_adapter("Adapter", commands=MockCommands, can_handle_connection=never_matches)
-    pydapper.register_adapter("adapter", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("Adapter", commands=MockCommands, using_connection_predicate=never_matches)
+    pydapper.register_adapter("adapter", commands=MockCommands, using_connection_predicate=never_matches)
 
     assert {"Adapter", "adapter"}.issubset(adapter_registry)
 
 
 def test_register_adapter_requires_a_command_class(adapter_registry):
     with pytest.raises(ValueError):
-        pydapper.register_adapter("missing-commands", can_handle_connection=never_matches)
+        pydapper.register_adapter("missing-commands", using_connection_predicate=never_matches)
+
+
+def test_register_adapter_requires_using_connection_predicate(adapter_registry):
+    with pytest.raises(TypeError):
+        pydapper.register_adapter("missing-predicate", commands=MockCommands)
 
 
 @pytest.mark.parametrize("commands", [object, MockAsyncCommands])
 def test_register_adapter_rejects_invalid_sync_command_class(adapter_registry, commands):
     with pytest.raises(TypeError):
-        pydapper.register_adapter("invalid-sync", commands=commands, can_handle_connection=never_matches)
+        pydapper.register_adapter("invalid-sync", commands=commands, using_connection_predicate=never_matches)
 
 
 @pytest.mark.parametrize("async_commands", [object, MockCommands])
 def test_register_adapter_rejects_invalid_async_command_class(adapter_registry, async_commands):
     with pytest.raises(TypeError):
-        pydapper.register_adapter("invalid-async", async_commands=async_commands, can_handle_connection=never_matches)
+        pydapper.register_adapter(
+            "invalid-async",
+            async_commands=async_commands,
+            using_connection_predicate=never_matches,
+        )
 
 
-def test_register_adapter_rejects_non_callable_predicate(adapter_registry):
+def test_register_adapter_rejects_non_callable_using_connection_predicate(adapter_registry):
     with pytest.raises(TypeError):
-        pydapper.register_adapter("invalid-predicate", commands=MockCommands, can_handle_connection=None)
+        pydapper.register_adapter("invalid-predicate", commands=MockCommands, using_connection_predicate=None)
 
 
 def test_registration_validation_failure_is_atomic(adapter_registry):
     before = adapter_registry.copy()
 
     with pytest.raises(TypeError):
-        pydapper.register_adapter("invalid", commands=object, can_handle_connection=never_matches)
+        pydapper.register_adapter("invalid", commands=object, using_connection_predicate=never_matches)
 
     assert adapter_registry == before
 
 
 def test_duplicate_registration_is_rejected_without_mutating_the_original(adapter_registry):
-    pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("duplicate", commands=MockCommands, using_connection_predicate=never_matches)
     original_registration = adapter_registry["duplicate"]
     before = adapter_registry.copy()
 
     with pytest.raises(ValueError):
-        pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+        pydapper.register_adapter("duplicate", commands=MockCommands, using_connection_predicate=never_matches)
 
     assert adapter_registry == before
     assert adapter_registry["duplicate"] is original_registration
 
 
 def test_duplicate_name_is_rejected_before_validating_a_second_payload(adapter_registry):
-    pydapper.register_adapter("duplicate", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("duplicate", commands=MockCommands, using_connection_predicate=never_matches)
 
     with pytest.raises(ValueError):
-        pydapper.register_adapter("duplicate", commands=object, can_handle_connection=None)
+        pydapper.register_adapter("duplicate", commands=object, using_connection_predicate=None)
 
 
 def test_explicit_selection_bypasses_predicates_for_sync_and_async(adapter_registry):
@@ -150,7 +159,7 @@ def test_explicit_selection_bypasses_predicates_for_sync_and_async(adapter_regis
         "explicit",
         commands=MockCommands,
         async_commands=MockAsyncCommands,
-        can_handle_connection=predicate,
+        using_connection_predicate=predicate,
     )
 
     assert isinstance(pydapper.using(MockConnection(), adapter="explicit"), MockCommands)
@@ -172,8 +181,12 @@ def test_explicit_selection_rejects_unknown_adapter(adapter_registry, factory, c
 
 
 def test_explicit_selection_rejects_adapter_without_requested_mode(adapter_registry):
-    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=never_matches)
-    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("sync-only", commands=MockCommands, using_connection_predicate=never_matches)
+    pydapper.register_adapter(
+        "async-only",
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
 
     with pytest.raises(ValueError, match="sync-only") as sync_exc_info:
         pydapper.using_async(MockAsyncConnection(), adapter="sync-only")
@@ -188,7 +201,7 @@ def test_using_automatically_selects_the_single_matching_sync_adapter(adapter_re
     pydapper.register_adapter(
         "sync-match",
         commands=MockCommands,
-        can_handle_connection=lambda connection: isinstance(connection, MockConnection),
+        using_connection_predicate=lambda connection: isinstance(connection, MockConnection),
     )
 
     assert isinstance(pydapper.using(MockConnection()), MockCommands)
@@ -198,7 +211,7 @@ def test_using_async_automatically_selects_the_single_matching_async_adapter(ada
     pydapper.register_adapter(
         "async-match",
         async_commands=MockAsyncCommands,
-        can_handle_connection=lambda connection: isinstance(connection, MockAsyncConnection),
+        using_connection_predicate=lambda connection: isinstance(connection, MockAsyncConnection),
     )
 
     assert isinstance(pydapper.using_async(MockAsyncConnection()), MockAsyncCommands)
@@ -228,7 +241,7 @@ def test_automatic_selection_rejects_ambiguity_regardless_of_registration_order(
         return True
 
     for name in names:
-        pydapper.register_adapter(name, commands=MockCommands, can_handle_connection=matches)
+        pydapper.register_adapter(name, commands=MockCommands, using_connection_predicate=matches)
 
     connection = MockConnection()
     with pytest.raises(ValueError, match="adapter=") as exc_info:
@@ -245,11 +258,15 @@ def test_sync_selection_does_not_call_async_only_predicates(adapter_registry):
     def must_not_run(connection):
         raise AssertionError("mode-ineligible predicate was called")
 
-    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=must_not_run)
+    pydapper.register_adapter(
+        "async-only",
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=must_not_run,
+    )
     pydapper.register_adapter(
         "sync-match",
         commands=MockCommands,
-        can_handle_connection=lambda connection: isinstance(connection, MockConnection),
+        using_connection_predicate=lambda connection: isinstance(connection, MockConnection),
     )
 
     assert isinstance(pydapper.using(MockConnection()), MockCommands)
@@ -259,11 +276,11 @@ def test_async_selection_does_not_call_sync_only_predicates(adapter_registry):
     def must_not_run(connection):
         raise AssertionError("mode-ineligible predicate was called")
 
-    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=must_not_run)
+    pydapper.register_adapter("sync-only", commands=MockCommands, using_connection_predicate=must_not_run)
     pydapper.register_adapter(
         "async-match",
         async_commands=MockAsyncCommands,
-        can_handle_connection=lambda connection: isinstance(connection, MockAsyncConnection),
+        using_connection_predicate=lambda connection: isinstance(connection, MockAsyncConnection),
     )
 
     assert isinstance(pydapper.using_async(MockAsyncConnection()), MockAsyncCommands)
@@ -275,7 +292,7 @@ def test_automatic_selection_wraps_predicate_errors_with_the_original_cause(adap
     def raises(connection):
         raise cause
 
-    pydapper.register_adapter("failing", commands=MockCommands, can_handle_connection=raises)
+    pydapper.register_adapter("failing", commands=MockCommands, using_connection_predicate=raises)
 
     with pytest.raises(ValueError, match="failing") as exc_info:
         pydapper.using(MockConnection())
@@ -284,20 +301,40 @@ def test_automatic_selection_wraps_predicate_errors_with_the_original_cause(adap
 
 
 def test_connect_routes_to_the_registered_sync_adapter(adapter_registry):
-    pydapper.register_adapter("tests", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("tests", commands=MockCommands, using_connection_predicate=never_matches)
 
     assert isinstance(pydapper.connect(DSN), MockCommands)
 
 
 @pytest.mark.asyncio
 async def test_connect_async_routes_to_the_registered_async_adapter(adapter_registry):
-    pydapper.register_adapter("tests", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter(
+        "tests",
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
 
     assert isinstance(await pydapper.connect_async(DSN), MockAsyncCommands)
 
 
+@pytest.mark.asyncio
+async def test_dsn_selection_bypasses_using_connection_predicate(adapter_registry):
+    def predicate(connection):
+        raise AssertionError("DSN selection must not call predicates")
+
+    pydapper.register_adapter(
+        "tests",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=predicate,
+    )
+
+    assert isinstance(pydapper.connect(DSN), MockCommands)
+    assert isinstance(await pydapper.connect_async(DSN), MockAsyncCommands)
+
+
 def test_connect_uses_the_environment_dsn_fallback(adapter_registry, monkeypatch):
-    pydapper.register_adapter("tests", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("tests", commands=MockCommands, using_connection_predicate=never_matches)
     monkeypatch.setenv("PYDAPPER_DSN", DSN)
 
     assert isinstance(pydapper.connect(), MockCommands)
@@ -305,7 +342,11 @@ def test_connect_uses_the_environment_dsn_fallback(adapter_registry, monkeypatch
 
 @pytest.mark.asyncio
 async def test_connect_async_uses_the_environment_dsn_fallback(adapter_registry, monkeypatch):
-    pydapper.register_adapter("tests", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter(
+        "tests",
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
     monkeypatch.setenv("PYDAPPER_DSN", DSN)
 
     assert isinstance(await pydapper.connect_async(), MockAsyncCommands)
@@ -326,7 +367,7 @@ def test_connect_async_rejects_an_unknown_dsn_adapter(adapter_registry):
 
 
 def test_connect_async_rejects_an_adapter_without_async_support(adapter_registry):
-    pydapper.register_adapter("sync-only", commands=MockCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter("sync-only", commands=MockCommands, using_connection_predicate=never_matches)
 
     with pytest.raises(ValueError, match="sync-only") as exc_info:
         pydapper.connect_async("some_db+sync-only://localhost")
@@ -335,7 +376,11 @@ def test_connect_async_rejects_an_adapter_without_async_support(adapter_registry
 
 
 def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
-    pydapper.register_adapter("async-only", async_commands=MockAsyncCommands, can_handle_connection=never_matches)
+    pydapper.register_adapter(
+        "async-only",
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
 
     with pytest.raises(ValueError, match="async-only") as exc_info:
         pydapper.connect("some_db+async-only://localhost")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -465,6 +465,14 @@ def test_builtin_detection_uses_anchored_module_prefixes():
         pydapper.using(unrelated_connection_class())
 
 
+def test_builtin_detection_ignores_non_string_class_modules():
+    connection_class = type("ConnectionWithNonStringModule", (), {})
+    connection_class.__module__ = None
+
+    with pytest.raises(ValueError, match="adapter="):
+        pydapper.using(connection_class())
+
+
 def test_adapter_argument_is_keyword_only():
     with pytest.raises(TypeError):
         pydapper.using(MockConnection(), "sqlite3")

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -120,7 +120,7 @@ def adapter_registration_types() -> None:
         pydapper.register_adapter(
             "type-sync",
             commands=PydapperCommands,
-            can_handle_connection=_cannot_handle_connection,
+            using_connection_predicate=_cannot_handle_connection,
         ),
         None,
     )
@@ -128,7 +128,7 @@ def adapter_registration_types() -> None:
         pydapper.register_adapter(
             "type-async",
             async_commands=PydapperCommandsAsync,
-            can_handle_connection=_cannot_handle_connection,
+            using_connection_predicate=_cannot_handle_connection,
         ),
         None,
     )
@@ -137,7 +137,7 @@ def adapter_registration_types() -> None:
             "type-combined",
             commands=PydapperCommands,
             async_commands=PydapperCommandsAsync,
-            can_handle_connection=_cannot_handle_connection,
+            using_connection_predicate=_cannot_handle_connection,
         ),
         None,
     )

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -9,11 +9,14 @@ from typing import List
 from typing import Literal
 from typing import Tuple
 from typing import Union
+from typing import cast
 
 import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper.commands import Commands as PydapperCommands
+from pydapper.commands import CommandsAsync as PydapperCommandsAsync
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
@@ -22,6 +25,8 @@ from pydapper.exceptions import NoResultException
 from pydapper.exceptions import PyDapperException
 from pydapper.exceptions import RowMappingException
 from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.types import AsyncConnectionType
+from pydapper.types import ConnectionType
 
 """This file tests some of the more complex type annotations on the Commands and AsyncCommands classes"""
 
@@ -104,6 +109,43 @@ def public_exceptions() -> None:
     assert_type(InvalidParameterShapeException(), InvalidParameterShapeException)
     assert_type(UnsupportedFeatureError(), UnsupportedFeatureError)
     assert_type(RowMappingException(), RowMappingException)
+
+
+def _cannot_handle_connection(connection: object) -> bool:
+    return False
+
+
+def adapter_registration_types() -> None:
+    assert_type(
+        pydapper.register_adapter(
+            "type-sync",
+            commands=PydapperCommands,
+            can_handle_connection=_cannot_handle_connection,
+        ),
+        None,
+    )
+    assert_type(
+        pydapper.register_adapter(
+            "type-async",
+            async_commands=PydapperCommandsAsync,
+            can_handle_connection=_cannot_handle_connection,
+        ),
+        None,
+    )
+    assert_type(
+        pydapper.register_adapter(
+            "type-combined",
+            commands=PydapperCommands,
+            async_commands=PydapperCommandsAsync,
+            can_handle_connection=_cannot_handle_connection,
+        ),
+        None,
+    )
+
+    sync_connection = cast(ConnectionType, object())
+    async_connection = cast(AsyncConnectionType, object())
+    assert_type(pydapper.using(sync_connection, adapter="type-sync"), PydapperCommands)
+    assert_type(pydapper.using_async(async_connection, adapter="type-async"), PydapperCommandsAsync)
 
 
 class Commands:


### PR DESCRIPTION
## What changed

- Replaced split decorator-based adapter registration with the public `pydapper.register_adapter()` API.
- Added deterministic predicate-based automatic selection and keyword-only `adapter=` overrides for `using()` and `using_async()`.
- Centralized eager built-in registrations, including combined Psycopg 3 sync and async support.
- Removed legacy `register` and `register_async` exports and adapter-module decorators.
- Added runtime and type coverage plus public migration and selection documentation.

## Before and after

Before, adapters registered independently at class definition time:

```python
@register("acmedb")
class AcmeCommands(Commands):
    ...

@register_async("acmedb")
class AcmeCommandsAsync(CommandsAsync):
    ...
```

After, both modes and the detection predicate are registered atomically:

```python
pydapper.register_adapter(
    "acmedb",
    commands=AcmeCommands,
    async_commands=AcmeCommandsAsync,
    can_handle_connection=can_handle_connection,
)
```

## Public API and compatibility

Breaking: `register` and `register_async` are removed. `register_adapter()` is now the supported registration API, and `using()` / `using_async()` accept keyword-only `adapter=` for explicit selection.

## Validation

- `poetry run pytest -m "core"`
- `poetry run pytest -m "sqlite"`
- `poetry run mypy pydapper`
- `poetry run mypy tests/type_tests.py`
- `poetry run black --check .`
- `poetry run isort --check .`
- `poetry run mkdocs build --strict`
- `git diff --check`

## Driver-specific suites skipped

Optional extras and services were not installed or launched for this change:

- PostgreSQL: `psycopg2-binary`, `psycopg`, and `aiopg` absent.
- MySQL: `mysql-connector-python` absent.
- SQL Server: `pymssql` absent.
- Oracle: `oracledb` absent.
- BigQuery: `google-cloud-bigquery` absent.

## Documentation

Added the adapter-registration guide, updated database-support selection examples, and recorded the intentional breaking change under release-note Breaking Changes.