### PR TITLE
test: cover query_multiple runtime failures inside the command-owned cursor lifecycle

### DIFF
--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -2632,6 +2632,7 @@ class TestCommands:
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is ValueError
         assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
         # the second mapper ran inside the cursor lifecycle: its failure reached the native exit
         assert cursor.events == [
             "enter",
@@ -2642,8 +2643,13 @@ class TestCommands:
             ("exit", ValueError),
         ]
 
-    def test_query_multiple_later_no_result_error_is_active_during_cleanup(self):
-        cursor = _MultiQueryExitCursor(fetch_results=(((1, "Zach"),), tuple()))
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_multiple_later_no_result_error_wins_over_native_cursor_exit(self, exit_behavior):
+        cursor = _MultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), tuple()),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
+        )
         mapped = []
 
         def mapper(row):
@@ -2661,26 +2667,46 @@ class TestCommands:
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is NoResultException
         assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
 
-    def test_query_multiple_later_duplicate_column_error_is_active_during_cleanup(self):
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_multiple_later_duplicate_column_error_wins_over_native_cursor_exit(self, exit_behavior):
         cursor = _MultiQueryExitCursor(
             fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
             descriptions=(
                 (("id", "int"), ("name", "text")),
                 (("id", "int"), ("name", "text"), ("id", "int")),
             ),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
         )
+        projected = []
+
+        def first_model(**row):
+            projected.append(row)
+            return row
 
         with pytest.raises(DuplicateColumnException) as exc_info:
             MockCommands(_CursorConnection(cursor)).query_multiple(
-                ("select id, name from some_table", "select id, name, id from another_table")
+                ("select id, name from some_table", "select id, name, id from another_table"),
+                models=(first_model, dict),
             )
 
         _assert_duplicate_column_exception(exc_info)
+        assert projected == [{"id": 1, "name": "Zach"}]
         assert cursor.exit_calls == 1
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is DuplicateColumnException
         assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", DuplicateColumnException),
+        ]
 
     def test_query_multiple_mapper_still_receives_later_duplicate_columns(self):
         cursor = _MultiQueryExitCursor(
@@ -2693,11 +2719,11 @@ class TestCommands:
 
         data1, data2 = MockCommands(_CursorConnection(cursor)).query_multiple(
             ("select id, name from some_table", "select id, name, id from another_table"),
-            mapper=lambda row: row.values,
+            mapper=lambda row: (row.columns, row.values),
         )
 
-        assert data1 == [(1, "Zach")]
-        assert data2 == [(1, "Zach", 2)]
+        assert data1 == [(("id", "name"), (1, "Zach"))]
+        assert data2 == [(("id", "name", "id"), (1, "Zach", 2))]
         assert cursor.exit_args == (None, None, None)
 
     def test_query_multiple_propagates_native_cursor_exit_error_after_successful_batch(self):
@@ -4419,6 +4445,7 @@ class TestCommandsAsync:
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is ValueError
         assert exc_val is mapper_error
+        assert cursor.exit_tb_was_active
         # the second mapper ran inside the cursor lifecycle: its failure reached the native exit
         assert cursor.events == [
             "enter",
@@ -4430,8 +4457,13 @@ class TestCommandsAsync:
         ]
 
     @pytest.mark.asyncio
-    async def test_query_multiple_async_later_no_result_error_is_active_during_cleanup(self):
-        cursor = _AsyncMultiQueryExitCursor(fetch_results=(((1, "Zach"),), tuple()))
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_query_multiple_async_later_no_result_error_wins_over_native_cursor_exit(self, exit_behavior):
+        cursor = _AsyncMultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), tuple()),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
+        )
         mapped = []
 
         def mapper(row):
@@ -4449,27 +4481,47 @@ class TestCommandsAsync:
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is NoResultException
         assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
 
     @pytest.mark.asyncio
-    async def test_query_multiple_async_later_duplicate_column_error_is_active_during_cleanup(self):
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_query_multiple_async_later_duplicate_column_error_wins_over_native_cursor_exit(self, exit_behavior):
         cursor = _AsyncMultiQueryExitCursor(
             fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
             descriptions=(
                 (("id", "int"), ("name", "text")),
                 (("id", "int"), ("name", "text"), ("id", "int")),
             ),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
         )
+        projected = []
+
+        def first_model(**row):
+            projected.append(row)
+            return row
 
         with pytest.raises(DuplicateColumnException) as exc_info:
             await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
