### PR TITLE
feat: add AdapterCapability vocabulary and command capability checks

### DIFF
--- a/pydapper/__init__.py
+++ b/pydapper/__init__.py
@@ -1,4 +1,5 @@
 from . import _builtin_adapters as _builtin_adapters
+from .capabilities import AdapterCapability
 from .command_options import CommandKind
 from .command_options import CommandOptions
 from .main import connect

--- a/pydapper/capabilities.py
+++ b/pydapper/capabilities.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from enum import unique
+
+
+@unique
+class AdapterCapability(str, Enum):
+    """Optional behaviors a command class may declare it implements."""
+
+    TRANSACTIONS = "transactions"
+    LIST_EXPANSION = "list_expansion"
+    RESULT_GRIDS = "result_grids"
+    RAW_READER = "raw_reader"
+    COMMAND_TIMEOUT = "command_timeout"
+    STORED_PROCEDURES = "stored_procedures"
+    OUTPUT_PARAMETERS = "output_parameters"
+    SCHEMA_INSPECTION = "schema_inspection"
+    SQL_VALIDATION = "sql_validation"
+    EXPLAIN = "explain"
+    READONLY = "readonly"
+    MAX_ROWS = "max_rows"

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncGenerator
 from typing import Callable
+from typing import ClassVar
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -26,6 +27,7 @@ from typing import overload
 from ._context import _AwaitableAsyncContextManager
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
+from .capabilities import AdapterCapability
 from .command_options import CommandKind
 from .command_options import CommandOptions
 from .exceptions import DuplicateColumnException
@@ -311,6 +313,17 @@ class DefaultSqlParamHandler(BaseSqlParamHandler):
 
 class BaseCommands(ABC):
     SqlParamHandler: Type[BaseSqlParamHandler] = DefaultSqlParamHandler
+
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
+    def supports(self, capability: AdapterCapability) -> bool:
+        if not isinstance(capability, AdapterCapability):
+            raise TypeError(f"capability must be an AdapterCapability, got {type(capability).__name__}")
+        return capability in self.capabilities
+
+    def _require_capability(self, capability: AdapterCapability) -> None:
+        if not self.supports(capability):
+            raise UnsupportedFeatureError(f"Capability {capability.value!r} is not supported by {type(self).__name__}")
 
     @staticmethod
     def _resolve_params(param=_PARAM_ALIAS_UNSET, params=_PARAM_ALIAS_UNSET):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -5423,16 +5423,26 @@ class TestAdapterCapabilities:
     @pytest.fixture
     def async_commands(self):
         class CapableAsyncCommands(MockAsyncCommands):
-            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+            capabilities = frozenset({AdapterCapability.RAW_READER})
 
         return CapableAsyncCommands(MockAsyncConnection())
 
     @pytest.fixture(params=["sync", "async"])
-    def commands(self, request, sync_commands, async_commands):
-        return sync_commands if request.param == "sync" else async_commands
+    def commands_with_declared(self, request, sync_commands, async_commands):
+        """(commands, its declared capability, the other mode's capability) — the sets differ per mode so
+        capability declarations proven per class, not leaked across classes."""
+        if request.param == "sync":
+            return sync_commands, AdapterCapability.TRANSACTIONS, AdapterCapability.RAW_READER
+        return async_commands, AdapterCapability.RAW_READER, AdapterCapability.TRANSACTIONS
 
-    def test_supports_declared_capability(self, commands):
-        assert commands.supports(AdapterCapability.TRANSACTIONS) is True
+    @pytest.fixture
+    def commands(self, commands_with_declared):
+        return commands_with_declared[0]
+
+    def test_supports_declared_capability(self, commands_with_declared):
+        commands, declared, other_modes = commands_with_declared
+        assert commands.supports(declared) is True
+        assert commands.supports(other_modes) is False
         assert commands.supports(AdapterCapability.EXPLAIN) is False
 
     @pytest.mark.parametrize("bad", ["transactions", 1, None, object(), CommandKind.TEXT])
@@ -5440,13 +5450,17 @@ class TestAdapterCapabilities:
         with pytest.raises(TypeError):
             commands.supports(bad)
 
