### PR TITLE
fix: validate and extract scalar results inside the command-owned cursor lifecycle

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1651,9 +1651,9 @@ class Commands(BaseCommands, ABC):
         with self._cursor_context_proxy() as cursor:
             handler.execute(cursor)
             first_row = cursor.fetchone()
-        if first_row is None:
-            raise NoResultException("Query returned no results")
-        return first_row[0]
+            if first_row is None:
+                raise NoResultException("Query returned no results")
+            return first_row[0]
 
 
 class CommandsAsync(BaseCommands, ABC):
@@ -2925,6 +2925,6 @@ class CommandsAsync(BaseCommands, ABC):
         async with self.cursor() as cursor:
             await handler.execute_async(cursor)
             first_row = await cursor.fetchone()
-        if first_row is None:
-            raise NoResultException("Query returned no results")
-        return first_row[0]
+            if first_row is None:
+                raise NoResultException("Query returned no results")
+            return first_row[0]

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2866,6 +2866,114 @@ class TestCommands:
         with MockCommands(connection) as commands:
             assert commands.execute_scalar("select nullable_column from some_table") is None
 
+    @pytest.mark.parametrize("value", [0, False, ""], ids=["zero", "false", "empty-string"])
+    def test_execute_scalar_preserves_falsey_first_column_values(self, value):
+        cursor = _PlainQueryCursor(rows=[(value,)])
+        with MockCommands(_CursorConnection(cursor)) as commands:
+            assert commands.execute_scalar("select flag from some_table") == value
+
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_execute_scalar_no_result_error_wins_over_native_cursor_exit(self, exit_behavior):
+        class RecordingExitCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchone(self):
+                return None
+
+        cursor = RecordingExitCursor()
+
+        with pytest.raises(NoResultException) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute_scalar("select id from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is NoResultException
+        assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
+
+    def test_execute_scalar_propagates_native_cursor_exit_error_after_successful_fetch(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchone(self):
+                return (42,)
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute_scalar("select id from some_table")
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    def test_execute_scalar_extraction_error_wins_over_native_cursor_exit_error(self):
+        class MalformedRowCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchone(self):
+                return ()
+
+        cursor = MalformedRowCursor()
+
+        with pytest.raises(IndexError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).execute_scalar("select id from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is IndexError
+        assert exc_val is exc_info.value
+
 
 class TestCommandsAsync:
     @pytest.fixture
@@ -4230,3 +4338,121 @@ class TestCommandsAsync:
     ):
         async with MockAsyncCommands(connection) as commands:
             assert await commands.execute_scalar_async("select nullable_column from some_table") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", [0, False, ""], ids=["zero", "false", "empty-string"])
+    async def test_execute_scalar_preserves_falsey_first_column_values(self, value):
+        cursor = _PlainAsyncQueryCursor(rows=[(value,)])
+        commands = MockAsyncCommands(_PlainAsyncQueryConnection(cursor))
+        assert await commands.execute_scalar_async("select flag from some_table") == value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_execute_scalar_async_no_result_error_wins_over_native_cursor_exit(self, exit_behavior):
+        class RecordingExitAsyncCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchone(self):
+                return None
+
+        cursor = RecordingExitAsyncCursor()
+
+        with pytest.raises(NoResultException) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_scalar_async(
+                "select id from some_table"
+            )
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is NoResultException
+        assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_execute_scalar_async_propagates_native_cursor_exit_error_after_successful_fetch(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitAsyncCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchone(self):
+                return (42,)
+
+        cursor = FailingExitAsyncCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_scalar_async(
+                "select id from some_table"
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_execute_scalar_async_extraction_error_wins_over_native_cursor_exit_error(self):
+        class MalformedRowAsyncCursor:
+            rowcount = 0
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchone(self):
+                return ()
+
+        cursor = MalformedRowAsyncCursor()
+
+        with pytest.raises(IndexError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).execute_scalar_async(
+                "select id from some_table"
+            )
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is IndexError
+        assert exc_val is exc_info.value


### PR DESCRIPTION
Part of #541 (scalar slice). Follows #546, #547, and #548.

## What changed and why

`Commands.execute_scalar()` and `CommandsAsync.execute_scalar_async()` executed and fetched inside their cursor contexts, but performed the no-row check and `first_row[0]` extraction after leaving the cursor lifecycle. Cleanup therefore never received those failures as active command errors: a cleanup failure could replace the intended `NoResultException`, and sync/async exception timing was inconsistent with the unified lifecycle contract established by the earlier #541 slices.

The no-row check, first-column extraction, and successful return now happen inside the command-owned cursor lifecycle for both methods. `NoResultException` is raised (not caught and re-raised) inside the context, so the established cursor wrappers receive it as the active error, preserve the exact exception object when cleanup also fails, and ignore truthy cursor exits.

No changes to public signatures, return annotations, exception types, parameter handling, or scalar semantics. SQL NULL first columns (`(None,)` → `None`) and falsey scalars (`0`, `False`, `""`) behave exactly as before.

## Before and after

```python
# cursor __exit__ raises RuntimeError("cleanup failed"); fetchone() returned no row
commands.execute_scalar("select id from some_table where id = -1")
```

Before: the `RuntimeError` from cleanup propagated and the caller never saw `NoResultException`.
After: `NoResultException` propagates (the exact object cleanup observed as the active error); the cleanup failure is subordinate to it. When the scalar fetch succeeds and only cleanup fails, the cleanup error still propagates.

## Tests

Added 14 focused public-method regressions in `tests/test_commands_interface.py`, mirrored sync/async:

* no-row failure + cleanup failure: `NoResultException` wins; the raised object is identically (`is`) the object received by `__exit__`/`__aexit__`; cleanup runs exactly once with the real type, value, and active traceback
* truthy `__exit__`/`__aexit__` during a no-row failure cannot suppress it or fake a SQL-NULL `None` return
* successful `(42,)` fetch + cleanup failure: the cleanup exception propagates instead of returning the value
* malformed empty row: the `IndexError` from extraction is active during cleanup and wins over a simultaneous cleanup failure
* falsey scalars `0`, `False`, `""` preserved (parametrized)

Existing SQL-NULL-vs-no-row tests are unchanged and still pass.

## Commands run

* `poetry run pytest tests/test_commands_interface.py -m "core"` — 373 passed
* `poetry run pytest -m "core"` — 575 passed
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `git diff --check` — clean

## Skipped

Driver-specific integrations (postgresql, mssql, mysql, oracle, bigquery) were skipped: this slice only touches shared command internals fully covered by core mocks and the sqlite marker, and those suites require optional extras/Docker services. Docs are intentionally deferred to the final #541 slice.

## Impact

No public API, typing, optional-extra, dependency, or docs impact. Does not close #541; the remaining slices are still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)