### PR TITLE
fix: validate complete query batches before DBAPI work

### DIFF
--- a/docs/.parameter_shapes_read.md
+++ b/docs/.parameter_shapes_read.md
@@ -9,3 +9,9 @@ placeholders such as `?id?`, every referenced placeholder must be supplied or py
 `MissingParameterException` before calling the DBAPI. An empty mapping is a real parameter record with no keys. A list
 inside one parameter record, such as `{"ids": []}` or `{"ids": [1, 2, 3]}`, is one value and is reserved for future `IN`
 list expansion support.
+
+Tuple-query APIs (`query_multiple` and `query_multiple_async`) apply this validation to the complete tuple: the
+placeholders of every query are scanned and every referenced value is resolved before a cursor is acquired or the
+first query executes, so a missing parameter in any query means no query reaches the database. This is client-side
+prevalidation, not transaction atomicity; after validation succeeds, a later query can still fail at runtime after
+earlier queries have executed.

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -19,6 +19,16 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.row_mapping.md!}
 
+## Batch validation and atomicity
+
+Every query in the tuple is validated client-side before any database work: placeholders are scanned and every
+referenced parameter value is resolved for the complete tuple before a cursor is acquired or the first query
+executes. A missing parameter in any query raises `MissingParameterException` and no query reaches the database.
+
+This is client-side prevalidation, not transaction atomicity. Once execution begins, the queries run sequentially on
+one cursor, and a later query can still fail at runtime (a driver error, no results, duplicate columns, or a mapper
+error) after earlier queries have executed. pydapper does not roll back or undo earlier queries in the tuple.
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -19,6 +19,16 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.row_mapping.md!}
 