-    def test_require_capability_returns_none_when_supported(self, commands):
-        assert commands._require_capability(AdapterCapability.TRANSACTIONS) is None
+    def test_require_capability_returns_none_when_supported(self, commands_with_declared):
+        commands, declared, _ = commands_with_declared
+        assert commands._require_capability(declared) is None
 
-    def test_require_capability_raises_when_unsupported(self, commands):
+    def test_require_capability_raises_when_unsupported(self, commands_with_declared):
+        commands, _, other_modes = commands_with_declared
         with pytest.raises(UnsupportedFeatureError) as exc_info:
             commands._require_capability(AdapterCapability.MAX_ROWS)
         assert "max_rows" in str(exc_info.value)
+        with pytest.raises(UnsupportedFeatureError):
+            commands._require_capability(other_modes)
 
     @pytest.mark.parametrize("bad", ["transactions", 1, None, object()])
     def test_require_capability_rejects_non_enum_arguments(self, commands, bad):

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -10,6 +10,8 @@ import pytest
 import pydapper
 from pydapper import RawRow
 from pydapper._context import _AwaitableAsyncContextManager
+from pydapper.capabilities import AdapterCapability
+from pydapper.command_options import CommandKind
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
@@ -5381,3 +5383,72 @@ class TestCommandsAsync:
         exc_type, exc_val, exc_tb = cursor.exit_args
         assert exc_type is IndexError
         assert exc_val is exc_info.value