-                ("select id, name from some_table", "select id, name, id from another_table")
+                ("select id, name from some_table", "select id, name, id from another_table"),
+                models=(first_model, dict),
             )
 
         _assert_duplicate_column_exception(exc_info)
+        assert projected == [{"id": 1, "name": "Zach"}]
         assert cursor.exit_calls == 1
         exc_type, exc_val, _ = cursor.exit_args
         assert exc_type is DuplicateColumnException
         assert exc_val is exc_info.value
+        assert cursor.exit_tb_was_active
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", DuplicateColumnException),
+        ]
 
     @pytest.mark.asyncio
     async def test_query_multiple_async_mapper_still_receives_later_duplicate_columns(self):
@@ -4483,11 +4535,11 @@ class TestCommandsAsync:
 
         data1, data2 = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
             ("select id, name from some_table", "select id, name, id from another_table"),
-            mapper=lambda row: row.values,
+            mapper=lambda row: (row.columns, row.values),
         )
 
-        assert data1 == [(1, "Zach")]
-        assert data2 == [(1, "Zach", 2)]
+        assert data1 == [(("id", "name"), (1, "Zach"))]
+        assert data2 == [(("id", "name", "id"), (1, "Zach", 2))]
         assert cursor.exit_args == (None, None, None)
 
     @pytest.mark.asyncio

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -308,6 +308,124 @@ class _AsyncCursorConnection:
         self.closed = 1
 
 
+class _MultiQueryExitCursor:
+    """Scripts per-query outcomes for query_multiple and records the native cursor lifecycle."""
+
+    rowcount = 0
+
+    def __init__(
+        self,
+        fetch_results=(((1, "Zach"),), ((2, "Bob"),)),
+        *,
+        execute_errors=(),
+        descriptions=None,
+        exit_error=None,
+        exit_return=None,
+    ):
+        self.events = []
+        self.exit_calls = 0
+        self.exit_args = None
+        self._fetch_results = tuple(fetch_results)
+        self._execute_errors = tuple(execute_errors)
+        self._descriptions = descriptions
+        self._exit_error = exit_error
+        self._exit_return = exit_return
+        self._query_index = -1
+
+    @property
+    def description(self):
+        if self._descriptions is not None:
+            return self._descriptions[self._query_index]
+        return ("id", "int"), ("name", "text")
+
+    def __enter__(self):
+        self.events.append("enter")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.exit_calls += 1
+        self.exit_args = exc_type, exc_val, exc_tb
+        self.exit_tb_was_active = exc_val is not None and exc_tb is exc_val.__traceback__
+        self.events.append(("exit", exc_type))
+        if self._exit_error is not None:
+            raise self._exit_error
+        return self._exit_return
+
+    def execute(self, sql, parameters=None):
+        self._query_index += 1
+        self.events.append(("execute", self._query_index))
+        if self._query_index < len(self._execute_errors):
+            error = self._execute_errors[self._query_index]
+            if error is not None:
+                raise error
+
+    def fetchall(self):
+        self.events.append(("fetchall", self._query_index))
+        result = self._fetch_results[self._query_index]
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class _AsyncMultiQueryExitCursor:
+    """Scripts per-query outcomes for query_multiple_async and records the native cursor lifecycle."""
+
+    rowcount = 0
+
+    def __init__(
+        self,
+        fetch_results=(((1, "Zach"),), ((2, "Bob"),)),
+        *,
+        execute_errors=(),
+        descriptions=None,
+        exit_error=None,
+        exit_return=None,
+    ):
+        self.events = []
+        self.exit_calls = 0
+        self.exit_args = None
+        self._fetch_results = tuple(fetch_results)
+        self._execute_errors = tuple(execute_errors)
+        self._descriptions = descriptions
+        self._exit_error = exit_error
+        self._exit_return = exit_return
+        self._query_index = -1
+
+    @property
+    def description(self):
+        if self._descriptions is not None:
+            return self._descriptions[self._query_index]
+        return ("id", "int"), ("name", "text")
+
+    async def __aenter__(self):
+        self.events.append("enter")
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.exit_calls += 1
+        self.exit_args = exc_type, exc_val, exc_tb
+        self.exit_tb_was_active = exc_val is not None and exc_tb is exc_val.__traceback__
+        self.events.append(("exit", exc_type))
+        if self._exit_error is not None:
+            raise self._exit_error
+        return self._exit_return
+
+    async def execute(self, sql, parameters=None):
+        self._query_index += 1
+        self.events.append(("execute", self._query_index))
+        if self._query_index < len(self._execute_errors):
+            error = self._execute_errors[self._query_index]
+            if error is not None:
+                raise error
+
+    async def fetchall(self):
+        self.events.append(("fetchall", self._query_index))
+        result = self._fetch_results[self._query_index]
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
 def _assert_duplicate_column_exception(exc_info):
     assert exc_info.value.columns == ("id", "name", "id")
     assert exc_info.value.duplicate_columns == ("id",)