+## Batch validation and atomicity
+
+Every query in the tuple is validated client-side before any database work: placeholders are scanned and every
+referenced parameter value is resolved for the complete tuple before a cursor is acquired or the first query
+executes. A missing parameter in any query raises `MissingParameterException` and no query reaches the database.
+
+This is client-side prevalidation, not transaction atomicity. Once execution begins, the queries run sequentially on
+one cursor, and a later query can still fail at runtime (a driver error, no results, duplicate columns, or a mapper
+error) after earlier queries have executed. pydapper does not roll back or undo earlier queries in the tuple.
+
 ## Example
 Query two tables and return the serialized results.
 ```python

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 ## Latest Changes
 
+* fix: validate complete query batches before DBAPI work. `query_multiple` and
+  `query_multiple_async` now construct and validate every parameter handler before acquiring
+  a cursor, so a missing or invalid parameter in any query of the tuple fails before any
+  query executes or fetches. This is client-side prevalidation, not transactional execution;
+  a validated batch can still fail partway through on a runtime database, fetch, column, or
+  mapping error.
 * chore(ai): Add CLAUDE.md symlink to AGENTS.md. PR [#544](https://github.com/zschumacher/pydapper/pull/544) by [@zschumacher](https://github.com/zschumacher).
 * fix: harden async context lifecycle. PR [#540](https://github.com/zschumacher/pydapper/pull/540) by [@zschumacher](https://github.com/zschumacher).
 * fix: harden async context lifecycle. Async resources now resolve exactly once and

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -988,10 +988,13 @@ class Commands(BaseCommands, ABC):
             projectors = models
             maps_raw_row = False
 
+        # every handler must construct (and therefore validate its placeholders and param values) before any
+        # query reaches the DBAPI; this does not make execution transactional
+        handlers = tuple(self.SqlParamHandler(query, resolved_params) for query in queries)
+
         results = list()
         with self._cursor_context_proxy() as cursor:
-            for query, projector in zip(queries, projectors):
-                handler = self.SqlParamHandler(query, resolved_params)
+            for query, projector, handler in zip(queries, projectors, handlers):
                 handler.execute(cursor)
                 headers = get_col_names(cursor)
                 data = cursor.fetchall()
@@ -2261,10 +2264,13 @@ class CommandsAsync(BaseCommands, ABC):
             projectors = models
             maps_raw_row = False
 
+        # every handler must construct (and therefore validate its placeholders and param values) before any
+        # query reaches the DBAPI; this does not make execution transactional
+        handlers = tuple(self.SqlParamHandler(query, resolved_params) for query in queries)
+
         results = list()
         async with self.cursor() as cursor:
-            for query, projector in zip(queries, projectors):
-                handler = self.SqlParamHandler(query, resolved_params)
+            for query, projector, handler in zip(queries, projectors, handlers):
                 await handler.execute_async(cursor)
                 headers = get_col_names(cursor)
                 data = await cursor.fetchall()

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2111,6 +2111,138 @@ class TestCommands:
             with MockCommands(connection) as commands:
                 commands.query_multiple(("select * from whatever",))
 
+    @pytest.mark.parametrize(
+        "queries",
+        [
+            pytest.param(
+                (
+                    "select id, name from some_table where id = ?missing?",
+                    "select id, name from another_table",
+                ),
+                id="first_query",
+            ),
+            pytest.param(
+                (
+                    "select id, name from some_table",
+                    "select id, name from another_table where id = ?missing?",
+                ),
+                id="later_query",
+            ),
+        ],
+    )
+    def test_query_multiple_missing_param_fails_before_cursor_acquisition(self, queries):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                commands.query_multiple(queries, params={})
+
+    def test_query_multiple_missing_param_in_later_query_makes_no_dbapi_calls(self):
+        events = []
+
+        class RecordingCursor(MockCursor):
+            def execute(self, sql, parameters=None):
+                events.append("execute")
+
+            def executemany(self, sql, params):
+                events.append("executemany")
+
+            def fetchone(self):
+                events.append("fetchone")
+
+            def fetchall(self):
+                events.append("fetchall")
+
+        class RecordingConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                events.append("cursor")
+                return RecordingCursor()
+
+        with MockCommands(RecordingConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                commands.query_multiple(
+                    (
+                        "select id, name from some_table",
+                        "select id, name from another_table where id = ?missing?",
+                    ),
+                    params={},
+                )
+
+        assert events == []
+
+    def test_query_multiple_missing_attribute_param_record_fails_before_cursor_acquisition(self):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                commands.query_multiple(
+                    (
+                        "select id, name from some_table where id = ?id?",
+                        "select id, name from another_table where id = ?missing?",
+                    ),
+                    params=SimpleNamespace(id=1),
+                )
+
+    @pytest.mark.parametrize(
+        "mapper",
+        [
+            pytest.param(lambda row: row.values, id="single_mapper"),
+            pytest.param((lambda row: row.values, lambda row: row.values), id="mapper_tuple"),
+        ],
+    )
+    def test_query_multiple_missing_param_with_mapper_fails_before_cursor_acquisition(self, mapper):
+        class NoCursorConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        with MockCommands(NoCursorConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                commands.query_multiple(
+                    (
+                        "select id, name from some_table",
+                        "select id, name from another_table where id = ?missing?",
+                    ),
+                    mapper=mapper,
+                    params={},
+                )
+
+    def test_query_multiple_constructs_all_handlers_before_cursor_entry_and_reuses_them(self):
+        events = []
+
+        class SpyParamHandler(MockParamHandler):
+            def __init__(self, sql, param=None):
+                events.append(("construct", self))
+                super().__init__(sql, param)
+
+            def execute(self, cursor):
+                events.append(("execute", self))
+                return super().execute(cursor)
+
+        class SpyConnection(MockConnection):
+            def cursor(self, *args, **kwargs):
+                events.append(("cursor", None))
+                return super().cursor(*args, **kwargs)
+
+        class SpyCommands(MockCommands):
+            SqlParamHandler = SpyParamHandler
+
+        queries = ("select id, name from some_table", "select id, name from another_table")
+        with SpyCommands(SpyConnection()) as commands:
+            results = commands.query_multiple(queries)
+
+        assert [name for name, _ in events] == ["construct", "construct", "cursor", "execute", "execute"]
+        constructed = [handler for name, handler in events if name == "construct"]
+        executed = [handler for name, handler in events if name == "execute"]
+        assert all(used is created for used, created in zip(executed, constructed))
+        assert [handler._sql for handler in executed] == list(queries)
+        assert isinstance(results, tuple)
+        assert [len(rows) for rows in results] == [2, 2]
+        assert all(isinstance(row, dict) for rows in results for row in rows)
+
     def test_query_first(self, connection):
         with MockCommands(connection) as commands:
             record = commands.query_first("select id, name from some_table", model=SimpleNamespace)
@@ -3019,6 +3151,127 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(NoResultException):
                 await commands.query_multiple_async(("select * from whatever",))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "queries",
+        [
+            pytest.param(
+                (
+                    "select id, name from some_table where id = ?missing?",
+                    "select id, name from another_table",
+                ),
+                id="first_query",
+            ),
+            pytest.param(
+                (
+                    "select id, name from some_table",
+                    "select id, name from another_table where id = ?missing?",
+                ),
+                id="later_query",
+            ),
+        ],
+    )
+    async def test_query_multiple_missing_param_fails_before_cursor_acquisition(self, queries):
+        class NoCursorAsyncConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        async with MockAsyncCommands(NoCursorAsyncConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                await commands.query_multiple_async(queries, params={})
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_missing_param_in_later_query_makes_no_dbapi_calls(self):
+        events = []
+
+        class RecordingAsyncCursor(MockAsyncCursor):
+            async def execute(self, sql, parameters=None):
+                events.append("execute")
+
+            async def executemany(self, sql, params=None):
+                events.append("executemany")
+
+            async def fetchone(self):
+                events.append("fetchone")
+
+            async def fetchall(self):
+                events.append("fetchall")
+
+        class RecordingAsyncConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                events.append("cursor")
+                return RecordingAsyncCursor()
+
+        async with MockAsyncCommands(RecordingAsyncConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                await commands.query_multiple_async(
+                    (
+                        "select id, name from some_table",
+                        "select id, name from another_table where id = ?missing?",
+                    ),
+                    params={},
+                )
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mapper",
+        [
+            pytest.param(lambda row: row.values, id="single_mapper"),
+            pytest.param((lambda row: row.values, lambda row: row.values), id="mapper_tuple"),
+        ],
+    )
+    async def test_query_multiple_missing_param_with_mapper_fails_before_cursor_acquisition(self, mapper):
+        class NoCursorAsyncConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                raise AssertionError("cursor should not be opened")
+
+        async with MockAsyncCommands(NoCursorAsyncConnection()) as commands:
+            with pytest.raises(MissingParameterException, match="missing"):
+                await commands.query_multiple_async(
+                    (
+                        "select id, name from some_table",
+                        "select id, name from another_table where id = ?missing?",
+                    ),
+                    mapper=mapper,
+                    params={},
+                )
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_constructs_all_handlers_before_cursor_entry_and_reuses_them(self):
+        events = []
+
+        class SpyParamHandler(MockParamHandler):
+            def __init__(self, sql, param=None):
+                events.append(("construct", self))
+                super().__init__(sql, param)
+
+            async def execute_async(self, cursor):
+                events.append(("execute", self))
+                return await super().execute_async(cursor)
+
+        class SpyAsyncConnection(MockAsyncConnection):
+            async def cursor(self, *args, **kwargs):
+                events.append(("cursor", None))
+                return await super().cursor(*args, **kwargs)
+
+        class SpyAsyncCommands(MockAsyncCommands):
+            SqlParamHandler = SpyParamHandler
+
+        queries = ("select id, name from some_table", "select id, name from another_table")
+        async with SpyAsyncCommands(SpyAsyncConnection()) as commands:
+            results = await commands.query_multiple_async(queries)
+
+        assert [name for name, _ in events] == ["construct", "construct", "cursor", "execute", "execute"]
+        constructed = [handler for name, handler in events if name == "construct"]
+        executed = [handler for name, handler in events if name == "execute"]
+        assert all(used is created for used, created in zip(executed, constructed))
+        assert [handler._sql for handler in executed] == list(queries)
+        assert isinstance(results, tuple)
+        assert [len(rows) for rows in results] == [2, 2]
+        assert all(isinstance(row, dict) for rows in results for row in rows)
 
     @pytest.mark.asyncio
     async def test_query_first(self, connection):


### PR DESCRIPTION
Closes #542

## What changed and why

`query_multiple()` and `query_multiple_async()` constructed each `SqlParamHandler` inside the open-cursor loop, so a missing placeholder value in a later query let earlier queries execute and fetch before validation failed — contradicting the M1 parameter contract (#458) that deterministic client-side validation fails before any DBAPI work, and risky because an earlier statement may have side effects.

Both methods now construct one handler per SQL string **before** cursor acquisition and execute those same retained instances in original query order. Since `BaseSqlParamHandler.__init__` performs placeholder scanning, parameter-record validation, and value lookup, this reuses the existing central validation mechanism — no scanner or lookup logic is duplicated, and no second cursor or validation SQL is involved.

This is client-side prevalidation, not transaction atomicity: after every handler validates, a later execute, fetch, duplicate-column check, or mapper can still fail after an earlier query ran. No commit/rollback/savepoint behavior was added (transactions belong to #463–#465). The invariant is documented so it carries into the #471 rename.

## Before / after

```python
queries = (
    "select id, name from some_table",
    "select id, name from another_table where id = ?missing?",
)
commands.query_multiple(queries, params={})
```

* **Before:** a cursor is acquired, the first query is passed to `cursor.execute()` and fetched, and only then does construction of the second handler raise `MissingParameterException`.
* **After:** `MissingParameterException` raises before cursor acquisition; no query in the tuple reaches `execute()`, `executemany()`, `fetchone()`, or `fetchall()`. Sync and async paths have identical ordering.

## Tests

13 new focused tests in `tests/test_commands_interface.py` (7 sync, 6 async), reusing the existing mock helpers:

* missing param in the first and in a later query raises before cursor acquisition (connection spy whose `cursor()` fails the test);
* a later missing param produces zero DBAPI events (cursor spy recording execute/executemany/fetch calls asserts `events == []`, so the fix cannot pass by merely raising just after cursor acquisition);
* a later query referencing a missing attribute on an attribute-style param record behaves the same (representative sync case);
* the invariant holds with a single mapper and with a heterogeneous mapper tuple;
* a constructor/execute spy proves the event order is `construct, construct, cursor, execute, execute`, that the retained handler instances (identity-checked) execute once each in query order, and that a valid batch returns the existing tuple-of-lists shape.

All new tests were confirmed failing against the unfixed implementation first. Existing model, mapper, duplicate-column, alias, cardinality, and list-shape tests are unchanged and pass.

## Docs

* `docs/.parameter_shapes_read.md`: tuple-query APIs validate placeholders and values for the complete tuple before acquiring a cursor or executing the first query.
* `docs/methods/query_multiple.md` and `docs/async_methods/query_multiple_async.md`: new "Batch validation and atomicity" section distinguishing client-side prevalidation from transaction atomicity.
* `docs/release_notes.md`: bug-fix entry under Latest Changes.

## Commands run

| Check | Result |
|---|---|
| `pytest tests/test_commands_interface.py -m core` | 339 passed |
| `pytest -m core` | 537 passed |
| `pytest -m sqlite` | 29 passed |
| `mypy pydapper` / `mypy tests/type_tests.py` | no issues |
| `black --check .` / `isort --check .` | clean |
| `mkdocs build --strict` | built successfully |
| `git diff --check` | clean |

Core, sqlite, and mkdocs checks were re-run after rebasing onto current `main`.

## Driver-specific tests skipped

postgresql, mssql, mysql, oracle, and bigquery suites were skipped: they require live services (testcontainers/Docker or emulators) and the Docker daemon was not running; starting services solely for this focused fix is out of scope per the issue. The change is pure client-side ordering in shared `commands.py`, fully exercised by the core and sqlite suites.

## Compatibility impact

No public signatures, typing, parameter shapes, placeholder syntax, or return shapes changed. No dependencies added; `poetry.lock` untouched. `params=`/`param=` alias behavior and all existing read-shape rejections are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)