### PR TITLE
fix: async command-owned cursor exception precedence

### DIFF
--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -53,7 +53,12 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
         obj = await self._resolve()
         try:
             if self._aexit is not None:
-                return await _await_if_needed(self._aexit(obj, exc_type, exc_val, exc_tb))
+                suppress = await _await_if_needed(self._aexit(obj, exc_type, exc_val, exc_tb))
+                if self._preserve_active_error and exc_type is not None:
+                    # a command-owned resource may not suppress the active command error, so a truthy
+                    # native __aexit__ result is ignored
+                    return False
+                return suppress
 
             close = getattr(obj, "close", None)
             if callable(close):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -9,6 +9,7 @@ import pytest
 
 import pydapper
 from pydapper import RawRow
+from pydapper._context import _AwaitableAsyncContextManager
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
@@ -2938,6 +2939,220 @@ class TestCommandsAsync:
         assert connection.cursor_instance.calls == [
             ("insert into some_table (id) values (%s)", [(1,), (2,)]),
         ]
+
+    @pytest.mark.asyncio
+    async def test_execute_async_error_wins_over_native_cursor_exit_error(self):
+        command_error = ValueError("execute failed")
+
+        class ExplodingAsyncCursor:
+            def __init__(self):
+                self.enter_calls = 0
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                self.enter_calls += 1
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                raise RuntimeError("cleanup failed")
+
+            async def execute(self, sql, parameters=None):
+                raise command_error
+
+        class CountingAsyncCursorConnection:
+            def __init__(self, cursor):
+                self.cursor_instance = cursor
+                self.cursor_calls = 0
+
+            async def cursor(self, *args, **kwargs):
+                self.cursor_calls += 1
+                return self.cursor_instance
+
+        cursor = ExplodingAsyncCursor()
+        connection = CountingAsyncCursorConnection(cursor)
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(connection).execute_async("insert into some_table (id) values (1)")
+
+        assert exc_info.value is command_error
+        assert connection.cursor_calls == 1
+        assert cursor.enter_calls == 1
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is command_error
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_execute_async_error_wins_over_truthy_native_cursor_exit(self):
+        command_error = ValueError("execute failed")
+
+        class SuppressingAsyncCursor:
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                return True
+
+            async def execute(self, sql, parameters=None):
+                raise command_error
+
+        cursor = SuppressingAsyncCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_async(
+                "insert into some_table (id) values (1)"
+            )
+
+        assert exc_info.value is command_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is command_error
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_execute_async_propagates_native_cursor_exit_error_after_success(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 3
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+                self.execute_calls = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            async def execute(self, sql, parameters=None):
+                self.execute_calls += 1
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_async(
+                "insert into some_table (id) values (1)"
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.execute_calls == 1
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_execute_async_error_wins_over_plain_cursor_sync_close_error(self):
+        command_error = ValueError("execute failed")
+
+        class SyncClosePlainCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.close_calls = 0
+
+            async def execute(self, sql, parameters=None):
+                raise command_error
+
+            def close(self):
+                self.close_calls += 1
+                raise RuntimeError("close failed")
+
+        cursor = SyncClosePlainCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_async(
+                "insert into some_table (id) values (1)"
+            )
+
+        assert exc_info.value is command_error
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_async_error_wins_over_plain_cursor_awaitable_close_error(self):
+        command_error = ValueError("execute failed")
+        cursor = _PlainAsyncQueryCursor()
+        cursor.execute_error = command_error
+        cursor.close_error = RuntimeError("close failed")
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_async(
+                "insert into some_table (id) values (1)"
+            )
+
+        assert exc_info.value is command_error
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("close_style", ["sync", "awaitable"])
+    async def test_execute_async_propagates_plain_cursor_close_error_after_success(self, close_style):
+        cleanup_error = RuntimeError("close failed")
+
+        class SyncClosePlainCursor:
+            rowcount = 1
+
+            def __init__(self):
+                self.close_calls = 0
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            def close(self):
+                self.close_calls += 1
+                raise cleanup_error
+
+        if close_style == "sync":
+            cursor = SyncClosePlainCursor()
+        else:
+            cursor = _PlainAsyncQueryCursor()
+            cursor.close_error = cleanup_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_async(
+                "insert into some_table (id) values (1)"
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_connection_wrapper_still_honors_truthy_connection_exit(self):
+        class SuppressingAsyncConnection(MockAsyncConnection):
+            def __init__(self):
+                super().__init__()
+                self.exit_calls = 0
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                return True
+
+        connection = SuppressingAsyncConnection()
+
+        async def connect():
+            return MockAsyncCommands(connection)
+
+        # mirrors CommandFactory.from_dsn_async, which wraps the connection without preserve_active_error
+        async with _AwaitableAsyncContextManager(connect()) as commands:
+            assert commands.connection is connection
+            raise ValueError("body")
+
+        assert connection.exit_calls == 1
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,13 +12,17 @@ class ContextObject:
         self.exit_result = exit_result
         self.exit_error = exit_error
         self.entered = object()
+        self.enter_calls = 0
         self.exit_calls = 0
+        self.exit_args = None
 
     async def __aenter__(self):
+        self.enter_calls += 1
         return self.entered
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self.exit_calls += 1
+        self.exit_args = exc_type, exc_val, exc_tb
         if self.exit_error:
             raise self.exit_error
         return self.exit_result
@@ -115,11 +119,81 @@ async def test_exit_result_is_propagated(exit_result, suppresses):
     obj = ContextObject(exit_result=exit_result)
     caught = False
     try:
-        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj)):
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=False):
             raise ValueError("body")
     except ValueError:
         caught = True
     assert caught is not suppresses