@@ -2433,6 +2551,195 @@ class TestCommands:
         assert [len(rows) for rows in results] == [2, 2]
         assert all(isinstance(row, dict) for rows in results for row in rows)
 
+    def test_query_multiple_later_execute_error_wins_over_failing_cursor_exit(self):
+        execute_error = RuntimeError("second execute failed")
+        cursor = _MultiQueryExitCursor(
+            execute_errors=(None, execute_error),
+            exit_error=RuntimeError("cleanup failed"),
+        )
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        # the first query's work is not rolled back (execution is not transactional), but raising here
+        # guarantees no partial tuple containing the first result can be returned
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is execute_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is RuntimeError
+        assert exc_val is execute_error
+        assert cursor.exit_tb_was_active
+        assert cursor.events == ["enter", ("execute", 0), ("fetchall", 0), ("execute", 1), ("exit", RuntimeError)]
+
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    def test_query_multiple_later_fetch_error_wins_over_native_cursor_exit(self, exit_behavior):
+        fetch_error = RuntimeError("second fetch failed")
+        cursor = _MultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), fetch_error),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
+        )
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is fetch_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is RuntimeError
+        assert exc_val is fetch_error
+        assert cursor.exit_tb_was_active
+
+    def test_query_multiple_later_mapper_error_wins_over_failing_cursor_exit(self):
+        mapper_error = ValueError("second mapper failed")
+        cursor = _MultiQueryExitCursor(exit_error=RuntimeError("cleanup failed"))
+        mapped = []
+
+        def first_mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        def second_mapper(row):
+            raise mapper_error
+
+        with pytest.raises(ValueError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=(first_mapper, second_mapper),
+            )
+
+        assert exc_info.value is mapper_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        # the second mapper ran inside the cursor lifecycle: its failure reached the native exit
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", ValueError),
+        ]
+
+    def test_query_multiple_later_no_result_error_is_active_during_cleanup(self):
+        cursor = _MultiQueryExitCursor(fetch_results=(((1, "Zach"),), tuple()))
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(NoResultException) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is NoResultException
+        assert exc_val is exc_info.value
+
+    def test_query_multiple_later_duplicate_column_error_is_active_during_cleanup(self):
+        cursor = _MultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
+            descriptions=(
+                (("id", "int"), ("name", "text")),
+                (("id", "int"), ("name", "text"), ("id", "int")),
+            ),
+        )
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name, id from another_table")
+            )
+
+        _assert_duplicate_column_exception(exc_info)
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is DuplicateColumnException
+        assert exc_val is exc_info.value
+
+    def test_query_multiple_mapper_still_receives_later_duplicate_columns(self):
+        cursor = _MultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
+            descriptions=(
+                (("id", "int"), ("name", "text")),
+                (("id", "int"), ("name", "text"), ("id", "int")),
+            ),
+        )
+
+        data1, data2 = MockCommands(_CursorConnection(cursor)).query_multiple(
+            ("select id, name from some_table", "select id, name, id from another_table"),
+            mapper=lambda row: row.values,
+        )
+
+        assert data1 == [(1, "Zach")]
+        assert data2 == [(1, "Zach", 2)]
+        assert cursor.exit_args == (None, None, None)
+
+    def test_query_multiple_propagates_native_cursor_exit_error_after_successful_batch(self):
+        cleanup_error = RuntimeError("cleanup failed")
+        cursor = _MultiQueryExitCursor(exit_error=cleanup_error)
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            MockCommands(_CursorConnection(cursor)).query_multiple(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is cleanup_error
+        assert mapped == [(1, "Zach"), (2, "Bob")]
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    def test_query_multiple_runs_all_queries_on_one_cursor_lifecycle(self):
+        cursor = _MultiQueryExitCursor()
+
+        data1, data2 = MockCommands(_CursorConnection(cursor)).query_multiple(
+            ("select id, name from some_table", "select id, name from another_table")
+        )
+
+        assert data1 == [{"id": 1, "name": "Zach"}]
+        assert data2 == [{"id": 2, "name": "Bob"}]
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", None),
+        ]
+
     def test_query_first(self, connection):
         with MockCommands(connection) as commands:
             record = commands.query_first("select id, name from some_table", model=SimpleNamespace)
