### PR TITLE
fix: harden async context lifecycle

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,8 @@
 ## Latest Changes
 
+* fix: harden async context lifecycle. Async resources now resolve exactly once and
+  context-manager exception suppression propagates correctly; both `await connect_async()`
+  and `async with connect_async()` usage remain unchanged.
 * feat: stabilize adapter registration. PR [#539](https://github.com/zschumacher/pydapper/pull/539) by [@zschumacher](https://github.com/zschumacher).
 
 ### Breaking Changes

--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -1,80 +1,61 @@
+import asyncio
+from collections.abc import Awaitable
 from inspect import isawaitable
-from types import TracebackType
 from typing import Any
-from typing import Coroutine
 from typing import Generator
 from typing import Generic
-from typing import Optional
-from typing import Type
 from typing import TypeVar
-from typing import Union
+from typing import cast
 
-_TObj = TypeVar("_TObj")
+_AwaitResultT = TypeVar("_AwaitResultT")
+_EnterResultT = TypeVar("_EnterResultT")
+_UNRESOLVED = object()
 
 
 async def _await_if_needed(value: Any) -> Any:
     return await value if isawaitable(value) else value
 
 
-class CoroContextManager(Coroutine[Any, Any, _TObj], Generic[_TObj]):
-    """Wrap an awaitable resource for use with ``async with``."""
+class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
+    """Wrap an awaitable resource for use with ``await`` or ``async with``."""
 
-    __slots__ = ("_coro", "_obj", "_entered_obj", "_aexit", "_preserve_active_error")
+    __slots__ = ("_awaitable", "_resolution", "_obj", "_aexit", "_preserve_active_error")
 
-    def __init__(
-        self,
-        coro: Coroutine[Any, Any, _TObj],
-        obj: _TObj = None,
-        *,
-        preserve_active_error: bool = False,
-    ):
-        self._coro = coro
-        self._obj = obj
-        self._entered_obj = obj
+    def __init__(self, awaitable: Awaitable[_AwaitResultT], *, preserve_active_error: bool = False):
+        self._awaitable = awaitable
+        self._resolution: asyncio.Future[_AwaitResultT] | object = _UNRESOLVED
+        self._obj: _AwaitResultT | object = _UNRESOLVED
         self._aexit = None
         self._preserve_active_error = preserve_active_error
 
-    def send(self, value: Any) -> "Any":  # pragma: no cover
-        return self._coro.send(value)
+    async def _resolve(self) -> _AwaitResultT:
+        if self._resolution is _UNRESOLVED:
+            self._resolution = asyncio.ensure_future(self._awaitable)
+        if self._obj is _UNRESOLVED:
+            self._obj = await cast(asyncio.Future[_AwaitResultT], self._resolution)
+        return cast(_AwaitResultT, self._obj)
 
-    def throw(  # type: ignore
-        self,
-        typ: Type[BaseException],
-        val: Optional[Union[BaseException, object]] = None,
-        tb: Optional[TracebackType] = None,
-    ) -> Any:  # pragma: no cover
-        if val is None:
-            return self._coro.throw(typ)
-        if tb is None:
-            return self._coro.throw(typ, val)
-        return self._coro.throw(typ, val, tb)
+    def __await__(self) -> Generator[Any, None, _AwaitResultT]:
+        return self._resolve().__await__()
 
-    def close(self) -> None:  # pragma: no cover
-        self._coro.close()
-
-    def __await__(self) -> Generator[Any, None, _TObj]:  # pragma: no cover
-        return self._coro.__await__()
-
-    async def __aenter__(self) -> _TObj:
-        if self._obj is None:  # pragma: no branch
-            self._obj = await self._coro
-
-        enter = getattr(type(self._obj), "__aenter__", None)
-        aexit = getattr(type(self._obj), "__aexit__", None)
+    async def __aenter__(self) -> _EnterResultT:
+        obj = await self._resolve()
+        enter = getattr(type(obj), "__aenter__", None)
+        aexit = getattr(type(obj), "__aexit__", None)
         self._aexit = None
-        if callable(enter) and callable(aexit):  # pragma: no branch
-            self._entered_obj = await _await_if_needed(enter(self._obj))
+        if callable(enter) and callable(aexit):
+            entered_obj = await _await_if_needed(enter(obj))
             self._aexit = aexit
-        else:
-            self._entered_obj = self._obj
-        return self._entered_obj
+            return cast(_EnterResultT, entered_obj)
+        return cast(_EnterResultT, obj)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
+        obj = await self._resolve()
         try:
             if self._aexit is not None:
-                return await _await_if_needed(self._aexit(self._obj, exc_type, exc_val, exc_tb))
+                return await _await_if_needed(self._aexit(obj, exc_type, exc_val, exc_tb))
 
-            close = getattr(self._obj, "close", None)
+            close = getattr(obj, "close", None)
             if callable(close):
                 await _await_if_needed(close())
         except BaseException:

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -23,7 +23,7 @@ from typing import Union
 from typing import cast
 from typing import overload
 
-from ._context import CoroContextManager
+from ._context import _AwaitableAsyncContextManager
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
 from .command_options import CommandKind
@@ -1661,14 +1661,14 @@ class CommandsAsync(BaseCommands, ABC):
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self.connection.__aexit__(exc_type, exc_val, exc_tb)
+        return await self.connection.__aexit__(exc_type, exc_val, exc_tb)
 
     @classmethod
     @abstractmethod
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync": ...
 
-    def cursor(self, *args, **kwargs) -> "CoroContextManager[AsyncCursorType]":
-        return CoroContextManager(self.connection.cursor(*args, **kwargs), preserve_active_error=True)
+    def cursor(self, *args, **kwargs) -> "_AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType]":
+        return _AwaitableAsyncContextManager(self.connection.cursor(*args, **kwargs), preserve_active_error=True)
 
     @overload
     async def execute_async(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from ._context import CoroContextManager
+from ._context import _AwaitableAsyncContextManager
 from .commands import Commands
 from .commands import CommandsAsync
 from .dsn_parser import PydapperParseResult
@@ -144,10 +144,12 @@ class CommandFactory:
         return _get_sync_commands_class(parsed_dsn.dbapi).connect(parsed_dsn, **connect_kwargs)
 
     @classmethod
-    def from_dsn_async(cls, dsn: str | None = None, **connect_kwargs) -> CoroContextManager[CommandsAsync]:
+    def from_dsn_async(
+        cls, dsn: str | None = None, **connect_kwargs
+    ) -> _AwaitableAsyncContextManager[CommandsAsync, CommandsAsync]:
         parsed_dsn = parse_dsn(dsn)
         commands_class = _get_async_commands_class(parsed_dsn.dbapi)
-        return CoroContextManager(commands_class.connect_async(parsed_dsn, **connect_kwargs))
+        return _AwaitableAsyncContextManager(commands_class.connect_async(parsed_dsn, **connect_kwargs))
 
     @classmethod
     def from_connection(cls, connection: ConnectionType, *, adapter: str | None = None) -> Commands:
@@ -168,7 +170,9 @@ def connect(dsn: str | None = None, **connect_kwargs) -> Commands:
     return CommandFactory.from_dsn(dsn, **connect_kwargs)
 
 
-def connect_async(dsn: str | None = None, **connect_kwargs) -> CoroContextManager[CommandsAsync]:
+def connect_async(
+    dsn: str | None = None, **connect_kwargs
+) -> _AwaitableAsyncContextManager[CommandsAsync, CommandsAsync]:
     return CommandFactory.from_dsn_async(dsn, **connect_kwargs)
 
 

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from pydapper.commands import Commands
 from pydapper.commands import CommandsAsync
 
-from .._context import CoroContextManager
+from .._context import _AwaitableAsyncContextManager
 from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
@@ -43,4 +43,4 @@ class Psycopg3CommandsAsync(CommandsAsync):
         async def cursor_proxy():
             return self.connection.cursor(*args, **kwargs)
 
-        return CoroContextManager(cursor_proxy(), preserve_active_error=True)
+        return _AwaitableAsyncContextManager(cursor_proxy(), preserve_active_error=True)

--- a/tests/test_adapter_units.py
+++ b/tests/test_adapter_units.py
@@ -317,7 +317,10 @@ async def test_psycopg3_async_cursor_wraps_sync_cursor_return_value():
     connection = Connection()
     commands = psycopg3_module.Psycopg3CommandsAsync(connection)
 
-    async with commands.cursor("cursor-name", row_factory=dict) as cursor:
+    wrapper = commands.cursor("cursor-name", row_factory=dict)
+    assert type(wrapper).__name__ == "_AwaitableAsyncContextManager"
+    assert wrapper._preserve_active_error is True
+    async with wrapper as cursor:
         assert cursor is connection.cursor_result
 
     assert connection.calls == [(("cursor-name",), {"row_factory": dict})]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,112 +2,200 @@ import asyncio
 
 import pytest
 
-from pydapper._context import CoroContextManager
+from pydapper._context import _AwaitableAsyncContextManager
 
 pytestmark = pytest.mark.core
 
 
-class MyObject:
-    def __init__(self):
-        self.some_value = 0
+class ContextObject:
+    def __init__(self, exit_result=False, exit_error=None):
+        self.exit_result = exit_result
+        self.exit_error = exit_error
+        self.entered = object()
+        self.exit_calls = 0
 
     async def __aenter__(self):
-        await asyncio.sleep(0.1)
-        self.some_value = 1
-        return self
+        return self.entered
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await asyncio.sleep(0.1)
-        self.some_value = 0
-
-    @classmethod
-    async def async_constructor(cls):
-        await asyncio.sleep(0.1)
-        return cls()
+        self.exit_calls += 1
+        if self.exit_error:
+            raise self.exit_error
+        return self.exit_result
 
 
 class PlainObject:
-    def __init__(self, close_result=None):
-        self.closed = False
+    def __init__(self, close_result=None, close_error=None):
+        self.closed = 0
         self.close_result = close_result
+        self.close_error = close_error
 
     def close(self):
-        self.closed = True
+        self.closed += 1
+        if self.close_error:
+            raise self.close_error
         return self.close_result
 
 
-class ProxyContextManager:
-    def __init__(self):
-        self.entered_obj = object()
-        self.exited = False
-
-    async def __aenter__(self):
-        return self.entered_obj
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.exited = True
-
-
-class FailingContextManager:
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        raise RuntimeError("exit failed")
+async def resolve_after(event, value):
+    await event.wait()
+    return value
 
 
 @pytest.mark.asyncio
-class TestCoroContextManager:
-    async def test__init__(self):
-        sentinel = object()
-        coro = asyncio.sleep(0.1)
-        cm = CoroContextManager(coro, obj=sentinel)
-        assert cm._coro is coro
-        assert cm._obj is sentinel
-        await coro
+async def test_await_resolves_once_and_returns_identical_object():
+    calls = 0
 
-    async def test_context_manager(self):
-        async with CoroContextManager(MyObject.async_constructor()) as myobj:
-            assert isinstance(myobj, MyObject)
-            assert myobj.some_value == 1
-        assert myobj.some_value == 0
+    async def source():
+        nonlocal calls
+        calls += 1
+        return []
 
-    async def test_context_manager_exits_original_object_when_enter_returns_proxy(self):
-        obj = ProxyContextManager()
+    wrapper = _AwaitableAsyncContextManager(source())
+    first = await wrapper
+    second = await wrapper
 
-        async with CoroContextManager(asyncio.sleep(0, result=obj)) as entered:
-            assert entered is obj.entered_obj
+    assert first is second
+    assert calls == 1
 
-        assert obj.exited is True
 
-    async def test_context_manager_cleanup_failure_is_not_suppressed(self):
-        obj = FailingContextManager()
+@pytest.mark.asyncio
+async def test_concurrent_awaits_share_one_resolution():
+    event = asyncio.Event()
+    calls = 0
 
-        with pytest.raises(RuntimeError, match="exit failed") as exc_info:
-            async with CoroContextManager(asyncio.sleep(0, result=obj)):
-                raise ValueError("body failed")
+    async def source():
+        nonlocal calls
+        calls += 1
+        return await resolve_after(event, object())
 
-        assert isinstance(exc_info.value.__context__, ValueError)
+    wrapper = _AwaitableAsyncContextManager(source())
 
-    async def test_plain_object_is_closed(self):
-        obj = PlainObject()
+    async def wait_for_wrapper():
+        return await wrapper
 
-        async with CoroContextManager(asyncio.sleep(0, result=obj)) as entered:
-            assert entered is obj
+    first = asyncio.create_task(wait_for_wrapper())
+    second = asyncio.create_task(wait_for_wrapper())
+    await asyncio.sleep(0)
+    event.set()
 
-        assert obj.closed is True
+    first_result, second_result = await asyncio.gather(first, second)
+    assert first_result is second_result
+    assert calls == 1
 
-    async def test_plain_object_awaits_close(self):
-        closed = False
 
-        async def close():
-            nonlocal closed
-            closed = True
+@pytest.mark.asyncio
+async def test_await_then_async_with_reuses_resolved_object():
+    calls = 0
 
-        obj = PlainObject(close())
+    async def source():
+        nonlocal calls
+        calls += 1
+        return PlainObject()
 
-        async with CoroContextManager(asyncio.sleep(0, result=obj)):
+    wrapper = _AwaitableAsyncContextManager(source())
+    obj = await wrapper
+    async with wrapper as entered:
+        assert entered is obj
+    assert calls == 1
+    assert obj.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_async_with_returns_entry_value_and_exits_original_object():
+    obj = ContextObject()
+    async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj)) as entered:
+        assert entered is obj.entered
+    assert obj.exit_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_result, suppresses", [(True, True), (False, False)])
+async def test_exit_result_is_propagated(exit_result, suppresses):
+    obj = ContextObject(exit_result=exit_result)
+    caught = False
+    try:
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj)):
+            raise ValueError("body")
+    except ValueError:
+        caught = True
+    assert caught is not suppresses
+
+
+@pytest.mark.asyncio
+async def test_plain_object_is_closed_and_awaitable_close_is_awaited():
+    closed = False
+
+    async def close():
+        nonlocal closed
+        closed = True
+
+    obj = PlainObject(close_result=close())
+    async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj)):
+        pass
+    assert obj.closed == 1
+    assert closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [None, False, 0, ""])
+async def test_falsey_resolved_values_are_cached(value):
+    calls = 0
+
+    async def source():
+        nonlocal calls
+        calls += 1
+        return value
+
+    wrapper = _AwaitableAsyncContextManager(source())
+    assert await wrapper is value
+    assert await wrapper is value
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("preserve, active", [(False, False), (False, True), (True, True)])
+async def test_cleanup_failure_behavior(preserve, active):
+    body_error = ValueError("body")
+    cleanup_error = RuntimeError("cleanup")
+    obj = PlainObject(close_error=cleanup_error)
+
+    with pytest.raises(type(body_error if active and preserve else cleanup_error)) as exc_info:
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=preserve):
+            if active:
+                raise body_error
+    if active and preserve:
+        assert exc_info.value is body_error
+
+
+@pytest.mark.asyncio
+async def test_source_failure_is_not_swallowed_or_retried():
+    calls = 0
+    error = RuntimeError("source")
+
+    async def source():
+        nonlocal calls
+        calls += 1
+        raise error
+
+    wrapper = _AwaitableAsyncContextManager(source())
+    with pytest.raises(RuntimeError, match="source") as first:
+        await wrapper
+    with pytest.raises(RuntimeError, match="source") as second:
+        await wrapper
+    assert first.value is second.value is error
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_context_entry_failure_is_not_swallowed():
+    class FailingEntry:
+        async def __aenter__(self):
+            raise RuntimeError("entry")
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            raise AssertionError("exit should not run")
+
+    with pytest.raises(RuntimeError, match="entry"):
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=FailingEntry())):
             pass
