### PR TITLE
fix: project query_first rows inside the command-owned cursor lifecycle

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1114,7 +1114,7 @@ class Commands(BaseCommands, ABC):
                 raise NoResultException("Query returned no results")
             if not maps_raw_row:
                 validate_no_duplicate_columns(headers)
-        return _project_row(projector, maps_raw_row, headers, row)
+            return _project_row(projector, maps_raw_row, headers, row)
 
     @overload
     def query_first_or_default(

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2468,6 +2468,86 @@ class TestCommands:
         with MockCommands(connection) as commands, pytest.raises(NoResultException):
             commands.query_first("select * from some_table")
 
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_first_mapper_error_wins_over_native_cursor_exit(self, exit_behavior):
+        mapper_error = ValueError("mapper failed")
+
+        class RecordingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchone(self):
+                return 1, "Zach"
+
+        def mapper(row):
+            raise mapper_error
+
+        cursor = RecordingExitCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_first("select id, name from some_table", mapper=mapper)
+
+        assert exc_info.value is mapper_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
+
+    def test_query_first_propagates_native_cursor_exit_error_after_successful_mapping(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchone(self):
+                return 1, "Zach"
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_first(
+                "select id, name from some_table", mapper=lambda row: row["id"]
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
     def test_query_first_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         with MockCommands(connection) as commands:
@@ -3733,6 +3813,90 @@ class TestCommandsAsync:
         async with MockAsyncCommands(connection) as commands:
             with pytest.raises(NoResultException):
                 await commands.query_first_async("select * from some_table")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_query_first_async_mapper_error_wins_over_native_cursor_exit(self, exit_behavior):
+        mapper_error = ValueError("mapper failed")
+
+        class RecordingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchone(self):
+                return 1, "Zach"
+
+        def mapper(row):
+            raise mapper_error
+
+        cursor = RecordingExitAsyncCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_first_async(
+                "select id, name from some_table", mapper=mapper
+            )
+
+        assert exc_info.value is mapper_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_query_first_async_propagates_native_cursor_exit_error_after_successful_mapping(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchone(self):
+                return 1, "Zach"
+
+        cursor = FailingExitAsyncCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_first_async(
+                "select id, name from some_table", mapper=lambda row: row["id"]
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
 
     @pytest.mark.asyncio
     async def test_query_first_or_default(self, connection, set_fetchone_to_return_none):


### PR DESCRIPTION
Part of #541.

## What changed and why

`Commands.query_first()` performed execution, fetching, no-row handling, and duplicate-column validation inside `_cursor_context_proxy()`, but called `_project_row()` after leaving that context. As a result:

* a mapper or model-construction error was raised only after cursor cleanup had already finished;
* cleanup never received the mapper error as its active exception;
* if cleanup itself failed, the cleanup error could occur before projection was even attempted;
* sync behavior diverged from `query_first_async()`, which already projects inside its cursor lifecycle.

This is a one-line move: the `return _project_row(...)` now sits inside the `with self._cursor_context_proxy()` block, so projection errors are active during cursor cleanup and the established #546/#541 precedence rules (command error beats cleanup error, truthy command-owned cursor exits are ignored) now cover mapper failures too. `query_first_async()` production code already satisfied the contract and is unchanged; it gains regression coverage only.

## Before and after

```python
mapper_error = ValueError("mapper failed")

def mapper(row):
    raise mapper_error

commands.query_first("select id, name from some_table", mapper=mapper)
```

With a cursor whose `__exit__` also raises, before this change the mapper error fired after cleanup, so cleanup saw no active exception and its own failure could surface instead. Now the exact `mapper_error` object propagates, cleanup runs exactly once, and `__exit__`/`__aexit__` receive the mapper error's real type, value, and traceback. After successful mapping, a cleanup failure still propagates because no command error is active.

## Tests

New cases in `tests/test_commands_interface.py`, all through the public methods:

* sync + async mapper failure with a raising or truthy cursor exit (parameterized): the exact mapper exception object wins (identity assertions), cleanup runs once, exit hooks receive the active exception triple;
* sync + async successful mapping followed by cleanup failure: the cleanup exception propagates and the exit hook received `(None, None, None)`.

Existing model=, mapper=, RawRow, duplicate-column, falsy-row, and no-result assertions are untouched.

## Commands run

* `poetry run pytest tests/test_commands_interface.py -m "core"` — 359 passed
* `poetry run pytest -m "core"` — 561 passed
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `git diff --check` — clean

Driver integrations (postgresql, mssql, mysql, oracle, bigquery) were skipped: they need optional extras/Docker and this change is fully exercised by the core mock suite plus sqlite.

## Impact

No public API, typing, mapping-rule, exception-class, dependency, or docs changes. MySQL's `query_first` override (driver-specific unread-result draining) is intentionally left for a later #541 slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)