@@ -4027,6 +4334,203 @@ class TestCommandsAsync:
         assert isinstance(results, tuple)
         assert [len(rows) for rows in results] == [2, 2]
         assert all(isinstance(row, dict) for rows in results for row in rows)
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_later_execute_error_wins_over_failing_cursor_exit(self):
+        execute_error = RuntimeError("second execute failed")
+        cursor = _AsyncMultiQueryExitCursor(
+            execute_errors=(None, execute_error),
+            exit_error=RuntimeError("cleanup failed"),
+        )
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        # the first query's work is not rolled back (execution is not transactional), but raising here
+        # guarantees no partial tuple containing the first result can be returned
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is execute_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is RuntimeError
+        assert exc_val is execute_error
+        assert cursor.exit_tb_was_active
+        assert cursor.events == ["enter", ("execute", 0), ("fetchall", 0), ("execute", 1), ("exit", RuntimeError)]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_behavior", ["raises", "truthy"])
+    async def test_query_multiple_async_later_fetch_error_wins_over_native_cursor_exit(self, exit_behavior):
+        fetch_error = RuntimeError("second fetch failed")
+        cursor = _AsyncMultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), fetch_error),
+            exit_error=RuntimeError("cleanup failed") if exit_behavior == "raises" else None,
+            exit_return=True if exit_behavior == "truthy" else None,
+        )
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is fetch_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is RuntimeError
+        assert exc_val is fetch_error
+        assert cursor.exit_tb_was_active
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_later_mapper_error_wins_over_failing_cursor_exit(self):
+        mapper_error = ValueError("second mapper failed")
+        cursor = _AsyncMultiQueryExitCursor(exit_error=RuntimeError("cleanup failed"))
+        mapped = []
+
+        def first_mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        def second_mapper(row):
+            raise mapper_error
+
+        with pytest.raises(ValueError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=(first_mapper, second_mapper),
+            )
+
+        assert exc_info.value is mapper_error
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is ValueError
+        assert exc_val is mapper_error
+        # the second mapper ran inside the cursor lifecycle: its failure reached the native exit
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", ValueError),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_later_no_result_error_is_active_during_cleanup(self):
+        cursor = _AsyncMultiQueryExitCursor(fetch_results=(((1, "Zach"),), tuple()))
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(NoResultException) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert mapped == [(1, "Zach")]
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is NoResultException
+        assert exc_val is exc_info.value
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_later_duplicate_column_error_is_active_during_cleanup(self):
+        cursor = _AsyncMultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
+            descriptions=(
+                (("id", "int"), ("name", "text")),
+                (("id", "int"), ("name", "text"), ("id", "int")),
+            ),
+        )
+
+        with pytest.raises(DuplicateColumnException) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name, id from another_table")
+            )
+
+        _assert_duplicate_column_exception(exc_info)
+        assert cursor.exit_calls == 1
+        exc_type, exc_val, _ = cursor.exit_args
+        assert exc_type is DuplicateColumnException
+        assert exc_val is exc_info.value
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_mapper_still_receives_later_duplicate_columns(self):
+        cursor = _AsyncMultiQueryExitCursor(
+            fetch_results=(((1, "Zach"),), ((1, "Zach", 2),)),
+            descriptions=(
+                (("id", "int"), ("name", "text")),
+                (("id", "int"), ("name", "text"), ("id", "int")),
+            ),
+        )
+
+        data1, data2 = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+            ("select id, name from some_table", "select id, name, id from another_table"),
+            mapper=lambda row: row.values,
+        )
+
+        assert data1 == [(1, "Zach")]
+        assert data2 == [(1, "Zach", 2)]
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_propagates_native_cursor_exit_error_after_successful_batch(self):
+        cleanup_error = RuntimeError("cleanup failed")
+        cursor = _AsyncMultiQueryExitCursor(exit_error=cleanup_error)
+        mapped = []
+
+        def mapper(row):
+            mapped.append(tuple(row.values))
+            return tuple(row.values)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+                ("select id, name from some_table", "select id, name from another_table"),
+                mapper=mapper,
+            )
+
+        assert exc_info.value is cleanup_error
+        assert mapped == [(1, "Zach"), (2, "Bob")]
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_runs_all_queries_on_one_cursor_lifecycle(self):
+        cursor = _AsyncMultiQueryExitCursor()
+
+        data1, data2 = await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_multiple_async(
+            ("select id, name from some_table", "select id, name from another_table")
+        )
+
+        assert data1 == [{"id": 1, "name": "Zach"}]
+        assert data2 == [{"id": 2, "name": "Bob"}]
+        assert cursor.exit_calls == 1
+        assert cursor.exit_args == (None, None, None)
+        assert cursor.events == [
+            "enter",
+            ("execute", 0),
+            ("fetchall", 0),
+            ("execute", 1),
+            ("fetchall", 1),
+            ("exit", None),
+        ]
 
     @pytest.mark.asyncio
     async def test_query_first(self, connection):


