### PR TITLE
fix: sync command-owned cursor exception precedence

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -363,10 +363,11 @@ class Commands(BaseCommands, ABC):
             try:
                 yield entered_cursor
             except BaseException:
+                # the cursor is command-owned, so its __exit__ may not suppress the command error: a truthy
+                # return value is ignored and a cleanup failure loses to the active command exception
                 exc_type, exc_val, exc_tb = sys.exc_info()
                 try:
-                    if exit(cursor, exc_type, exc_val, exc_tb):
-                        return
+                    exit(cursor, exc_type, exc_val, exc_tb)
                 except BaseException:
                     pass
                 raise

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1210,7 +1210,7 @@ class TestCommands:
         assert records == [{"id": 1, "name": "Zach"}, {"id": 2, "name": "Bob"}]
         assert connection.cursor_calls == 1
 
-    def test_cursor_context_proxy_allows_cursor_to_suppress_error(self):
+    def test_cursor_context_proxy_ignores_cursor_exit_suppression(self):
         class SuppressingCursor:
             def __init__(self):
                 self.exit_args = None
@@ -1223,10 +1223,13 @@ class TestCommands:
                 return True
 
         cursor = SuppressingCursor()
+        command_error = RuntimeError("query failed")
 
-        with MockCommands(_CursorConnection(cursor))._cursor_context_proxy():
-            raise RuntimeError("query failed")
+        with pytest.raises(RuntimeError) as exc_info:
+            with MockCommands(_CursorConnection(cursor))._cursor_context_proxy():
+                raise command_error
 
+        assert exc_info.value is command_error
         assert cursor.exit_args[0] is RuntimeError
 
     def test_cursor_context_proxy_preserves_error_when_cursor_exit_fails(self):
@@ -1240,6 +1243,192 @@ class TestCommands:
         with pytest.raises(ValueError, match="query failed"):
             with MockCommands(_CursorConnection(FailingExitCursor()))._cursor_context_proxy():
                 raise ValueError("query failed")
+
+    def test_execute_error_wins_over_native_cursor_exit_error(self):
+        command_error = ValueError("execute failed")
+
+        class ExplodingCursor:
+            def __init__(self):
+                self.enter_calls = 0
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                self.enter_calls += 1
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                raise command_error
+
+        class ExplodingCursorConnection:
+            def __init__(self, cursor):
+                self.cursor_instance = cursor
+                self.cursor_calls = 0
+
+            def cursor(self, *args, **kwargs):
+                self.cursor_calls += 1
+                return self.cursor_instance
+
+        cursor = ExplodingCursor()
+        connection = ExplodingCursorConnection(cursor)
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(connection).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is command_error
+        assert connection.cursor_calls == 1
+        assert cursor.enter_calls == 1
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is command_error
+        assert cursor.exit_tb_was_active
+
+    def test_execute_error_wins_over_truthy_native_cursor_exit(self):
+        command_error = ValueError("execute failed")
+
+        class SuppressingCursor:
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                return True
+
+            def execute(self, sql, parameters=None):
+                raise command_error
+
+        cursor = SuppressingCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is command_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is command_error
+        assert cursor.exit_tb_was_active
+
+    def test_execute_error_propagates_with_falsey_native_cursor_exit(self):
+        command_error = ValueError("execute failed")
+
+        class NonSuppressingCursor:
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                return None
+
+            def execute(self, sql, parameters=None):
+                raise command_error
+
+        cursor = NonSuppressingCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is command_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is command_error
+        assert cursor.exit_tb_was_active
+
+    def test_execute_propagates_native_cursor_exit_error_after_success(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            def execute(self, sql, parameters=None):
+                pass
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    def test_execute_error_wins_over_plain_cursor_close_error(self):
+        command_error = ValueError("execute failed")
+
+        class PlainExplodingCursor:
+            def __init__(self):
+                self.close_calls = 0
+
+            def execute(self, sql, parameters=None):
+                raise command_error
+
+            def close(self):
+                self.close_calls += 1
+                raise RuntimeError("close failed")
+
+        cursor = PlainExplodingCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is command_error
+        assert cursor.close_calls == 1
+
+    def test_execute_propagates_plain_cursor_close_error_after_success(self):
+        close_error = RuntimeError("close failed")
+
+        class PlainFailingCloseCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.close_calls = 0
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def close(self):
+                self.close_calls += 1
+                raise close_error
+
+        cursor = PlainFailingCloseCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute("insert into some_table (id) values (1)")
+
+        assert exc_info.value is close_error
+        assert cursor.close_calls == 1
 
     def test_execute(self, connection):
         with MockCommands(connection) as commands:


### PR DESCRIPTION
## What changed and why

First work unit of #541 (sync only).

In `Commands._cursor_context_proxy()`, the native-context-manager error path honored a truthy cursor `__exit__` return and swallowed the active command exception. Since command-owned cursors are an implementation detail, this let public methods like `execute()` fall through and return an undocumented value instead of raising.

The sync error path now:

* calls the native cursor `__exit__` exactly once with the real active exception triple;
* ignores a truthy `__exit__` return and re-raises the original command exception as the exact same object;
* still shields the active command error when `__exit__` itself raises.

Unchanged: success-path cleanup failures still propagate, the plain-cursor `close()` path already matched this contract, and connection-level `Commands.__exit__` suppression is untouched.

## Before and after

```python
class SuppressingCursor:
    def __enter__(self): return self
    def __exit__(self, *exc): return True  # suppresses
    def execute(self, sql, parameters=None): raise ValueError("boom")

commands.execute("insert ...")
# before: returns an undocumented uninitialized value (UnboundLocalError surface)
# after:  raises the original ValueError("boom")
```

## Tests

Public `Commands.execute()` coverage added in `tests/test_commands_interface.py` for: execution failure + `__exit__` failure, execution failure + truthy `__exit__`, execution failure + falsey `__exit__`, success + native cleanup failure, plain-cursor failure + `close()` failure, and success + plain `close()` failure. Exception identity is asserted with `is`; `__exit__` triples are verified at call time. The old private-wrapper suppression test was inverted to match the new contract.

## Commands run

* `poetry run pytest -m core` — 543 passed
* `poetry run pytest -m sqlite` — 29 passed
* `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `git diff --check` — clean

## Skipped

PostgreSQL, MSSQL, MySQL, Oracle, and BigQuery suites (require optional drivers and services; not installed for this narrow unit). Docs are deferred to the final #541 unit.

## Impact

No public API, signature, type, dependency, or docs changes. Async cursor behavior and the remaining #541 units are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)