### PR TITLE
fix: project query_single rows inside the command-owned cursor lifecycle

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1426,7 +1426,7 @@ class Commands(BaseCommands, ABC):
             if not maps_raw_row:
                 validate_no_duplicate_columns(headers)
 
-        return _project_row(projector, maps_raw_row, headers, data[0])
+            return _project_row(projector, maps_raw_row, headers, data[0])
 
     @overload
     def query_single_or_default(

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2764,6 +2764,169 @@ class TestCommands:
 
         assert calls == [connection.cursor_instance]
 
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_single_mapper_error_wins_over_native_cursor_exit(self, exit_behavior):
+        mapper_error = ValueError("mapper failed")
+
+        class RecordingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach")]
+
+        def mapper(row):
+            raise mapper_error
+
+        cursor = RecordingExitCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single("select id, name from some_table", mapper=mapper)
+
+        assert exc_info.value is mapper_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
+
+    def test_query_single_propagates_native_cursor_exit_error_after_successful_mapping(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach")]
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single(
+                "select id, name from some_table", mapper=lambda row: row["id"]
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.parametrize(
+        "rows, expected_exception",
+        [
+            ([], NoResultException),
+            ([(1, "Zach"), (2, "Bob")], MoreThanOneResultException),
+        ],
+    )
+    def test_query_single_cardinality_error_wins_over_native_cursor_exit_error(self, rows, expected_exception):
+        hook_calls = []
+
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return list(rows)
+
+        class HookedCommands(MockCommands):
+            def _on_query_single_more_than_one_result(self, cursor):
+                hook_calls.append(cursor)
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(expected_exception) as exc_info:
+            HookedCommands(_CursorConnection(cursor)).query_single("select id, name from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is expected_exception
+        assert exc_val is exc_info.value
+        if expected_exception is MoreThanOneResultException:
+            assert hook_calls == [cursor]
+        else:
+            assert hook_calls == []
+
+    def test_query_single_duplicate_column_error_wins_over_native_cursor_exit_error(self):
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text"), ("id", "int")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach", 2)]
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single("select id, name, id from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is DuplicateColumnException
+        assert exc_val is exc_info.value
+
     def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         with MockCommands(connection) as commands:


### PR DESCRIPTION
## What changed and why

Part of #541 (sync `query_single` slice). `Commands.query_single()` previously executed, fetched at most two rows, checked cardinality, and validated duplicate columns inside `_cursor_context_proxy()`, but projected the final row **after** leaving the cursor lifecycle. A `mapper=`/`model=` failure therefore occurred after cursor cleanup — cleanup never received it as the active exception, a truthy cursor `__exit__` couldn't interact with it correctly, and a cleanup failure could preempt projection.

The fix moves `_project_row()` and the successful return inside the existing `with` block (a one-line indentation change in `pydapper/commands.py`), matching the pattern established for `query_first` (#548) and `execute_scalar` (#549).

## Before / after

Before: a mapper that raises caused the cursor's `__exit__` to run with `(None, None, None)`, and a simultaneous cleanup failure would mask the mapper error.

After: the mapper exception is active during cleanup — `__exit__` receives its real type, exact object, and traceback — and the command's own exception (mapper, `NoResultException`, `MoreThanOneResultException`, `DuplicateColumnException`) wins over cleanup failures, per the command-owned cursor exception precedence from #546.

## Behavior preserved

- Bounded fetching at two rows (fetchmany and fetchone paths).
- Zero-row / multi-row exceptions and the `_on_query_single_more_than_one_result()` adapter hook.
- Duplicate-column validation, RawRow mapper behavior, model=/mapper= mutual exclusion, public signatures.

## Tests

New focused tests in `tests/test_commands_interface.py` using public `query_single()`: mapper error vs raising and truthy cursor `__exit__` (identity, type, and traceback assertions; cleanup runs once), cleanup error propagation after successful projection, zero-row and two-row cardinality errors winning over cleanup failure (with hook invocation checked), and duplicate-column error winning over cleanup failure.

## Checks run

- `poetry run pytest tests/test_commands_interface.py -m core` — 379 passed
- `poetry run pytest -m core` — 581 passed
- `poetry run pytest -m sqlite` — 29 passed
- `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
- `poetry run black --check .` / `poetry run isort --check .` — clean
- `git diff --check` — clean

Driver-specific integrations (postgresql, mssql, mysql, oracle, bigquery) were skipped: shared-command behavior only, fully covered by core mocks.

No public API, typing, docs, or dependency changes. `query_single_async` is the next slice of #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)