### PR DESCRIPTION
## What changed and why

Part of #541 (command-owned cursor lifecycle), building on the completed prevalidation work in #542. This is the combined sync/async `query_multiple` runtime-failure slice: after client-side prevalidation succeeds, a later query's execute, fetch, empty-result check, duplicate-column validation, or mapper can still fail once earlier queries have completed. The contract is that the method raises that runtime error and never returns a partial tuple containing earlier results, cleanup runs exactly once with the real exception triple, active errors win over simultaneous cleanup failures as the exact same objects, and truthy native cursor exits cannot suppress the error and expose accumulated results.

**This is a test-only PR — no production code changed.** `query_multiple()` and `query_multiple_async()` on main already validate and construct every `SqlParamHandler` before cursor acquisition, run all queries on one command-owned cursor, project rows inside the lifecycle, accumulate into a private local, and return only after cleanup; the cursor wrappers from earlier #541 slices supply the exception precedence. The new focused tests confirm this rather than exposing a defect.

Note the deliberate distinction: no partial Python return value is guaranteed, but batch execution is **not** transactional — earlier queries are not rolled back and no atomicity is added.

## Behavior example (now locked in by tests)

```python
commands.query_multiple(
    ("select id, name from users", "select id, name from orders"),
)
# first query executes and maps successfully, second query's fetchall() raises;
# even if the cursor's __exit__ also raises (or returns True), the exact fetch
# exception object propagates, cleanup runs once with the real (type, value,
# traceback), and no partial ([users_rows],) tuple is returned
```

## Coverage added (mirrored sync/async in tests/test_commands_interface.py)

* Two recording doubles, `_MultiQueryExitCursor` / `_AsyncMultiQueryExitCursor`, scripting per-query fetch results, per-call execute errors, per-query descriptions, and raising/truthy native exits, with an event log for enter/execute/fetch/exit and an at-exit record of whether the received traceback was the active exception's.
* Later execute failure after one completed result, with failing cleanup: exact exception identity, once-only cleanup with active traceback, event order.
* Later fetch failure, parametrized over raising and truthy native exits — the truthy case proves exit suppression cannot convert the failure into a partial-tuple return.
* Later mapper failure (heterogeneous mapper tuple) with failing cleanup; events prove mapping ran inside the lifecycle and the active traceback reached the exit.
* Later `NoResultException` and later `DuplicateColumnException`, each parametrized over raising and truthy native exits: identity-active during cleanup with the active traceback after a completed (and, for duplicate columns, provably projected) first result; mapper/RawRow mode still receives later-query duplicate columns with the duplicate column names visible on the row.
* Fully successful batch plus cleanup failure: cleanup error propagates, native exit received `(None, None, None)`, completed tuple is not returned.
* Fully successful batch: one enter/exit, query order, and tuple-of-lists shape proven via the event log.
* All existing #542 prevalidation tests (missing later placeholder fails before cursor acquisition, zero DBAPI calls, handler construct-before-cursor reuse) are untouched and still pass.

## Commands run

* `poetry run pytest tests/test_commands_interface.py -m "core"` — 408 passed
* `poetry run pytest -m "core"` — 620 passed
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` — clean
* `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `git diff --check` — clean

## Skipped driver tests

postgresql, mssql, mysql, oracle, and bigquery suites were skipped: this slice only adds shared-command tests against mock cursors, and those suites require optional extras/containers that should not be installed for it.

## Impact

No public API, typing, docs, dependency, or optional-extra changes. Docs remain deferred to the final #541 slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)