+
+
+class TestAdapterCapabilities:
+    EXPECTED_VALUES = {
+        "TRANSACTIONS": "transactions",
+        "LIST_EXPANSION": "list_expansion",
+        "RESULT_GRIDS": "result_grids",
+        "RAW_READER": "raw_reader",
+        "COMMAND_TIMEOUT": "command_timeout",
+        "STORED_PROCEDURES": "stored_procedures",
+        "OUTPUT_PARAMETERS": "output_parameters",
+        "SCHEMA_INSPECTION": "schema_inspection",
+        "SQL_VALIDATION": "sql_validation",
+        "EXPLAIN": "explain",
+        "READONLY": "readonly",
+        "MAX_ROWS": "max_rows",
+    }
+
+    def test_enum_members_and_values(self):
+        assert {member.name: member.value for member in AdapterCapability} == self.EXPECTED_VALUES
+
+    def test_importable_from_package_root(self):
+        assert pydapper.AdapterCapability is AdapterCapability
+
+    def test_default_declaration_is_immutable_frozenset(self):
+        assert MockCommands.capabilities == frozenset()
+        assert MockAsyncCommands.capabilities == frozenset()
+        assert isinstance(MockCommands.capabilities, frozenset)
+        assert not hasattr(MockCommands.capabilities, "add")
+
+    @pytest.fixture
+    def sync_commands(self):
+        class CapableCommands(MockCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        return CapableCommands(MockConnection())
+
+    @pytest.fixture
+    def async_commands(self):
+        class CapableAsyncCommands(MockAsyncCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        return CapableAsyncCommands(MockAsyncConnection())
+
+    @pytest.fixture(params=["sync", "async"])
+    def commands(self, request, sync_commands, async_commands):
+        return sync_commands if request.param == "sync" else async_commands
+
+    def test_supports_declared_capability(self, commands):
+        assert commands.supports(AdapterCapability.TRANSACTIONS) is True
+        assert commands.supports(AdapterCapability.EXPLAIN) is False
+
+    @pytest.mark.parametrize("bad", ["transactions", 1, None, object(), CommandKind.TEXT])
+    def test_supports_rejects_non_enum_arguments(self, commands, bad):
+        with pytest.raises(TypeError):
+            commands.supports(bad)
+
+    def test_require_capability_returns_none_when_supported(self, commands):
+        assert commands._require_capability(AdapterCapability.TRANSACTIONS) is None
+
+    def test_require_capability_raises_when_unsupported(self, commands):
+        with pytest.raises(UnsupportedFeatureError) as exc_info:
+            commands._require_capability(AdapterCapability.MAX_ROWS)
+        assert "max_rows" in str(exc_info.value)
+
+    @pytest.mark.parametrize("bad", ["transactions", 1, None, object()])
+    def test_require_capability_rejects_non_enum_arguments(self, commands, bad):
+        with pytest.raises(TypeError):
+            commands._require_capability(bad)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -5430,7 +5430,7 @@ class TestAdapterCapabilities:
     @pytest.fixture(params=["sync", "async"])
     def commands_with_declared(self, request, sync_commands, async_commands):
         """(commands, its declared capability, the other mode's capability) — the sets differ per mode so
-        capability declarations proven per class, not leaked across classes."""
+        the tests prove declarations are per class rather than leaked across classes."""
         if request.param == "sync":
             return sync_commands, AdapterCapability.TRANSACTIONS, AdapterCapability.RAW_READER
         return async_commands, AdapterCapability.RAW_READER, AdapterCapability.TRANSACTIONS

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -111,6 +111,18 @@ def public_exceptions() -> None:
     assert_type(RowMappingException(), RowMappingException)
 
 
+def adapter_capability_types() -> None:
+    assert_type(pydapper.AdapterCapability.TRANSACTIONS, Literal[pydapper.AdapterCapability.TRANSACTIONS])
+    sync_commands = cast(PydapperCommands, object())
+    async_commands = cast(PydapperCommandsAsync, object())
+    assert_type(sync_commands.capabilities, frozenset[pydapper.AdapterCapability])
+    assert_type(async_commands.capabilities, frozenset[pydapper.AdapterCapability])
+    assert_type(sync_commands.supports(pydapper.AdapterCapability.TRANSACTIONS), bool)
+    assert_type(async_commands.supports(pydapper.AdapterCapability.TRANSACTIONS), bool)
+    assert_type(sync_commands._require_capability(pydapper.AdapterCapability.TRANSACTIONS), None)
+    assert_type(async_commands._require_capability(pydapper.AdapterCapability.TRANSACTIONS), None)
+
+
 def _cannot_handle_connection(connection: object) -> bool:
     return False
 


### PR DESCRIPTION
## What changed and why

First reviewable slice of #467 (does not close it): the public capability vocabulary and the minimal command-object capability API.

* New `pydapper/capabilities.py` with `AdapterCapability(str, Enum)` (`@unique`, twelve members exactly as specified in #467). `str, Enum` rather than `StrEnum` for Python 3.10 support.
* `AdapterCapability` re-exported from the package root.
* `BaseCommands` (inherited by both `Commands` and `CommandsAsync`) gains:
  * `capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()`
  * `supports(capability) -> bool` — rejects any non-`AdapterCapability` argument (including raw strings, since the enum subclasses `str`) with `TypeError`; no coercion.
  * `_require_capability(capability) -> None` — same validation; raises `UnsupportedFeatureError` identifying the capability when unsupported.
* Every adapter remains at the empty capability set in this slice.

## Example

```python
from pydapper import AdapterCapability

commands.supports(AdapterCapability.TRANSACTIONS)  # False everywhere for now
commands.supports("transactions")                  # TypeError
commands._require_capability(AdapterCapability.MAX_ROWS)  # UnsupportedFeatureError
```

## Tests

* `tests/test_commands_interface.py`: new `TestAdapterCapabilities` — exact member/value map, package-root import, frozenset immutability, a declared-capability test subclass, supports True/False, `TypeError` on strings/unrelated objects, `_require_capability` return/raise behavior (capability identifiable without freezing the message), parametrized across sync and async command objects.
* `tests/type_tests.py`: root export, `capabilities` typing, `supports()` returning `bool`, `_require_capability()` returning `None`, both modes.

## Commands run

* `poetry run pytest tests/test_commands_interface.py -m "core"` — 435 passed
* `poetry run pytest tests/test_main.py` — 60 passed
* `poetry run pytest -m "core"` — 647 passed, 208 deselected
* `poetry run mypy pydapper` — clean
* `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` / `git diff --check` — clean

Driver-specific tests (postgresql, mysql, mssql, oracle, bigquery) skipped: no adapter-specific behavior changed and they require Docker/testcontainers/cloud services.

## Impact

Additive public API (`AdapterCapability`, `capabilities`, `supports`); typed and covered in `tests/type_tests.py`. No dependency, lockfile, or docs changes. Deferred #467 work (registration validation, per-adapter declarations, preparation hooks, capability-gated `CommandOptions`) is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)