+
+
+@pytest.mark.asyncio
+async def test_preserve_active_error_ignores_truthy_native_exit():
+    calls = 0
+    obj = ContextObject(exit_result=True)
+
+    async def source():
+        nonlocal calls
+        calls += 1
+        return obj
+
+    body_error = ValueError("body")
+    wrapper = _AwaitableAsyncContextManager(source(), preserve_active_error=True)
+    with pytest.raises(ValueError) as exc_info:
+        async with wrapper:
+            raise body_error
+
+    assert exc_info.value is body_error
+    assert calls == 1
+    assert obj.enter_calls == 1
+    assert obj.exit_calls == 1
+    exc_type, exc_val, exc_tb = obj.exit_args
+    assert exc_type is ValueError
+    assert exc_val is body_error
+    assert exc_tb is body_error.__traceback__
+
+
+@pytest.mark.asyncio
+async def test_preserve_active_error_wins_over_native_exit_failure():
+    body_error = ValueError("body")
+    obj = ContextObject(exit_error=RuntimeError("cleanup"))
+
+    with pytest.raises(ValueError) as exc_info:
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True):
+            raise body_error
+
+    assert exc_info.value is body_error
+    assert obj.enter_calls == 1
+    assert obj.exit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_preserve_active_error_propagates_native_exit_failure_after_success():
+    cleanup_error = RuntimeError("cleanup")
+    obj = ContextObject(exit_error=cleanup_error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True):
+            pass
+
+    assert exc_info.value is cleanup_error
+    assert obj.exit_calls == 1
+    assert obj.exit_args == (None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_preserve_active_error_passes_through_native_exit_result_without_active_error():
+    # async with discards __aexit__'s return value when no exception is active, so drive the
+    # protocol directly to observe that the native result passes through unchanged
+    marker = object()
+    obj = ContextObject(exit_result=marker)
+    wrapper = _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True)
+
+    entered = await wrapper.__aenter__()
+    result = await wrapper.__aexit__(None, None, None)
+
+    assert entered is obj.entered
+    assert result is marker
+    assert obj.exit_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed and why

Second unit of #541. `_AwaitableAsyncContextManager.__aexit__` previously returned the native `__aexit__` result unconditionally, so a driver cursor whose `__aexit__` returned a truthy value could suppress an active `execute_async()` error and make the command return an undocumented `None`. The wrapper now still invokes native `__aexit__` exactly once with the real exception triple, but when constructed with `preserve_active_error=True` (the command-owned cursor path used by `CommandsAsync.cursor()`) and an exception is active, it ignores a truthy cleanup result and returns `False`, so the original command exception re-raises as the exact same object. Existing behavior is unchanged: cleanup exceptions still lose to an active command error, cleanup failures still propagate when the body succeeded, and the connection wrapper used by `connect_async()` (`preserve_active_error=False`) still honors truthy native suppression.

## Before / after

```python
class SuppressingCursor:
    async def __aenter__(self): return self
    async def __aexit__(self, *exc): return True  # driver suppresses
    async def execute(self, sql, parameters=None): raise ProgrammingError("bad sql")

commands = pydapper.using_async(conn)
await commands.execute_async("...")
# before: returned None (error silently suppressed by cursor cleanup)
# after:  raises ProgrammingError("bad sql") — the exact original exception object
```

## Tests

* `tests/test_context.py`: wrapper policy tests — truthy-exit non-suppression with exact exception triple and resolve/enter/exit-once counts; body error winning over failing native exit by identity; cleanup propagation after success; native result passing through unchanged (asserted via direct protocol calls, since `async with` discards the value); explicit `preserve_active_error=False` suppression regression.
* `tests/test_commands_interface.py`: public `execute_async()` tests — command error wins by identity over failing native `__aexit__`, truthy native `__aexit__`, and sync/awaitable plain-`close()` failures (close called exactly once); cleanup errors propagate after success for native exit (receiving `(None, None, None)`) and both plain-close forms; connection-level regression proving the `from_dsn_async` wrapper path still honors a truthy connection `__aexit__`.

## Commands run

* `poetry run pytest -m "core"` — 555 passed
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — no issues
* `poetry run black --check .` / `poetry run isort --check .` — clean

Skipped: postgresql, mssql, mysql, oracle, bigquery integration suites — optional drivers not installed and no adapter code touched.

## Impact

No public API, signature, return-type, dependency, or docs changes. #541 documentation is deferred to the final unit; the remaining parent-ticket work (query-family lifecycle units) is still outstanding, so this does not close #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)