-
-        assert obj.closed is True
-        assert closed is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -318,6 +318,42 @@ async def test_connect_async_routes_to_the_registered_async_adapter(adapter_regi
 
 
 @pytest.mark.asyncio
+async def test_connect_async_context_returns_commands_and_propagates_connection_suppression(adapter_registry):
+    class SuppressingConnection:
+        exited = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            return True
+
+    class SuppressingCommands(MockAsyncCommands):
+        @classmethod
+        async def connect_async(cls, parsed_dsn, **connect_kwargs):
+            connection = SuppressingConnection()
+            commands = cls(connection)
+            commands.test_connection = connection
+            return commands
+
+    pydapper.register_adapter(
+        "tests",
+        async_commands=SuppressingCommands,
+        using_connection_predicate=never_matches,
+    )
+
+    try:
+        async with pydapper.connect_async(DSN) as commands:
+            assert isinstance(commands, SuppressingCommands)
+            connection = commands.test_connection
+            raise ValueError("body")
+    except ValueError:
+        pytest.fail("connection suppression did not propagate")
+    assert connection.exited
+
+
+@pytest.mark.asyncio
 async def test_dsn_selection_bypasses_using_connection_predicate(adapter_registry):
     def predicate(connection):
         raise AssertionError("DSN selection must not call predicates")

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -422,7 +422,9 @@ class CommandsAsync:
         slotted_params = SlottedParams(1)
         batch_params = [{"id": 1}, {"id": 2}]
 
+        assert_type(await pydapper.connect_async(), PydapperCommandsAsync)
         async with pydapper.connect_async() as commands:
+            assert_type(commands, PydapperCommandsAsync)
             assert_type(await commands.execute_async(query, param=params), int)
             assert_type(await commands.execute_async(query, params=params), int)
             assert_type(await commands.execute_async(query, params=mapping_subclass_params), int)


### PR DESCRIPTION
## What changed

Hardened the private async awaitable/context-manager wrapper used by `connect_async()` and async cursor factories.

- Resolves async resources exactly once, including concurrent awaits and falsey results.
- Preserves source and entry failures without retry or suppression.
- Correctly forwards context-manager entry, exit, and exception-suppression results.
- Preserves cursor cleanup guarantees from #529.
- Adds separate typing for await and async-with results.

## Compatibility

Both supported call patterns remain unchanged:

```python
commands = await pydapper.connect_async(...)
```

```python
async with pydapper.connect_async(...) as commands:
    ...
```

## Verification

Core, SQLite, focused runtime tests, mypy, Black, isort, strict MkDocs, and diff checks pass. PostgreSQL integration suites were skipped because optional drivers and services were unavailable.