### PR TITLE
fix: project query_single rows inside the command-owned cursor lifecycle

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -1426,7 +1426,7 @@ class Commands(BaseCommands, ABC):
             if not maps_raw_row:
                 validate_no_duplicate_columns(headers)
 
-        return _project_row(projector, maps_raw_row, headers, data[0])
+            return _project_row(projector, maps_raw_row, headers, data[0])
 
     @overload
     def query_single_or_default(

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -2692,15 +2692,16 @@ class CommandsAsync(BaseCommands, ABC):
             headers = get_col_names(cursor)
             data = await _fetch_at_most_two_rows_async(cursor)
 
-        num_records = len(data)
-        if num_records == 0:
-            raise NoResultException("Expected exactly one record, got zero")
-        elif num_records > 1:
-            raise MoreThanOneResultException("Expected exactly one record, got at least two")
+            num_records = len(data)
+            if num_records == 0:
+                raise NoResultException("Expected exactly one record, got zero")
+            elif num_records > 1:
+                raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
-        if not maps_raw_row:
-            validate_no_duplicate_columns(headers)
-        return _project_row(projector, maps_raw_row, headers, data[0])
+            if not maps_raw_row:
+                validate_no_duplicate_columns(headers)
+
+            return _project_row(projector, maps_raw_row, headers, data[0])
 
     @overload
     async def query_single_or_default_async(

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -4378,6 +4378,212 @@ class TestCommandsAsync:
         assert connection.cursor_instance.fetchall_calls == 0
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_query_single_async_mapper_error_wins_over_native_cursor_exit(self, exit_behavior):
+        mapper_error = ValueError("mapper failed")
+
+        class RecordingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchmany(self, size=None):
+                return ((1, "Zach"),)
+
+        def mapper(row):
+            raise mapper_error
+
+        cursor = RecordingExitAsyncCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_single_async(
+                "select id, name from some_table", mapper=mapper
+            )
+
+        assert exc_info.value is mapper_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_propagates_native_cursor_exit_error_after_successful_mapping(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchmany(self, size=None):
+                return ((1, "Zach"),)
+
+        cursor = FailingExitAsyncCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_single_async(
+                "select id, name from some_table", mapper=lambda row: row["id"]
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "rows, expected_exception",
+        [
+            ([], NoResultException),
+            ([(1, "Zach"), (2, "Bob"), (3, "Alice")], MoreThanOneResultException),
+        ],
+    )
+    async def test_query_single_async_cardinality_error_wins_over_native_cursor_exit_error(
+        self, rows, expected_exception
+    ):
+        class FailingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+                self.fetchmany_calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                return tuple(rows[:size])
+
+        cursor = FailingExitAsyncCursor()
+
+        with pytest.raises(expected_exception) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_single_async(
+                "select id, name from some_table"
+            )
+
+        assert cursor.fetchmany_calls == [2]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is expected_exception
+        assert exc_val is exc_info.value
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_duplicate_column_error_wins_over_native_cursor_exit_error(self):
+        class FailingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text"), ("id", "int")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                raise RuntimeError("cleanup failed")
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchmany(self, size=None):
+                return ((1, "Zach", 2),)
+
+        cursor = FailingExitAsyncCursor()
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_single_async(
+                "select id, name, id from some_table"
+            )
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is DuplicateColumnException
+        assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_enters_and_exits_cursor_exactly_once_on_success(self):
+        class RecordingAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.enter_calls = 0
+                self.exit_calls = 0
+                self.fetchmany_calls = []
+
+            async def __aenter__(self):
+                self.enter_calls += 1
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchmany(self, size=None):
+                self.fetchmany_calls.append(size)
+                return ((1, "Zach"),)
+
+        cursor = RecordingAsyncCursor()
+
+        record = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_single_async(
+            "select id, name from some_table"
+        )
+
+        assert record == {"id": 1, "name": "Zach"}
+        assert cursor.enter_calls == 1
+        assert cursor.exit_calls == 1
+        assert cursor.fetchmany_calls == [2]
+
+    @pytest.mark.asyncio
     async def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         async with MockAsyncCommands(connection) as commands:

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2764,6 +2764,169 @@ class TestCommands:
 
         assert calls == [connection.cursor_instance]
 
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_single_mapper_error_wins_over_native_cursor_exit(self, exit_behavior):
+        mapper_error = ValueError("mapper failed")
+
+        class RecordingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                self.exit_tb_was_active = exc_tb is exc_val.__traceback__
+                if exit_behavior == "raises":
+                    raise RuntimeError("cleanup failed")
+                return True
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach")]
+
+        def mapper(row):
+            raise mapper_error
+
+        cursor = RecordingExitCursor()
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single("select id, name from some_table", mapper=mapper)
+
+        assert exc_info.value is mapper_error
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
+
+    def test_query_single_propagates_native_cursor_exit_error_after_successful_mapping(self):
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise cleanup_error
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach")]
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single(
+                "select id, name from some_table", mapper=lambda row: row["id"]
+            )
+
+        assert exc_info.value is cleanup_error
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.parametrize(
+        "rows, expected_exception",
+        [
+            ([], NoResultException),
+            ([(1, "Zach"), (2, "Bob")], MoreThanOneResultException),
+        ],
+    )
+    def test_query_single_cardinality_error_wins_over_native_cursor_exit_error(self, rows, expected_exception):
+        hook_calls = []
+
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return list(rows)
+
+        class HookedCommands(MockCommands):
+            def _on_query_single_more_than_one_result(self, cursor):
+                hook_calls.append(cursor)
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(expected_exception) as exc_info:
+            HookedCommands(_CursorConnection(cursor)).query_single("select id, name from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is expected_exception
+        assert exc_val is exc_info.value
+        if expected_exception is MoreThanOneResultException:
+            assert hook_calls == [cursor]
+        else:
+            assert hook_calls == []
+
+    def test_query_single_duplicate_column_error_wins_over_native_cursor_exit_error(self):
+        class FailingExitCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text"), ("id", "int")
+
+            def __init__(self):
+                self.exit_calls = 0
+                self.exit_args = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+                self.exit_args = exc_type, exc_val, exc_tb
+                raise RuntimeError("cleanup failed")
+
+            def execute(self, sql, parameters=None):
+                pass
+
+            def fetchmany(self, size):
+                return [(1, "Zach", 2)]
+
+        cursor = FailingExitCursor()
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_single("select id, name, id from some_table")
+
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, exc_tb = cursor.exit_args
+        assert exc_type is DuplicateColumnException
+        assert exc_val is exc_info.value
+
     def test_query_single_or_default(self, connection, set_fetchone_to_return_none):
         default = SimpleNamespace(id=10, name="default")
         with MockCommands(connection) as commands:


### PR DESCRIPTION
## What changed and why

Part of #541. This branch moves `query_single` / `query_single_async` post-fetch result processing — zero/many cardinality checks, duplicate-column validation, and `model=`/`mapper=` projection — inside the command-owned cursor lifecycle in `pydapper/commands.py`. Previously the cursor context exited before these checks ran, so cursor cleanup could fail before pydapper raised the intended error, and cleanup never saw the active exception triple for those failures.

## Before / after

Before:

```python
async with self.cursor() as cursor:
    await handler.execute_async(cursor)
    headers = get_col_names(cursor)
    data = await _fetch_at_most_two_rows_async(cursor)
# cardinality/duplicate-column/projection happened here, outside the cursor
```

After: those steps and the successful return happen inside the `async with` block (the sync method mirrors this). Consequences:

* `NoResultException`, `MoreThanOneResultException`, `DuplicateColumnException`, and mapper errors are active during cursor cleanup, so `__exit__`/`__aexit__` receives the real exception triple.
* Those command errors win over a simultaneous cleanup failure as the exact same exception objects.
* A truthy cursor `__exit__`/`__aexit__` can no longer suppress a result-processing failure.
* A cleanup failure after successful projection still propagates.

Bounded-at-two fetching, exception types, `model=`/`mapper=` semantics, RawRow behavior, and public signatures are unchanged. `query_single_or_default(_async)` and the `_context.py` wrapper policy are untouched.

## Tests

Added focused public-method tests in `tests/test_commands_interface.py` for both sync and async: cardinality/duplicate-column/mapper errors vs. raising and truthy cursor exits (with identity and traceback-triple assertions), cleanup failure after successful mapping, bounded fetch, and enter/exit-exactly-once on success.

## Commands run

* `poetry run pytest -m "core"` — 588 passed
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `git diff --check` — clean

## Skipped

Driver-specific integrations (postgresql, mssql, mysql, oracle, bigquery) were not run — the change is in shared command behavior covered by the shared mock-based and sqlite suites, and optional drivers/services are not installed here. No docs, dependency, or lockfile changes; docs updates are deferred to the final #541 slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)