### PR TITLE
feat: validate capability declarations and add command preparation hooks

### DIFF
--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -4,22 +4,53 @@
 the command implementation for one or both modes and a synchronous `using_connection_predicate` used only for
 automatic adapter selection of externally supplied connections through `using()` and `using_async()`.
 
+The example below is a complete third-party adapter: sync and async command classes, explicit capability
+declarations, optional preparation hooks, and one `register_adapter()` call.
+
 ```python
+from typing import ClassVar
+
 import pydapper
+from pydapper.capabilities import AdapterCapability
+from pydapper.command_options import CommandOptions
+from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 from pydapper.commands import CommandsAsync
+from pydapper.types import AsyncCursorType
+from pydapper.types import CursorType
 
 
 class AcmeCommands(Commands):
+    # declare only capabilities this command class actually implements; empty is valid
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     def connect(cls, parsed_dsn, **connect_kwargs):
         raise NotImplementedError
 
+    def _prepare_cursor(self, cursor: CursorType, *, options: CommandOptions) -> None:
+        ...  # configure the entered cursor once per command, e.g. driver-specific cursor state
+
+    def _prepare_command(
+        self, cursor: CursorType, handler: BaseSqlParamHandler, *, options: CommandOptions
+    ) -> None:
+        ...  # inspect handler.prepared_sql / handler.ordered_param_values before it executes
+
 
 class AcmeCommandsAsync(CommandsAsync):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     async def connect_async(cls, parsed_dsn, **connect_kwargs):
         raise NotImplementedError
+
+    async def _prepare_cursor_async(self, cursor: AsyncCursorType, *, options: CommandOptions) -> None:
+        ...
+
+    async def _prepare_command_async(
+        self, cursor: AsyncCursorType, handler: BaseSqlParamHandler, *, options: CommandOptions
+    ) -> None:
+        ...
 
 
 def is_acme_connection(connection: object) -> bool:
@@ -61,9 +92,117 @@ The registration name is exact and case-sensitive. It is also the DB-API part of
 allows `connect()` to route an `acme+acmedb://...` DSN to that adapter. Names must be non-empty strings without
 leading or trailing whitespace. A predicate is required and must be callable.
 
-Registration is atomic and permanent for the process: supplying no command class, an invalid command class, or an
-invalid predicate raises an error without changing the registry. A second registration of the same exact name always
-raises `ValueError`, even if it appears identical. There is no replacement, priority, alias, or unregister API.
+Registration is atomic and permanent for the process: supplying no command class, an invalid command class, an
+invalid predicate, or an invalid capability declaration raises an error without changing the registry. When both
+modes are supplied, both declarations are validated before the registry is touched, so an invalid declaration in
+either mode fails the entire registration. A second registration of the same exact name always raises `ValueError`,
+even if it appears identical. There is no replacement, priority, alias, or unregister API.
+
+## Declaring capabilities
+
+Every command class carries an immutable class-level declaration of the optional behaviors it implements:
+
+```python
+capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+```
+
+`AdapterCapability` is a string enum exported from the package root (`pydapper.AdapterCapability`). A declaration
+must be a `frozenset` whose members are all `AdapterCapability` values. `register_adapter()` rejects anything else
+with `TypeError`: mutable sets, tuples, lists, raw strings, sets mixing enum members with other values, and
+unrelated objects are all invalid. Arbitrary strings are not an extension mechanism; new capabilities are added to
+the enum by pydapper when the corresponding feature ships.
+
+Declare a capability only when the command class actually implements and tests the behavior. Native driver
+potential is not sufficient. All first-party declarations are currently empty because no optional capability is
+implemented yet; the feature tickets that implement transactions, timeouts, and the other optional behaviors own
+enabling their flags.
+
+Users inspect a selected command object with `supports()`:
+
+```python
+commands = pydapper.using(connection)
+commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # False for every first-party adapter today
+commands.supports("transactions")  # TypeError: not an AdapterCapability
+```
+
+Capabilities are declared per command class, so one adapter may declare different sync and async sets. Sync/async
+mode support itself is intentionally **not** a capability flag: it is already represented unambiguously by which of
+`commands` and `async_commands` a registration supplies, and duplicating it as a flag would allow contradictory
+registrations.
+
+### First-party adapters
+
+| Registration name | Command class | Mode | Declared optional capabilities |
+|---|---|---|---|
+| `sqlite3` | `Sqlite3Commands` | sync | *(empty)* |
+| `psycopg2` | `Psycopg2Commands` | sync | *(empty)* |
+| `psycopg` | `Psycopg3Commands` | sync | *(empty)* |
+| `psycopg` | `Psycopg3CommandsAsync` | async | *(empty)* |
+| `aiopg` | `AiopgCommands` | async | *(empty)* |
+| `mysql` | `MySqlConnectorPythonCommands` | sync | *(empty)* |
+| `pymssql` | `PymssqlCommands` | sync | *(empty)* |
+| `oracledb` | `OracledbCommands` | sync | *(empty)* |
+| `google` | `GoogleBigqueryClientCommands` | sync | *(empty)* |
+
+Empty sets are honest: they mean no optional capability is implemented yet, not that the underlying database lacks
+the feature.
+
+## Preparation hooks
+
+Command classes may override four protected, documented adapter-author hooks. They are extension points for
+adapter authors, not ordinary query APIs, and application code should never call them directly. Although their
+names begin with an underscore, they are documented public extension points and are compatibility-sensitive under
+the [compatibility policy](compatibility.md).
+
+```python
+def _prepare_cursor(self, cursor: CursorType, *, options: CommandOptions) -> None: ...
+
+def _prepare_command(
+    self, cursor: CursorType, handler: BaseSqlParamHandler, *, options: CommandOptions
+) -> None: ...
+
+
+async def _prepare_cursor_async(self, cursor: AsyncCursorType, *, options: CommandOptions) -> None: ...
+
+async def _prepare_command_async(
+    self, cursor: AsyncCursorType, handler: BaseSqlParamHandler, *, options: CommandOptions
+) -> None: ...
+```
+
+The base implementations are no-ops. Every public command method — `execute`, `execute_scalar`, buffered and
+unbuffered `query`, `query_multiple`, `query_first`, `query_first_or_default`, `query_single`,
+`query_single_or_default`, and their async equivalents — invokes them in exactly this order for one acquired
+cursor:
+
+1. Options, parameter aliases, parameter shape, and placeholders are resolved and validated before any cursor is
+   acquired.
+2. The command acquires and enters exactly one cursor through the shared command-owned cursor lifecycle.
+3. `_prepare_cursor*()` runs exactly once with the entered cursor.
+4. For each SQL handler executed on that cursor, `_prepare_command*()` runs exactly once immediately before that
+   handler executes, then the handler executes and results are fetched, validated, and mapped.
+5. The cursor exits or closes through the shared lifecycle.
+
+Cursor preparation runs once per acquired cursor; command preparation runs once per executed handler. For the
+tuple-query `query_multiple()` API that means one `_prepare_cursor*()` call and one `_prepare_command*()` call per
+query in the tuple. `execute()` with an empty parameter list performs no cursor or driver work, so neither hook
+runs.
+
+Both hooks always receive a normalized `CommandOptions` instance — never `None` — including when the caller omitted
+`options=`. Unsupported non-default options still fail before cursor acquisition, so the hooks never observe them.
+
+Hook restrictions and error behavior:
+
+* Hooks may configure the entered cursor or driver command state, and may inspect the handler's `prepared_sql` and
+  `ordered_param_values`.
+* Hooks must not acquire, replace, enter, close, execute with, or fetch from a cursor.
+* Hooks must not mutate `CommandOptions`; it is immutable.
+* A hook may raise. A preparation failure is an active command error: the cursor is cleaned up through the shared
+  lifecycle exactly once, command preparation and execution do not run after a cursor-preparation failure, and the
+  original preparation exception propagates even if cleanup also fails or a native cursor `__exit__` returns a
+  truthy value.
+
+Drivers with unusual cursor-factory shapes should normalize the cursor factory by overriding `cursor()`, as the
+psycopg3 async commands already do, rather than replacing cursor ownership inside a preparation hook.
 
 ## Selecting an adapter for an existing connection
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -146,7 +146,21 @@ rewriting older entries to fit the current format.
 
 Adapter guarantees are capability-scoped: a documented operation is stable
 when the selected adapter declares support for it, while unsupported or
-adapter-specific behavior must be identified as such. The adapter package
+adapter-specific behavior must be identified as such. `AdapterCapability`,
+the `capabilities` declaration, `supports()`, and the validation of
+declarations during `register_adapter()` are part of the documented adapter
+contract.
+
+The documented preparation hooks — `_prepare_cursor`, `_prepare_command`,
+`_prepare_cursor_async`, and `_prepare_command_async` — are an explicit
+exception to the underscore rule above: although their names begin with an
+underscore, they are documented adapter-author extension points. Their
+signatures, their invocation order (cursor preparation once per acquired
+cursor, command preparation once per executed handler, both between cursor
+entry and handler execution), the normalized non-`None` `CommandOptions`
+argument they receive, and their documented error behavior are
+compatibility-sensitive. They are extension points for adapter authors, not
+ordinary query APIs. The adapter package
 split and the concrete decision about legacy in-core imports such as
 `pydapper.postgresql`, `pydapper.mysql`, and `pydapper.sqlite` belong to
 [#501](https://github.com/zschumacher/pydapper/issues/501). This policy does

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -10,10 +10,9 @@
   cursor lifecycle for every sync and async command family: `_prepare_cursor*()` once per
   acquired cursor and `_prepare_command*()` once per executed handler, both receiving a
   normalized `CommandOptions` instance. No optional capability (transactions, timeouts,
-  stored procedures, readonly, max rows, etc.) is implemented by this change. Subclass
-  overrides of `query_first`, `query_single`, and their async equivalents must now accept
-  the `options=` keyword, because the `*_or_default` helpers forward the normalized
-  options instead of discarding them.
+  stored procedures, readonly, max rows, etc.) is implemented by this change. The
+  `*_or_default` helpers now forward the normalized options to `query_first` /
+  `query_single`; see **Breaking Changes** below for the subclass-override impact.
 * feat: add AdapterCapability vocabulary and command capability checks. PR [#554](https://github.com/zschumacher/pydapper/pull/554) by [@zschumacher](https://github.com/zschumacher).
 * test: cover query_multiple runtime failures inside the command-owned cursor lifecycle. PR [#553](https://github.com/zschumacher/pydapper/pull/553) by [@zschumacher](https://github.com/zschumacher).
 * fix: project query_single rows inside the command-owned cursor lifecycle. PR [#551](https://github.com/zschumacher/pydapper/pull/551) by [@zschumacher](https://github.com/zschumacher).
@@ -39,6 +38,12 @@
 
 ### Breaking Changes
 
+* Command delegation: `query_first_or_default`, `query_single_or_default`, and their async
+  equivalents now forward the normalized `options=` keyword to `query_first` /
+  `query_single` (and the async equivalents) instead of validating and discarding it.
+  Subclass overrides of those four target methods must accept an `options=` keyword;
+  overrides without it now raise `TypeError` when called through the `*_or_default`
+  helpers. Add `*, options=None` to the override signature to migrate.
 * Adapter registration: `register` and `register_async` were removed. Use [`register_adapter`](adapter_registration.md) and explicit `adapter=` selection where needed.
 
 ### Other Changes

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,19 @@
 ## Latest Changes
 
+* feat: validate adapter capability declarations and add command preparation hooks.
+  `register_adapter()` now validates each supplied command class's `capabilities`
+  declaration (a `frozenset` of `AdapterCapability` members) for both modes before the
+  registry is touched, so an invalid declaration fails atomically. Every first-party
+  command class explicitly declares its current — empty — capability set, and
+  `commands.supports(AdapterCapability.X)` reports declared support. New documented,
+  compatibility-sensitive adapter-author preparation seams run inside the command-owned
+  cursor lifecycle for every sync and async command family: `_prepare_cursor*()` once per
+  acquired cursor and `_prepare_command*()` once per executed handler, both receiving a
+  normalized `CommandOptions` instance. No optional capability (transactions, timeouts,
+  stored procedures, readonly, max rows, etc.) is implemented by this change. Subclass
+  overrides of `query_first`, `query_single`, and their async equivalents must now accept
+  the `options=` keyword, because the `*_or_default` helpers forward the normalized
+  options instead of discarding them.
 * feat: add AdapterCapability vocabulary and command capability checks. PR [#554](https://github.com/zschumacher/pydapper/pull/554) by [@zschumacher](https://github.com/zschumacher).
 * test: cover query_multiple runtime failures inside the command-owned cursor lifecycle. PR [#553](https://github.com/zschumacher/pydapper/pull/553) by [@zschumacher](https://github.com/zschumacher).
 * fix: project query_single rows inside the command-owned cursor lifecycle. PR [#551](https://github.com/zschumacher/pydapper/pull/551) by [@zschumacher](https://github.com/zschumacher).

--- a/pydapper/bigquery/google_bigquery_client.py
+++ b/pydapper/bigquery/google_bigquery_client.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import Commands
 
 from ..utils import import_dbapi_module
@@ -9,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class GoogleBigqueryClientCommands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         google_bigquery_client = import_dbapi_module("google.cloud.bigquery.dbapi")

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -406,6 +406,31 @@ class Commands(BaseCommands, ABC):
     def cursor(self, *args, **kwargs) -> "CursorType":
         return self.connection.cursor(*args, **kwargs)
 
+    def _prepare_cursor(self, cursor: "CursorType", *, options: CommandOptions) -> None:
+        """Adapter-author hook run exactly once per command-owned cursor, immediately after the
+        cursor is entered and before any handler is prepared or executed.
+
+        ``options`` is always a normalized ``CommandOptions`` instance, never ``None``, and must
+        not be mutated. The hook may configure the entered cursor but must not acquire, replace,
+        enter, or close a cursor, execute SQL, or fetch rows. An exception raised here is treated
+        as an active command error: the cursor is cleaned up through the shared lifecycle and the
+        preparation exception propagates.
+        """
+
+    def _prepare_command(
+        self,
+        cursor: "CursorType",
+        handler: BaseSqlParamHandler,
+        *,
+        options: CommandOptions,
+    ) -> None:
+        """Adapter-author hook run exactly once per executed handler, immediately before that
+        handler executes on the already-prepared cursor.
+
+        The handler exposes ``prepared_sql`` and ``ordered_param_values`` for inspection. The same
+        restrictions and error behavior as ``_prepare_cursor`` apply.
+        """
+
     @overload
     def execute(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...
 
@@ -423,13 +448,15 @@ class Commands(BaseCommands, ABC):
     ) -> int: ...
 
     def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         if _is_empty_executemany_params(resolved_params):
             return 0
 
         handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
+            self._prepare_command(cursor, handler, options=resolved_options)
             rowcount = handler.execute(cursor)
         return rowcount
 
@@ -438,8 +465,11 @@ class Commands(BaseCommands, ABC):
         handler: BaseSqlParamHandler,
         projector: Union[Type["_T"], Callable[..., "_T"]],
         maps_raw_row: bool,
+        options: CommandOptions,
     ) -> List["_T"]:
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=options)
+            self._prepare_command(cursor, handler, options=options)
             handler.execute(cursor)
             headers = get_col_names(cursor)
             if not maps_raw_row:
@@ -456,8 +486,11 @@ class Commands(BaseCommands, ABC):
         handler: BaseSqlParamHandler,
         projector: Union[Type["_T"], Callable[..., "_T"]],
         maps_raw_row: bool,
+        options: CommandOptions,
     ) -> Generator["_T", None, None]:
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=options)
+            self._prepare_command(cursor, handler, options=options)
             handler.execute(cursor)
             headers = get_col_names(cursor)
             if not maps_raw_row:
@@ -758,14 +791,14 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
         if buffered:
-            return self._buffered_query(handler, projector, maps_raw_row)
-        return self._unbuffered_query(handler, projector, maps_raw_row)
+            return self._buffered_query(handler, projector, maps_raw_row, resolved_options)
+        return self._unbuffered_query(handler, projector, maps_raw_row, resolved_options)
 
     # endregion
 
@@ -983,7 +1016,7 @@ class Commands(BaseCommands, ABC):
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
@@ -1008,7 +1041,9 @@ class Commands(BaseCommands, ABC):
 
         results = list()
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
             for query, projector, handler in zip(queries, projectors, handlers):
+                self._prepare_command(cursor, handler, options=resolved_options)
                 handler.execute(cursor)
                 headers = get_col_names(cursor)
                 data = cursor.fetchall()
@@ -1113,13 +1148,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
+            self._prepare_command(cursor, handler, options=resolved_options)
             handler.execute(cursor)
             headers = get_col_names(cursor)
             row = cursor.fetchone()
@@ -1316,15 +1353,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return self.query_first(sql, param=resolved_params, mapper=mapper)
+                return self.query_first(sql, param=resolved_params, mapper=mapper, options=resolved_options)
             if model is _MODEL_UNSET:
-                return self.query_first(sql, param=resolved_params)
-            return self.query_first(sql, model=model, param=resolved_params)
+                return self.query_first(sql, param=resolved_params, options=resolved_options)
+            return self.query_first(sql, model=model, param=resolved_params, options=resolved_options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -1418,13 +1455,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
+            self._prepare_command(cursor, handler, options=resolved_options)
             handler.execute(cursor)
             headers = get_col_names(cursor)
             data = _fetch_at_most_two_rows(cursor)
@@ -1628,15 +1667,15 @@ class Commands(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return self.query_single(sql, param=resolved_params, mapper=mapper)
+                return self.query_single(sql, param=resolved_params, mapper=mapper, options=resolved_options)
             if model is _MODEL_UNSET:
-                return self.query_single(sql, param=resolved_params)
-            return self.query_single(sql, model=model, param=resolved_params)
+                return self.query_single(sql, param=resolved_params, options=resolved_options)
+            return self.query_single(sql, model=model, param=resolved_params, options=resolved_options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -1657,11 +1696,13 @@ class Commands(BaseCommands, ABC):
     ) -> Any: ...
 
     def execute_scalar(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
+            self._prepare_command(cursor, handler, options=resolved_options)
             handler.execute(cursor)
             first_row = cursor.fetchone()
             if first_row is None:
@@ -1687,6 +1728,31 @@ class CommandsAsync(BaseCommands, ABC):
     def cursor(self, *args, **kwargs) -> "_AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType]":
         return _AwaitableAsyncContextManager(self.connection.cursor(*args, **kwargs), preserve_active_error=True)
 
+    async def _prepare_cursor_async(self, cursor: "AsyncCursorType", *, options: CommandOptions) -> None:
+        """Adapter-author hook run exactly once per command-owned cursor, immediately after the
+        cursor is entered and before any handler is prepared or executed.
+
+        ``options`` is always a normalized ``CommandOptions`` instance, never ``None``, and must
+        not be mutated. The hook may configure the entered cursor but must not acquire, replace,
+        enter, or close a cursor, execute SQL, or fetch rows. An exception raised here is treated
+        as an active command error: the cursor is cleaned up through the shared lifecycle and the
+        preparation exception propagates.
+        """
+
+    async def _prepare_command_async(
+        self,
+        cursor: "AsyncCursorType",
+        handler: BaseSqlParamHandler,
+        *,
+        options: CommandOptions,
+    ) -> None:
+        """Adapter-author hook run exactly once per executed handler, immediately before that
+        handler executes on the already-prepared cursor.
+
+        The handler exposes ``prepared_sql`` and ``ordered_param_values`` for inspection. The same
+        restrictions and error behavior as ``_prepare_cursor_async`` apply.
+        """
+
     @overload
     async def execute_async(self, sql: str, params: Union["ParamType", "ListParamType"] = None) -> int: ...
 
@@ -1704,13 +1770,15 @@ class CommandsAsync(BaseCommands, ABC):
     ) -> int: ...
 
     async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         if _is_empty_executemany_params(resolved_params):
             return 0
 
         handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=resolved_options)
+            await self._prepare_command_async(cursor, handler, options=resolved_options)
             return await handler.execute_async(cursor)
 
     async def _buffered_query(
@@ -1718,8 +1786,11 @@ class CommandsAsync(BaseCommands, ABC):
         handler: BaseSqlParamHandler,
         projector: Union[Type["_T"], Callable[..., "_T"]],
         maps_raw_row: bool,
+        options: CommandOptions,
     ) -> List["_T"]:
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=options)
+            await self._prepare_command_async(cursor, handler, options=options)
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             if not maps_raw_row:
@@ -1736,8 +1807,11 @@ class CommandsAsync(BaseCommands, ABC):
         handler: BaseSqlParamHandler,
         projector: Union[Type["_T"], Callable[..., "_T"]],
         maps_raw_row: bool,
+        options: CommandOptions,
     ) -> AsyncGenerator["_T", None]:
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=options)
+            await self._prepare_command_async(cursor, handler, options=options)
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             if not maps_raw_row:
@@ -2035,15 +2109,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
         if buffered:
-            records = await self._buffered_query(handler, projector, maps_raw_row)
+            records = await self._buffered_query(handler, projector, maps_raw_row, resolved_options)
             return records
-        return self._unbuffered_query(handler, projector, maps_raw_row)
+        return self._unbuffered_query(handler, projector, maps_raw_row, resolved_options)
 
     @overload
     async def query_multiple_async(
@@ -2259,7 +2333,7 @@ class CommandsAsync(BaseCommands, ABC):
         :todo use TypeVarTuple for the variadic types of models once the mypy support is better such that type checkers
               and hinters will be able to infer which model type you're working with.  Leaving this as is for now...
         """
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
 
@@ -2284,7 +2358,9 @@ class CommandsAsync(BaseCommands, ABC):
 
         results = list()
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=resolved_options)
             for query, projector, handler in zip(queries, projectors, handlers):
+                await self._prepare_command_async(cursor, handler, options=resolved_options)
                 await handler.execute_async(cursor)
                 headers = get_col_names(cursor)
                 data = await cursor.fetchall()
@@ -2389,13 +2465,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=resolved_options)
+            await self._prepare_command_async(cursor, handler, options=resolved_options)
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             row = await cursor.fetchone()
@@ -2592,15 +2670,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return await self.query_first_async(sql, param=resolved_params, mapper=mapper)
+                return await self.query_first_async(sql, param=resolved_params, mapper=mapper, options=resolved_options)
             if model is _MODEL_UNSET:
-                return await self.query_first_async(sql, param=resolved_params)
-            return await self.query_first_async(sql, model=model, param=resolved_params)
+                return await self.query_first_async(sql, param=resolved_params, options=resolved_options)
+            return await self.query_first_async(sql, model=model, param=resolved_params, options=resolved_options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -2694,13 +2772,15 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=resolved_options)
+            await self._prepare_command_async(cursor, handler, options=resolved_options)
             await handler.execute_async(cursor)
             headers = get_col_names(cursor)
             data = await _fetch_at_most_two_rows_async(cursor)
@@ -2903,15 +2983,17 @@ class CommandsAsync(BaseCommands, ABC):
         mapper=_MAPPER_UNSET,
         options=None,
     ):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _resolve_row_projector(model, mapper)
         try:
             if mapper is not _MAPPER_UNSET:
-                return await self.query_single_async(sql, param=resolved_params, mapper=mapper)
+                return await self.query_single_async(
+                    sql, param=resolved_params, mapper=mapper, options=resolved_options
+                )
             if model is _MODEL_UNSET:
-                return await self.query_single_async(sql, param=resolved_params)
-            return await self.query_single_async(sql, model=model, param=resolved_params)
+                return await self.query_single_async(sql, param=resolved_params, options=resolved_options)
+            return await self.query_single_async(sql, model=model, param=resolved_params, options=resolved_options)
         except NoResultException:
             return _resolve_default_value(default)
 
@@ -2932,11 +3014,13 @@ class CommandsAsync(BaseCommands, ABC):
     ) -> Any: ...
 
     async def execute_scalar_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
+            await self._prepare_cursor_async(cursor, options=resolved_options)
+            await self._prepare_command_async(cursor, handler, options=resolved_options)
             await handler.execute_async(cursor)
             first_row = await cursor.fetchone()
             if first_row is None:

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from ._context import _AwaitableAsyncContextManager
+from .capabilities import AdapterCapability
+from .commands import BaseCommands
 from .commands import Commands
 from .commands import CommandsAsync
 from .dsn_parser import PydapperParseResult
@@ -26,6 +28,21 @@ class _AdapterRegistration:
 _adapter_registry: dict[str, _AdapterRegistration] = {}
 
 
+def _validate_capability_declaration(command_class: type[BaseCommands], argument_name: str) -> None:
+    declared = command_class.capabilities
+    if not isinstance(declared, frozenset):
+        raise TypeError(
+            f"{argument_name}.capabilities must be a frozenset of AdapterCapability members, "
+            f"got {type(declared).__name__}"
+        )
+    for member in declared:
+        if not isinstance(member, AdapterCapability):
+            raise TypeError(
+                f"{argument_name}.capabilities must contain only AdapterCapability members, "
+                f"got {type(member).__name__}"
+            )
+
+
 def register_adapter(
     name: str,
     *,
@@ -38,6 +55,11 @@ def register_adapter(
     Registration is intentionally one-way: an adapter name may only be registered
     once so import order cannot silently replace a command implementation. The
     using_connection_predicate is used only for automatic connection selection.
+
+    Each supplied command class must declare ``capabilities`` as a frozenset of
+    AdapterCapability members. Declarations are validated per mode before the
+    registry is touched, so an invalid declaration fails the whole registration
+    without mutating the registry.
     """
     if not isinstance(name, str):
         raise TypeError("Adapter name must be a string")
@@ -55,6 +77,12 @@ def register_adapter(
         raise TypeError("async_commands must be a CommandsAsync subclass")
     if not callable(using_connection_predicate):
         raise TypeError("using_connection_predicate must be callable")
+    # both declarations must validate before the registry mutates so an invalid mode never leaves a
+    # partially registered adapter behind
+    if commands is not None:
+        _validate_capability_declaration(commands, "commands")
+    if async_commands is not None:
+        _validate_capability_declaration(async_commands, "async_commands")
 
     _adapter_registry[name] = _AdapterRegistration(
         name=name,

--- a/pydapper/mssql/pymssql.py
+++ b/pydapper/mssql/pymssql.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -14,6 +16,8 @@ _PARAM_TYPE_LOOKUP = {float: "%d", int: "%d", str: "%s", Decimal: "%d"}
 
 
 class PymssqlCommands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:
             if isinstance(self._param, list):

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import _MAPPER_UNSET
 from pydapper.commands import _MODEL_UNSET
 from pydapper.commands import _PARAM_ALIAS_UNSET
@@ -53,6 +55,8 @@ def _discard_unread_result(cursor: "CursorType") -> None:
 
 
 class MySqlConnectorPythonCommands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         mysql = import_dbapi_module("mysql.connector")
@@ -80,13 +84,15 @@ class MySqlConnectorPythonCommands(Commands):
         the mysql connector throws an exception if you only read one row from a cursor.  Unfortunately, we have to
         fetchall to make the lib happy.
         """
-        self._resolve_options(options)
+        resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
         _raise_if_list_params_for_read(resolved_params)
         projector, maps_raw_row = _resolve_row_projector(model, mapper)
         handler = self.SqlParamHandler(sql, resolved_params)
 
         with self._cursor_context_proxy() as cursor:
+            self._prepare_cursor(cursor, options=resolved_options)
+            self._prepare_command(cursor, handler, options=resolved_options)
             handler.execute(cursor)
             headers = get_col_names(cursor)
             row = cursor.fetchone()

--- a/pydapper/oracle/oracledb.py
+++ b/pydapper/oracle/oracledb.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -10,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class OracledbCommands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:
             return f":{param_name}"

--- a/pydapper/postgresql/aiopg.py
+++ b/pydapper/postgresql/aiopg.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import CommandsAsync
 from pydapper.commands import DefaultSqlParamHandler
 
@@ -11,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class AiopgCommands(CommandsAsync):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     class SqlParamHandler(DefaultSqlParamHandler):
         async def execute_async(self, cursor: "AsyncCursorType"):
             if isinstance(self.ordered_param_values, list):

--- a/pydapper/postgresql/psycopg2.py
+++ b/pydapper/postgresql/psycopg2.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import Commands
 
 from ..utils import import_dbapi_module
@@ -9,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class Psycopg2Commands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         psycopg2 = import_dbapi_module("psycopg2")

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import Commands
 from pydapper.commands import CommandsAsync
 
@@ -11,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class Psycopg3Commands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         psycopg = import_dbapi_module("psycopg")
@@ -26,6 +30,8 @@ class Psycopg3Commands(Commands):
 
 
 class Psycopg3CommandsAsync(CommandsAsync):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     @classmethod
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync":
         psycopg = import_dbapi_module("psycopg")

--- a/pydapper/sqlite/sqlite3.py
+++ b/pydapper/sqlite/sqlite3.py
@@ -2,7 +2,9 @@ import os
 import sqlite3
 from sqlite3 import Cursor
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from pydapper.capabilities import AdapterCapability
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 
@@ -11,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class Sqlite3Commands(Commands):
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:
             return "?"

--- a/tests/test_command_options.py
+++ b/tests/test_command_options.py
@@ -64,19 +64,31 @@ class UnorderableFraction(Fraction):
         raise TypeError("comparison is not supported")
 
 
-class LegacyDefaultCommands(OptionsCommands):
-    def query_first(self, sql, model=dict, param=None, *, mapper=None):
+class DelegatingDefaultCommands(OptionsCommands):
+    def __init__(self, connection):
+        super().__init__(connection)
+        self.received_options = []
+
+    def query_first(self, sql, model=dict, param=None, *, mapper=None, options=None):
+        self.received_options.append(options)
         return "first"
 
-    def query_single(self, sql, model=dict, param=None, *, mapper=None):
+    def query_single(self, sql, model=dict, param=None, *, mapper=None, options=None):
+        self.received_options.append(options)
         return "single"
 
 
-class LegacyDefaultCommandsAsync(OptionsCommandsAsync):
-    async def query_first_async(self, sql, model=dict, param=None, *, mapper=None):
+class DelegatingDefaultCommandsAsync(OptionsCommandsAsync):
+    def __init__(self, connection):
+        super().__init__(connection)
+        self.received_options = []
+
+    async def query_first_async(self, sql, model=dict, param=None, *, mapper=None, options=None):
+        self.received_options.append(options)
         return "first"
 
-    async def query_single_async(self, sql, model=dict, param=None, *, mapper=None):
+    async def query_single_async(self, sql, model=dict, param=None, *, mapper=None, options=None):
+        self.received_options.append(options)
         return "single"
 
 
@@ -171,21 +183,29 @@ def test_default_options_are_supported():
 
 
 @pytest.mark.parametrize("options", [None, pydapper.CommandOptions(), DerivedOptions()])
-def test_default_options_are_omitted_for_legacy_default_helper_overrides(options):
-    commands = LegacyDefaultCommands(NoCursorConnection())
+def test_default_helper_overrides_receive_normalized_options(options):
+    commands = DelegatingDefaultCommands(NoCursorConnection())
 
     assert commands.query_first_or_default("select 1", None, options=options) == "first"
     assert commands.query_single_or_default("select 1", None, options=options) == "single"
 
+    for received in commands.received_options:
+        if options is None:
+            assert received == pydapper.CommandOptions()
+        else:
+            assert received is options
+    assert len(commands.received_options) == 2
 
-def test_unsupported_options_fail_before_legacy_default_helper_overrides():
-    commands = LegacyDefaultCommands(NoCursorConnection())
+
+def test_unsupported_options_fail_before_default_helper_overrides():
+    commands = DelegatingDefaultCommands(NoCursorConnection())
     options = pydapper.CommandOptions(timeout=1)
 
     with pytest.raises(UnsupportedFeatureError, match="timeout"):
         commands.query_first_or_default("select 1", None, options=options)
     with pytest.raises(UnsupportedFeatureError, match="timeout"):
         commands.query_single_or_default("select 1", None, options=options)
+    assert commands.received_options == []
 
 
 def test_non_options_value_fails_clearly():
@@ -203,19 +223,27 @@ async def test_async_unsupported_options_fail_before_cursor_use():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("options", [None, pydapper.CommandOptions(), DerivedOptions()])
-async def test_default_options_are_omitted_for_legacy_async_default_helper_overrides(options):
-    commands = LegacyDefaultCommandsAsync(NoCursorConnection())
+async def test_async_default_helper_overrides_receive_normalized_options(options):
+    commands = DelegatingDefaultCommandsAsync(NoCursorConnection())
 
     assert await commands.query_first_or_default_async("select 1", None, options=options) == "first"
     assert await commands.query_single_or_default_async("select 1", None, options=options) == "single"
 
+    for received in commands.received_options:
+        if options is None:
+            assert received == pydapper.CommandOptions()
+        else:
+            assert received is options
+    assert len(commands.received_options) == 2
+
 
 @pytest.mark.asyncio
-async def test_unsupported_options_fail_before_legacy_async_default_helper_overrides():
-    commands = LegacyDefaultCommandsAsync(NoCursorConnection())
+async def test_unsupported_options_fail_before_async_default_helper_overrides():
+    commands = DelegatingDefaultCommandsAsync(NoCursorConnection())
     options = pydapper.CommandOptions(timeout=1)
 
     with pytest.raises(UnsupportedFeatureError, match="timeout"):
         await commands.query_first_or_default_async("select 1", None, options=options)
     with pytest.raises(UnsupportedFeatureError, match="timeout"):
         await commands.query_single_or_default_async("select 1", None, options=options)
+    assert commands.received_options == []

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1691,19 +1691,21 @@ class TestCommands:
         with MockCommands(connection) as commands, pytest.raises(ValueError, match="Pass either 'params' or 'param'"):
             call(commands, params)
 
-    def test_or_default_methods_preserve_param_only_overrides(self, connection):
-        class ParamOnlyOverrideCommands(MockCommands):
-            def query_first(self, sql, model=dict, param=None):
-                assert param == {"id": 1}
+    def test_or_default_methods_delegate_param_spelling_and_normalized_options(self, connection):
+        received = []
+
+        class ParamSpellingOverrideCommands(MockCommands):
+            def query_first(self, sql, model=dict, param=None, *, options=None):
+                received.append(("first", param, options))
                 raise NoResultException
 
-            def query_single(self, sql, model=dict, param=None):
-                assert param == {"id": 1}
+            def query_single(self, sql, model=dict, param=None, *, options=None):
+                received.append(("single", param, options))
                 raise NoResultException
 
         default = object()
 
-        with ParamOnlyOverrideCommands(connection) as commands:
+        with ParamSpellingOverrideCommands(connection) as commands:
             assert (
                 commands.query_first_or_default("select * from some_table where id = ?id?", default, params={"id": 1})
                 is default
@@ -1712,6 +1714,11 @@ class TestCommands:
                 commands.query_single_or_default("select * from some_table where id = ?id?", default, params={"id": 1})
                 is default
             )
+
+        assert received == [
+            ("first", {"id": 1}, pydapper.CommandOptions()),
+            ("single", {"id": 1}, pydapper.CommandOptions()),
+        ]
 
     def test_mysql_query_first_accepts_params(self, connection, captured_handler_params):
         from pydapper.mysql import MySqlConnectorPythonCommands
@@ -3899,19 +3906,21 @@ class TestCommandsAsync:
                 await call(commands, params)
 
     @pytest.mark.asyncio
-    async def test_or_default_methods_preserve_param_only_overrides(self, connection):
-        class ParamOnlyOverrideCommands(MockAsyncCommands):
-            async def query_first_async(self, sql, model=dict, param=None):
-                assert param == {"id": 1}
+    async def test_or_default_methods_delegate_param_spelling_and_normalized_options(self, connection):
+        received = []
+
+        class ParamSpellingOverrideCommands(MockAsyncCommands):
+            async def query_first_async(self, sql, model=dict, param=None, *, options=None):
+                received.append(("first", param, options))
                 raise NoResultException
 
-            async def query_single_async(self, sql, model=dict, param=None):
-                assert param == {"id": 1}
+            async def query_single_async(self, sql, model=dict, param=None, *, options=None):
+                received.append(("single", param, options))
                 raise NoResultException
 
         default = object()
 
-        async with ParamOnlyOverrideCommands(connection) as commands:
+        async with ParamSpellingOverrideCommands(connection) as commands:
             assert (
                 await commands.query_first_or_default_async(
                     "select * from some_table where id = ?id?", default, params={"id": 1}
@@ -3924,6 +3933,11 @@ class TestCommandsAsync:
                 )
                 is default
             )
+
+        assert received == [
+            ("first", {"id": 1}, pydapper.CommandOptions()),
+            ("single", {"id": 1}, pydapper.CommandOptions()),
+        ]
 
     @pytest.mark.asyncio
     async def test_query(self, connection):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -132,6 +132,101 @@ def test_registration_validation_failure_is_atomic(adapter_registry):
     assert adapter_registry == before
 
 
+class DeclaredSyncCommands(MockCommands):
+    capabilities = frozenset({pydapper.AdapterCapability.TRANSACTIONS})
+
+
+class DeclaredAsyncCommands(MockAsyncCommands):
+    capabilities = frozenset({pydapper.AdapterCapability.RAW_READER, pydapper.AdapterCapability.EXPLAIN})
+
+
+def test_register_adapter_accepts_empty_capability_declarations(adapter_registry):
+    pydapper.register_adapter(
+        "empty-capabilities",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
+
+    registration = adapter_registry["empty-capabilities"]
+    assert registration.commands.capabilities == frozenset()
+    assert registration.async_commands.capabilities == frozenset()
+
+
+def test_register_adapter_accepts_distinct_nonempty_per_mode_declarations(adapter_registry):
+    pydapper.register_adapter(
+        "declared-capabilities",
+        commands=DeclaredSyncCommands,
+        async_commands=DeclaredAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
+
+    registration = adapter_registry["declared-capabilities"]
+    assert registration.commands.capabilities == frozenset({pydapper.AdapterCapability.TRANSACTIONS})
+    assert registration.async_commands.capabilities == frozenset(
+        {pydapper.AdapterCapability.RAW_READER, pydapper.AdapterCapability.EXPLAIN}
+    )
+    assert registration.commands.capabilities != registration.async_commands.capabilities
+
+
+INVALID_CAPABILITY_DECLARATIONS = [
+    pytest.param({pydapper.AdapterCapability.TRANSACTIONS}, id="mutable-set"),
+    pytest.param((pydapper.AdapterCapability.TRANSACTIONS,), id="tuple"),
+    pytest.param([pydapper.AdapterCapability.TRANSACTIONS], id="list"),
+    pytest.param("transactions", id="raw-string"),
+    pytest.param(frozenset({"transactions"}), id="raw-string-member"),
+    pytest.param(frozenset({pydapper.AdapterCapability.TRANSACTIONS, "explain"}), id="mixed-members"),
+    pytest.param(frozenset({pydapper.AdapterCapability.TRANSACTIONS, 1}), id="unrelated-member"),
+    pytest.param(object(), id="unrelated-object"),
+    pytest.param(None, id="none"),
+]
+
+
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize("declared", INVALID_CAPABILITY_DECLARATIONS)
+def test_register_adapter_rejects_invalid_capability_declarations_atomically(adapter_registry, mode, declared):
+    before = adapter_registry.copy()
+    if mode == "sync":
+        kwargs = {"commands": type("InvalidCapabilityCommands", (MockCommands,), {"capabilities": declared})}
+    else:
+        kwargs = {
+            "async_commands": type("InvalidCapabilityCommandsAsync", (MockAsyncCommands,), {"capabilities": declared})
+        }
+
+    with pytest.raises(TypeError) as exc_info:
+        pydapper.register_adapter("invalid-capabilities", using_connection_predicate=never_matches, **kwargs)
+
+    assert "capabilities" in str(exc_info.value)
+    assert adapter_registry == before
+
+
+@pytest.mark.parametrize("invalid_mode", ["sync", "async"])
+def test_register_adapter_capability_failure_in_one_mode_fails_the_whole_registration(adapter_registry, invalid_mode):
+    before = adapter_registry.copy()
+    invalid_sync = type("InvalidCapabilityCommands", (MockCommands,), {"capabilities": {"transactions"}})
+    invalid_async = type("InvalidCapabilityCommandsAsync", (MockAsyncCommands,), {"capabilities": {"transactions"}})
+    commands = invalid_sync if invalid_mode == "sync" else DeclaredSyncCommands
+    async_commands = invalid_async if invalid_mode == "async" else DeclaredAsyncCommands
+
+    with pytest.raises(TypeError) as exc_info:
+        pydapper.register_adapter(
+            "half-invalid",
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=never_matches,
+        )
+
+    message = str(exc_info.value)
+    if invalid_mode == "sync":
+        assert "commands" in message
+        assert "async_commands" not in message
+    else:
+        assert "async_commands" in message
+    assert "capabilities" in message
+    assert "half-invalid" not in adapter_registry
+    assert adapter_registry == before
+
+
 def test_duplicate_registration_is_rejected_without_mutating_the_original(adapter_registry):
     pydapper.register_adapter("duplicate", commands=MockCommands, using_connection_predicate=never_matches)
     original_registration = adapter_registry["duplicate"]
@@ -422,6 +517,41 @@ def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
         pydapper.connect("some_db+async-only://localhost")
 
     assert "sync" in str(exc_info.value)
+
+
+FIRST_PARTY_COMMAND_CLASSES = [
+    Sqlite3Commands,
+    Psycopg2Commands,
+    Psycopg3Commands,
+    Psycopg3CommandsAsync,
+    AiopgCommands,
+    MySqlConnectorPythonCommands,
+    PymssqlCommands,
+    OracledbCommands,
+    GoogleBigqueryClientCommands,
+]
+
+
+@pytest.mark.parametrize("command_class", FIRST_PARTY_COMMAND_CLASSES, ids=lambda command_class: command_class.__name__)
+def test_first_party_command_classes_declare_explicit_empty_capability_sets(command_class):
+    declared = vars(command_class).get("capabilities")
+
+    assert declared is not None, f"{command_class.__name__} must declare capabilities directly, not inherit the default"
+    assert type(declared) is frozenset
+    assert all(isinstance(member, pydapper.AdapterCapability) for member in declared)
+    # no optional capability is implemented yet, so any non-empty set would be an overclaim
+    assert declared == frozenset()
+
+
+def test_first_party_capability_audit_covers_every_registered_command_class():
+    registered = {
+        command_class
+        for registration in main._adapter_registry.values()
+        for command_class in (registration.commands, registration.async_commands)
+        if command_class is not None
+    }
+
+    assert registered == set(FIRST_PARTY_COMMAND_CLASSES)
 
 
 def test_builtin_adapter_name_and_command_class_mappings():

--- a/tests/test_preparation_hooks.py
+++ b/tests/test_preparation_hooks.py
@@ -20,6 +20,17 @@ from tests.mocks import MockCommands
 pytestmark = pytest.mark.core
 
 
+class _EnteredRecordingCursor:
+    """Distinct object returned by cursor entry so identity assertions can prove the hooks
+    receive the entered cursor rather than the raw one."""
+
+    def __init__(self, raw_cursor):
+        self._raw_cursor = raw_cursor
+
+    def __getattr__(self, name):
+        return getattr(self._raw_cursor, name)
+
+
 class RecordingCursor:
     description = ("id", "int"), ("name", "text")
 
@@ -32,10 +43,11 @@ class RecordingCursor:
         self.exit_result = exit_result
         self.exit_args = []
         self.exit_tb_matches = []
+        self.entered = _EnteredRecordingCursor(self)
 
     def __enter__(self):
         self.log.append("enter")
-        return self
+        return self.entered
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.log.append(("exit", exc_type))
@@ -82,10 +94,11 @@ class RecordingAsyncCursor:
         self.exit_result = exit_result
         self.exit_args = []
         self.exit_tb_matches = []
+        self.entered = _EnteredRecordingCursor(self)
 
     async def __aenter__(self):
         self.log.append("enter")
-        return self
+        return self.entered
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self.log.append(("exit", exc_type))
@@ -188,6 +201,21 @@ def _event_kinds(log):
     return [event[0] if isinstance(event, tuple) else event for event in log]
 
 
+def _canonical_events(log):
+    """Object-free view of the full event sequence so sync and async logs are directly comparable."""
+    canonical = []
+    for event in log:
+        if not isinstance(event, tuple):
+            canonical.append(event)
+        elif event[0] in ("execute", "executemany", "exit"):
+            canonical.append((event[0], event[1]))
+        elif event[0] == "prepare_command":
+            canonical.append((event[0], event[2].prepared_sql))
+        else:
+            canonical.append(event[0])
+    return canonical
+
+
 def _assert_prepared_once_in_order(log, cursor):
     kinds = _event_kinds(log)
     assert kinds[:3] == ["enter", "prepare_cursor", "prepare_command"]
@@ -200,8 +228,10 @@ def _assert_prepared_once_in_order(log, cursor):
 
     _, prepared_cursor, cursor_options = log[1]
     _, command_cursor, handler, command_options = log[2]
-    assert prepared_cursor is cursor
-    assert command_cursor is cursor
+    assert prepared_cursor is cursor.entered
+    assert prepared_cursor is not cursor
+    assert command_cursor is cursor.entered
+    assert command_cursor is not cursor
     assert handler.prepared_sql == log[3][1]
     assert cursor_options is not None
     assert command_options is not None
@@ -317,6 +347,43 @@ async def test_async_families_prepare_cursor_and_command_once_in_order(call):
     await call(commands)
 
     _assert_prepared_once_in_order(log, cursor)
+
+
+SYNC_ASYNC_FAMILY_PAIRS = [
+    pytest.param(sync_param.values[0], async_param.values[0], id=async_param.id)
+    for sync_param, async_param in zip(SYNC_FAMILY_CALLS, ASYNC_FAMILY_CALLS)
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("sync_call", "async_call"), SYNC_ASYNC_FAMILY_PAIRS)
+async def test_sync_and_async_families_produce_identical_event_sequences(sync_call, async_call):
+    sync_log, _, _, sync_commands = _sync_commands()
+    async_log, _, _, async_commands = _async_commands()
+
+    sync_call(sync_commands)
+    await async_call(async_commands)
+
+    assert _canonical_events(sync_log) == _canonical_events(async_log)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_hook", ["prepare_cursor_error", "prepare_command_error"])
+@pytest.mark.parametrize(("sync_call", "async_call"), SYNC_ASYNC_FAMILY_PAIRS)
+async def test_sync_and_async_preparation_failures_produce_identical_event_sequences(
+    sync_call, async_call, failing_hook
+):
+    sync_log, _, _, sync_commands = _sync_commands()
+    async_log, _, _, async_commands = _async_commands()
+    setattr(sync_commands, failing_hook, RuntimeError("preparation failed"))
+    setattr(async_commands, failing_hook, RuntimeError("preparation failed"))
+
+    with pytest.raises(RuntimeError):
+        sync_call(sync_commands)
+    with pytest.raises(RuntimeError):
+        await async_call(async_commands)
+
+    assert _canonical_events(sync_log) == _canonical_events(async_log)
 
 
 @pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
@@ -479,7 +546,7 @@ def test_sync_query_multiple_prepares_cursor_once_and_each_handler_once():
     prepared = [event for event in log if isinstance(event, tuple) and event[0] == "prepare_command"]
     assert [event[2].prepared_sql for event in prepared] == list(queries)
     assert len({id(event[2]) for event in prepared}) == 2
-    assert all(event[1] is cursor for event in prepared)
+    assert all(event[1] is cursor.entered for event in prepared)
 
 
 @pytest.mark.asyncio
@@ -503,7 +570,7 @@ async def test_async_query_multiple_prepares_cursor_once_and_each_handler_once()
     prepared = [event for event in log if isinstance(event, tuple) and event[0] == "prepare_command"]
     assert [event[2].prepared_sql for event in prepared] == list(queries)
     assert len({id(event[2]) for event in prepared}) == 2
-    assert all(event[1] is cursor for event in prepared)
+    assert all(event[1] is cursor.entered for event in prepared)
 
 
 def test_sync_unbuffered_query_defers_hooks_until_iteration_and_cleans_up_on_close():
@@ -730,7 +797,7 @@ def test_mysql_query_first_reaches_hooks_and_keeps_unread_result_drain():
         "fetchall",
         "exit",
     ]
-    assert log[1][1] is cursor
+    assert log[1][1] is cursor.entered
     assert log[1][2] is options
     assert log[2][3] is options
 

--- a/tests/test_preparation_hooks.py
+++ b/tests/test_preparation_hooks.py
@@ -1,0 +1,803 @@
+"""Service-free coverage for the cursor/command preparation seams added by #467.
+
+Every public sync and async command family must enter exactly one command-owned cursor, run
+``_prepare_cursor*`` once per cursor and ``_prepare_command*`` once per executed handler in
+order, and clean the cursor through the existing lifecycle when preparation fails.
+"""
+
+import pytest
+
+import pydapper
+from pydapper.exceptions import InvalidParameterShapeException
+from pydapper.exceptions import MissingParameterException
+from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from tests.mocks import MockAsyncCommands
+from tests.mocks import MockCommands
+
+pytestmark = pytest.mark.core
+
+
+class RecordingCursor:
+    description = ("id", "int"), ("name", "text")
+
+    def __init__(self, log, rows=((1, "zach"),), exit_error=None, exit_result=False):
+        self.log = log
+        self.rowcount = 0
+        self._rows_template = tuple(rows)
+        self.rows = []
+        self.exit_error = exit_error
+        self.exit_result = exit_result
+        self.exit_args = []
+        self.exit_tb_matches = []
+
+    def __enter__(self):
+        self.log.append("enter")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.log.append(("exit", exc_type))
+        self.exit_args.append((exc_type, exc_val, exc_tb))
+        self.exit_tb_matches.append(exc_val is not None and exc_tb is exc_val.__traceback__)
+        if self.exit_error is not None:
+            raise self.exit_error
+        return self.exit_result
+
+    def execute(self, sql, parameters=None):
+        self.log.append(("execute", sql))
+        self.rowcount = 1
+        self.rows = list(self._rows_template)
+
+    def executemany(self, sql, seq_of_parameters=None):
+        self.log.append(("executemany", sql))
+        self.rowcount = len(seq_of_parameters)
+        self.rows = []
+
+    def fetchone(self):
+        self.log.append("fetchone")
+        return self.rows.pop(0) if self.rows else None
+
+    def fetchmany(self, size=None):
+        self.log.append("fetchmany")
+        taken, self.rows = self.rows[:size], self.rows[size:]
+        return tuple(taken)
+
+    def fetchall(self):
+        self.log.append("fetchall")
+        remaining, self.rows = self.rows, []
+        return tuple(remaining)
+
+
+class RecordingAsyncCursor:
+    description = ("id", "int"), ("name", "text")
+
+    def __init__(self, log, rows=((1, "zach"),), exit_error=None, exit_result=False):
+        self.log = log
+        self.rowcount = 0
+        self._rows_template = tuple(rows)
+        self.rows = []
+        self.exit_error = exit_error
+        self.exit_result = exit_result
+        self.exit_args = []
+        self.exit_tb_matches = []
+
+    async def __aenter__(self):
+        self.log.append("enter")
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.log.append(("exit", exc_type))
+        self.exit_args.append((exc_type, exc_val, exc_tb))
+        self.exit_tb_matches.append(exc_val is not None and exc_tb is exc_val.__traceback__)
+        if self.exit_error is not None:
+            raise self.exit_error
+        return self.exit_result
+
+    async def execute(self, sql, parameters=None):
+        self.log.append(("execute", sql))
+        self.rowcount = 1
+        self.rows = list(self._rows_template)
+
+    async def executemany(self, sql, seq_of_parameters=None):
+        self.log.append(("executemany", sql))
+        self.rowcount = len(seq_of_parameters)
+        self.rows = []
+
+    async def fetchone(self):
+        self.log.append("fetchone")
+        return self.rows.pop(0) if self.rows else None
+
+    async def fetchmany(self, size=None):
+        self.log.append("fetchmany")
+        taken, self.rows = self.rows[:size], self.rows[size:]
+        return tuple(taken)
+
+    async def fetchall(self):
+        self.log.append("fetchall")
+        remaining, self.rows = self.rows, []
+        return tuple(remaining)
+
+
+class RecordingConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+        self.cursor_calls = 0
+
+    def cursor(self, *args, **kwargs):
+        self.cursor_calls += 1
+        return self.cursor_instance
+
+
+class RecordingAsyncConnection:
+    def __init__(self, cursor):
+        self.cursor_instance = cursor
+        self.cursor_calls = 0
+
+    async def cursor(self, *args, **kwargs):
+        self.cursor_calls += 1
+        return self.cursor_instance
+
+
+class _SyncHookRecorderMixin:
+    def _prepare_cursor(self, cursor, *, options):
+        self.log.append(("prepare_cursor", cursor, options))
+        if self.prepare_cursor_error is not None:
+            raise self.prepare_cursor_error
+        super()._prepare_cursor(cursor, options=options)
+
+    def _prepare_command(self, cursor, handler, *, options):
+        self.log.append(("prepare_command", cursor, handler, options))
+        if self.prepare_command_error is not None:
+            raise self.prepare_command_error
+        super()._prepare_command(cursor, handler, options=options)
+
+
+class _AsyncHookRecorderMixin:
+    async def _prepare_cursor_async(self, cursor, *, options):
+        self.log.append(("prepare_cursor", cursor, options))
+        if self.prepare_cursor_error is not None:
+            raise self.prepare_cursor_error
+        await super()._prepare_cursor_async(cursor, options=options)
+
+    async def _prepare_command_async(self, cursor, handler, *, options):
+        self.log.append(("prepare_command", cursor, handler, options))
+        if self.prepare_command_error is not None:
+            raise self.prepare_command_error
+        await super()._prepare_command_async(cursor, handler, options=options)
+
+
+class RecordingHookCommands(_SyncHookRecorderMixin, MockCommands):
+    def __init__(self, connection, log):
+        super().__init__(connection)
+        self.log = log
+        self.prepare_cursor_error = None
+        self.prepare_command_error = None
+
+
+class RecordingHookCommandsAsync(_AsyncHookRecorderMixin, MockAsyncCommands):
+    def __init__(self, connection, log):
+        super().__init__(connection)
+        self.log = log
+        self.prepare_cursor_error = None
+        self.prepare_command_error = None
+
+
+def _event_kinds(log):
+    return [event[0] if isinstance(event, tuple) else event for event in log]
+
+
+def _assert_prepared_once_in_order(log, cursor):
+    kinds = _event_kinds(log)
+    assert kinds[:3] == ["enter", "prepare_cursor", "prepare_command"]
+    assert kinds[3] in ("execute", "executemany")
+    assert kinds[-1] == "exit"
+    assert kinds.count("enter") == 1
+    assert kinds.count("prepare_cursor") == 1
+    assert kinds.count("prepare_command") == 1
+    assert kinds.count("exit") == 1
+
+    _, prepared_cursor, cursor_options = log[1]
+    _, command_cursor, handler, command_options = log[2]
+    assert prepared_cursor is cursor
+    assert command_cursor is cursor
+    assert handler.prepared_sql == log[3][1]
+    assert cursor_options is not None
+    assert command_options is not None
+    assert cursor_options == pydapper.CommandOptions()
+    assert command_options == pydapper.CommandOptions()
+
+
+SYNC_FAMILY_CALLS = [
+    pytest.param(
+        lambda commands, **kw: commands.execute("insert into task (id) values (?id?)", params={"id": 1}, **kw),
+        id="execute",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.execute(
+            "insert into task (id) values (?id?)", params=[{"id": 1}, {"id": 2}], **kw
+        ),
+        id="execute-executemany",
+    ),
+    pytest.param(lambda commands, **kw: commands.execute_scalar("select id from task", **kw), id="execute_scalar"),
+    pytest.param(lambda commands, **kw: commands.query("select id, name from task", **kw), id="query-buffered"),
+    pytest.param(
+        lambda commands, **kw: list(commands.query("select id, name from task", buffered=False, **kw)),
+        id="query-unbuffered",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_multiple(("select id, name from task",), **kw), id="query_multiple"
+    ),
+    pytest.param(lambda commands, **kw: commands.query_first("select id, name from task", **kw), id="query_first"),
+    pytest.param(
+        lambda commands, **kw: commands.query_first_or_default("select id, name from task", None, **kw),
+        id="query_first_or_default",
+    ),
+    pytest.param(lambda commands, **kw: commands.query_single("select id, name from task", **kw), id="query_single"),
+    pytest.param(
+        lambda commands, **kw: commands.query_single_or_default("select id, name from task", None, **kw),
+        id="query_single_or_default",
+    ),
+]
+
+
+async def _consume_unbuffered_async(commands, **kw):
+    generator = await commands.query_async("select id, name from task", buffered=False, **kw)
+    return [row async for row in generator]
+
+
+ASYNC_FAMILY_CALLS = [
+    pytest.param(
+        lambda commands, **kw: commands.execute_async("insert into task (id) values (?id?)", params={"id": 1}, **kw),
+        id="execute_async",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.execute_async(
+            "insert into task (id) values (?id?)", params=[{"id": 1}, {"id": 2}], **kw
+        ),
+        id="execute_async-executemany",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.execute_scalar_async("select id from task", **kw), id="execute_scalar_async"
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_async("select id, name from task", **kw), id="query_async-buffered"
+    ),
+    pytest.param(_consume_unbuffered_async, id="query_async-unbuffered"),
+    pytest.param(
+        lambda commands, **kw: commands.query_multiple_async(("select id, name from task",), **kw),
+        id="query_multiple_async",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_first_async("select id, name from task", **kw), id="query_first_async"
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_first_or_default_async("select id, name from task", None, **kw),
+        id="query_first_or_default_async",
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_single_async("select id, name from task", **kw), id="query_single_async"
+    ),
+    pytest.param(
+        lambda commands, **kw: commands.query_single_or_default_async("select id, name from task", None, **kw),
+        id="query_single_or_default_async",
+    ),
+]
+
+
+def _sync_commands():
+    log = []
+    cursor = RecordingCursor(log)
+    connection = RecordingConnection(cursor)
+    return log, cursor, connection, RecordingHookCommands(connection, log)
+
+
+def _async_commands():
+    log = []
+    cursor = RecordingAsyncCursor(log)
+    connection = RecordingAsyncConnection(cursor)
+    return log, cursor, connection, RecordingHookCommandsAsync(connection, log)
+
+
+@pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
+def test_sync_families_prepare_cursor_and_command_once_in_order(call):
+    log, cursor, _, commands = _sync_commands()
+
+    call(commands)
+
+    _assert_prepared_once_in_order(log, cursor)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call", ASYNC_FAMILY_CALLS)
+async def test_async_families_prepare_cursor_and_command_once_in_order(call):
+    log, cursor, _, commands = _async_commands()
+
+    await call(commands)
+
+    _assert_prepared_once_in_order(log, cursor)
+
+
+@pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
+def test_sync_families_pass_provided_options_instance_to_both_hooks(call):
+    log, _, _, commands = _sync_commands()
+    options = pydapper.CommandOptions()
+
+    call(commands, options=options)
+
+    assert log[1][2] is options
+    assert log[2][3] is options
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call", ASYNC_FAMILY_CALLS)
+async def test_async_families_pass_provided_options_instance_to_both_hooks(call):
+    log, _, _, commands = _async_commands()
+    options = pydapper.CommandOptions()
+
+    await call(commands, options=options)
+
+    assert log[1][2] is options
+    assert log[2][3] is options
+
+
+@pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
+def test_sync_unsupported_options_fail_before_cursor_acquisition_and_hooks(call):
+    log, _, connection, commands = _sync_commands()
+
+    with pytest.raises(UnsupportedFeatureError):
+        call(commands, options=pydapper.CommandOptions(timeout=1))
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call", ASYNC_FAMILY_CALLS)
+async def test_async_unsupported_options_fail_before_cursor_acquisition_and_hooks(call):
+    log, _, connection, commands = _async_commands()
+
+    with pytest.raises(UnsupportedFeatureError):
+        await call(commands, options=pydapper.CommandOptions(timeout=1))
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("call", "expected_exception"),
+    [
+        pytest.param(
+            lambda commands: commands.query("select 1", param={"id": 1}, params={"id": 1}),
+            ValueError,
+            id="param-alias-conflict",
+        ),
+        pytest.param(
+            lambda commands: commands.query("select 1", model=dict, mapper=lambda row: row),
+            ValueError,
+            id="model-and-mapper",
+        ),
+        pytest.param(lambda commands: commands.query("select ?id?"), MissingParameterException, id="missing-param"),
+        pytest.param(
+            lambda commands: commands.query_first("select 1", params=[{"id": 1}]),
+            InvalidParameterShapeException,
+            id="list-params-for-read",
+        ),
+        pytest.param(
+            lambda commands: commands.query_multiple(("select 1", "select ?id?")),
+            MissingParameterException,
+            id="query_multiple-later-missing-param",
+        ),
+    ],
+)
+def test_sync_validation_fails_before_cursor_acquisition_and_hooks(call, expected_exception):
+    log, _, connection, commands = _sync_commands()
+
+    with pytest.raises(expected_exception):
+        call(commands)
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("call", "expected_exception"),
+    [
+        pytest.param(
+            lambda commands: commands.query_async("select 1", param={"id": 1}, params={"id": 1}),
+            ValueError,
+            id="param-alias-conflict",
+        ),
+        pytest.param(
+            lambda commands: commands.query_async("select 1", model=dict, mapper=lambda row: row),
+            ValueError,
+            id="model-and-mapper",
+        ),
+        pytest.param(
+            lambda commands: commands.query_async("select ?id?"), MissingParameterException, id="missing-param"
+        ),
+        pytest.param(
+            lambda commands: commands.query_first_async("select 1", params=[{"id": 1}]),
+            InvalidParameterShapeException,
+            id="list-params-for-read",
+        ),
+        pytest.param(
+            lambda commands: commands.query_multiple_async(("select 1", "select ?id?")),
+            MissingParameterException,
+            id="query_multiple-later-missing-param",
+        ),
+    ],
+)
+async def test_async_validation_fails_before_cursor_acquisition_and_hooks(call, expected_exception):
+    log, _, connection, commands = _async_commands()
+
+    with pytest.raises(expected_exception):
+        await call(commands)
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+def test_sync_execute_empty_executemany_fast_path_skips_cursor_and_hooks():
+    log, _, connection, commands = _sync_commands()
+
+    assert commands.execute("insert into task (id) values (?id?)", params=[]) == 0
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_async_execute_empty_executemany_fast_path_skips_cursor_and_hooks():
+    log, _, connection, commands = _async_commands()
+
+    assert await commands.execute_async("insert into task (id) values (?id?)", params=[]) == 0
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+def test_sync_query_multiple_prepares_cursor_once_and_each_handler_once():
+    log, cursor, _, commands = _sync_commands()
+    queries = ("select id from task", "select name from task")
+
+    commands.query_multiple(queries)
+
+    assert _event_kinds(log) == [
+        "enter",
+        "prepare_cursor",
+        "prepare_command",
+        "execute",
+        "fetchall",
+        "prepare_command",
+        "execute",
+        "fetchall",
+        "exit",
+    ]
+    prepared = [event for event in log if isinstance(event, tuple) and event[0] == "prepare_command"]
+    assert [event[2].prepared_sql for event in prepared] == list(queries)
+    assert len({id(event[2]) for event in prepared}) == 2
+    assert all(event[1] is cursor for event in prepared)
+
+
+@pytest.mark.asyncio
+async def test_async_query_multiple_prepares_cursor_once_and_each_handler_once():
+    log, cursor, _, commands = _async_commands()
+    queries = ("select id from task", "select name from task")
+
+    await commands.query_multiple_async(queries)
+
+    assert _event_kinds(log) == [
+        "enter",
+        "prepare_cursor",
+        "prepare_command",
+        "execute",
+        "fetchall",
+        "prepare_command",
+        "execute",
+        "fetchall",
+        "exit",
+    ]
+    prepared = [event for event in log if isinstance(event, tuple) and event[0] == "prepare_command"]
+    assert [event[2].prepared_sql for event in prepared] == list(queries)
+    assert len({id(event[2]) for event in prepared}) == 2
+    assert all(event[1] is cursor for event in prepared)
+
+
+def test_sync_unbuffered_query_defers_hooks_until_iteration_and_cleans_up_on_close():
+    log, _, _, commands = _sync_commands()
+
+    generator = commands.query("select id, name from task", buffered=False)
+    assert log == []
+
+    next(generator)
+    assert _event_kinds(log)[:4] == ["enter", "prepare_cursor", "prepare_command", "execute"]
+    assert "exit" not in _event_kinds(log)
+
+    generator.close()
+    assert _event_kinds(log)[-1] == "exit"
+    assert _event_kinds(log).count("exit") == 1
+
+
+@pytest.mark.asyncio
+async def test_async_unbuffered_query_defers_hooks_until_iteration_and_cleans_up_on_aclose():
+    log, _, _, commands = _async_commands()
+
+    generator = await commands.query_async("select id, name from task", buffered=False)
+    assert log == []
+
+    await generator.__anext__()
+    assert _event_kinds(log)[:4] == ["enter", "prepare_cursor", "prepare_command", "execute"]
+    assert "exit" not in _event_kinds(log)
+
+    await generator.aclose()
+    assert _event_kinds(log)[-1] == "exit"
+    assert _event_kinds(log).count("exit") == 1
+
+
+@pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
+def test_sync_cursor_preparation_failure_exits_once_and_prevents_command_preparation(call):
+    log, cursor, _, commands = _sync_commands()
+    error = RuntimeError("cursor preparation failed")
+    commands.prepare_cursor_error = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        call(commands)
+
+    assert exc_info.value is error
+    assert _event_kinds(log) == ["enter", "prepare_cursor", "exit"]
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call", ASYNC_FAMILY_CALLS)
+async def test_async_cursor_preparation_failure_exits_once_and_prevents_command_preparation(call):
+    log, cursor, _, commands = _async_commands()
+    error = RuntimeError("cursor preparation failed")
+    commands.prepare_cursor_error = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await call(commands)
+
+    assert exc_info.value is error
+    assert _event_kinds(log) == ["enter", "prepare_cursor", "exit"]
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.parametrize("call", SYNC_FAMILY_CALLS)
+def test_sync_command_preparation_failure_exits_once_and_prevents_execution(call):
+    log, cursor, _, commands = _sync_commands()
+    error = RuntimeError("command preparation failed")
+    commands.prepare_command_error = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        call(commands)
+
+    assert exc_info.value is error
+    assert _event_kinds(log) == ["enter", "prepare_cursor", "prepare_command", "exit"]
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call", ASYNC_FAMILY_CALLS)
+async def test_async_command_preparation_failure_exits_once_and_prevents_execution(call):
+    log, cursor, _, commands = _async_commands()
+    error = RuntimeError("command preparation failed")
+    commands.prepare_command_error = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await call(commands)
+
+    assert exc_info.value is error
+    assert _event_kinds(log) == ["enter", "prepare_cursor", "prepare_command", "exit"]
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.parametrize("failing_hook", ["prepare_cursor_error", "prepare_command_error"])
+def test_sync_preparation_error_wins_over_cleanup_failure(failing_hook):
+    log = []
+    cursor = RecordingCursor(log, exit_error=OSError("cleanup failed"))
+    commands = RecordingHookCommands(RecordingConnection(cursor), log)
+    error = RuntimeError("preparation failed")
+    setattr(commands, failing_hook, error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        commands.query("select id, name from task")
+
+    assert exc_info.value is error
+    assert _event_kinds(log).count("exit") == 1
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_hook", ["prepare_cursor_error", "prepare_command_error"])
+async def test_async_preparation_error_wins_over_cleanup_failure(failing_hook):
+    log = []
+    cursor = RecordingAsyncCursor(log, exit_error=OSError("cleanup failed"))
+    commands = RecordingHookCommandsAsync(RecordingAsyncConnection(cursor), log)
+    error = RuntimeError("preparation failed")
+    setattr(commands, failing_hook, error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await commands.query_async("select id, name from task")
+
+    assert exc_info.value is error
+    assert _event_kinds(log).count("exit") == 1
+    [(exc_type, exc_val, _)] = cursor.exit_args
+    assert exc_type is RuntimeError
+    assert exc_val is error
+    assert cursor.exit_tb_matches == [True]
+
+
+@pytest.mark.parametrize("failing_hook", ["prepare_cursor_error", "prepare_command_error"])
+def test_sync_truthy_cursor_exit_does_not_suppress_preparation_error(failing_hook):
+    log = []
+    cursor = RecordingCursor(log, exit_result=True)
+    commands = RecordingHookCommands(RecordingConnection(cursor), log)
+    error = RuntimeError("preparation failed")
+    setattr(commands, failing_hook, error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        commands.query("select id, name from task")
+
+    assert exc_info.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_hook", ["prepare_cursor_error", "prepare_command_error"])
+async def test_async_truthy_cursor_exit_does_not_suppress_preparation_error(failing_hook):
+    log = []
+    cursor = RecordingAsyncCursor(log, exit_result=True)
+    commands = RecordingHookCommandsAsync(RecordingAsyncConnection(cursor), log)
+    error = RuntimeError("preparation failed")
+    setattr(commands, failing_hook, error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await commands.query_async("select id, name from task")
+
+    assert exc_info.value is error
+
+
+def test_sync_cleanup_failure_after_successful_command_propagates():
+    log = []
+    cleanup_error = OSError("cleanup failed")
+    cursor = RecordingCursor(log, exit_error=cleanup_error)
+    commands = RecordingHookCommands(RecordingConnection(cursor), log)
+
+    with pytest.raises(OSError) as exc_info:
+        commands.query("select id, name from task")
+
+    assert exc_info.value is cleanup_error
+    assert _event_kinds(log)[:4] == ["enter", "prepare_cursor", "prepare_command", "execute"]
+    assert cursor.exit_args == [(None, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_async_cleanup_failure_after_successful_command_propagates():
+    log = []
+    cleanup_error = OSError("cleanup failed")
+    cursor = RecordingAsyncCursor(log, exit_error=cleanup_error)
+    commands = RecordingHookCommandsAsync(RecordingAsyncConnection(cursor), log)
+
+    with pytest.raises(OSError) as exc_info:
+        await commands.query_async("select id, name from task")
+
+    assert exc_info.value is cleanup_error
+    assert _event_kinds(log)[:4] == ["enter", "prepare_cursor", "prepare_command", "execute"]
+    assert cursor.exit_args == [(None, None, None)]
+
+
+class RecordingMySqlCommands(_SyncHookRecorderMixin, MySqlConnectorPythonCommands):
+    def __init__(self, connection, log):
+        super().__init__(connection)
+        self.log = log
+        self.prepare_cursor_error = None
+        self.prepare_command_error = None
+
+
+def test_mysql_query_first_reaches_hooks_and_keeps_unread_result_drain():
+    log = []
+    cursor = RecordingCursor(log, rows=((1, "zach"), (2, "sam")))
+    commands = RecordingMySqlCommands(RecordingConnection(cursor), log)
+    options = pydapper.CommandOptions()
+
+    result = commands.query_first("select id, name from task", options=options)
+
+    assert result == {"id": 1, "name": "zach"}
+    assert _event_kinds(log) == [
+        "enter",
+        "prepare_cursor",
+        "prepare_command",
+        "execute",
+        "fetchone",
+        "fetchall",
+        "exit",
+    ]
+    assert log[1][1] is cursor
+    assert log[1][2] is options
+    assert log[2][3] is options
+
+
+def test_mysql_query_first_unsupported_options_fail_before_cursor_acquisition_and_hooks():
+    log = []
+    connection = RecordingConnection(RecordingCursor(log))
+    commands = RecordingMySqlCommands(connection, log)
+
+    with pytest.raises(UnsupportedFeatureError):
+        commands.query_first("select id, name from task", options=pydapper.CommandOptions(timeout=1))
+
+    assert log == []
+    assert connection.cursor_calls == 0
+
+
+def test_mysql_query_first_cursor_preparation_failure_prevents_execution_and_drain():
+    log = []
+    cursor = RecordingCursor(log, rows=((1, "zach"), (2, "sam")))
+    commands = RecordingMySqlCommands(RecordingConnection(cursor), log)
+    error = RuntimeError("cursor preparation failed")
+    commands.prepare_cursor_error = error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        commands.query_first("select id, name from task")
+
+    assert exc_info.value is error
+    assert _event_kinds(log) == ["enter", "prepare_cursor", "exit"]
+
+
+class RecordingPsycopg3Commands(_SyncHookRecorderMixin, Psycopg3Commands):
+    def __init__(self, connection, log):
+        super().__init__(connection)
+        self.log = log
+        self.prepare_cursor_error = None
+        self.prepare_command_error = None
+
+
+class RecordingPsycopg3CommandsAsync(_AsyncHookRecorderMixin, Psycopg3CommandsAsync):
+    def __init__(self, connection, log):
+        super().__init__(connection)
+        self.log = log
+        self.prepare_cursor_error = None
+        self.prepare_command_error = None
+
+
+def test_psycopg3_sync_commands_reach_hooks():
+    log = []
+    cursor = RecordingCursor(log)
+    commands = RecordingPsycopg3Commands(RecordingConnection(cursor), log)
+
+    result = commands.query_first("select id, name from task")
+
+    assert result == {"id": 1, "name": "zach"}
+    _assert_prepared_once_in_order(log, cursor)
+
+
+@pytest.mark.asyncio
+async def test_psycopg3_async_sync_returning_cursor_factory_does_not_bypass_hooks():
+    log = []
+    cursor = RecordingAsyncCursor(log)
+    connection = RecordingConnection(cursor)
+
+    commands = RecordingPsycopg3CommandsAsync(connection, log)
+
+    result = await commands.query_first_async("select id, name from task")
+
+    assert result == {"id": 1, "name": "zach"}
+    _assert_prepared_once_in_order(log, cursor)
+    assert connection.cursor_calls == 1

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -15,6 +15,7 @@ import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands as PydapperCommands
 from pydapper.commands import CommandsAsync as PydapperCommandsAsync
 from pydapper.exceptions import DuplicateColumnException
@@ -25,8 +26,12 @@ from pydapper.exceptions import NoResultException
 from pydapper.exceptions import PyDapperException
 from pydapper.exceptions import RowMappingException
 from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.sqlite import Sqlite3Commands
 from pydapper.types import AsyncConnectionType
+from pydapper.types import AsyncCursorType
 from pydapper.types import ConnectionType
+from pydapper.types import CursorType
 
 """This file tests some of the more complex type annotations on the Commands and AsyncCommands classes"""
 
@@ -121,6 +126,27 @@ def adapter_capability_types() -> None:
     assert_type(async_commands.supports(pydapper.AdapterCapability.TRANSACTIONS), bool)
     assert_type(sync_commands._require_capability(pydapper.AdapterCapability.TRANSACTIONS), None)
     assert_type(async_commands._require_capability(pydapper.AdapterCapability.TRANSACTIONS), None)
+    # concrete first-party declarations stay typed as frozenset[AdapterCapability]
+    assert_type(Sqlite3Commands.capabilities, frozenset[pydapper.AdapterCapability])
+    assert_type(Psycopg3CommandsAsync.capabilities, frozenset[pydapper.AdapterCapability])
+
+
+def preparation_hook_types() -> None:
+    sync_commands = cast(PydapperCommands, object())
+    cursor = cast(CursorType, object())
+    handler = cast(BaseSqlParamHandler, object())
+    options = pydapper.CommandOptions()
+    assert_type(sync_commands._prepare_cursor(cursor, options=options), None)
+    assert_type(sync_commands._prepare_command(cursor, handler, options=options), None)
+
+
+async def preparation_hook_async_types() -> None:
+    async_commands = cast(PydapperCommandsAsync, object())
+    async_cursor = cast(AsyncCursorType, object())
+    handler = cast(BaseSqlParamHandler, object())
+    options = pydapper.CommandOptions()
+    assert_type(await async_commands._prepare_cursor_async(async_cursor, options=options), None)
+    assert_type(await async_commands._prepare_command_async(async_cursor, handler, options=options), None)
 
 
 def _cannot_handle_connection(connection: object) -> bool:


### PR DESCRIPTION
## What changed and why

Completes the remaining scope of #467 on top of #554 (which shipped `AdapterCapability`, the package-root export, `BaseCommands.capabilities`, `supports()`, and `_require_capability()`; none of that is duplicated here). Closes #467.

**Atomic registration validation** (`pydapper/main.py`): `register_adapter()` now validates each supplied command class's `capabilities` declaration — it must be a `frozenset` containing only `AdapterCapability` members — for the sync and async classes independently, after the existing #466 name/subclass/predicate checks and before the registry dict is touched. Mutable sets, tuples, lists, raw strings, mixed sets, and unrelated objects raise `TypeError` naming the offending argument (`commands.capabilities` / `async_commands.capabilities`); an invalid declaration in either mode fails the whole registration with the registry unchanged. All #466 behavior (duplicate names, mode selection, one-way registration) is preserved and no unregister/inspection API was added.

**Explicit first-party declarations**: all nine concrete command classes (`Sqlite3Commands`, `Psycopg2Commands`, `Psycopg3Commands`, `Psycopg3CommandsAsync`, `AiopgCommands`, `MySqlConnectorPythonCommands`, `PymssqlCommands`, `OracledbCommands`, `GoogleBigqueryClientCommands`) now declare `capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()` directly on the class. A repository test proves each declaration is direct (via `vars()`), a valid frozenset, and empty, and a companion test proves the audited list covers every registered builtin command class.

**Preparation hooks** (`pydapper/commands.py`): `Commands` gains `_prepare_cursor(cursor, *, options)` and `_prepare_command(cursor, handler, *, options)`; `CommandsAsync` gains the `_async` equivalents. Base implementations are no-ops, typed against the project's `CursorType`/`AsyncCursorType`/`BaseSqlParamHandler`/`CommandOptions`. Every handler execution call site was audited and integrated: `execute`, `execute_scalar`, buffered and unbuffered `query`, `query_multiple`, `query_first`, `query_single`, and both `*_or_default` delegations, sync and async. For one acquired cursor the order is: pre-cursor validation → cursor enter → `_prepare_cursor*` once → (per handler) `_prepare_command*` once immediately before execution → execute/fetch/map → single lifecycle exit. `query_multiple` prepares its cursor once and each retained handler once. The empty-executemany fast path performs no cursor work and runs no hooks. Hook failures follow the #541 active-error policy: cleanup runs once, the exact preparation exception object wins over cleanup failures and truthy native exits, and native exit receives the live exception triple.

**Options threading (behavior change)**: each command stores `_resolve_options(options)` and passes that normalized instance to both hooks, and the four `*_or_default` helpers now forward the normalized options to `query_first`/`query_single` (sync and async) instead of validating and discarding them. Consequence: subclass overrides of `query_first`/`query_single`/`query_first_async`/`query_single_async` must accept an `options=` keyword. The two tests that pinned the old omit-on-delegation behavior (`tests/test_command_options.py`, `tests/test_commands_interface.py`) were updated to pin the new forwarding contract; this is called out in the release notes.

**Adapter seams**: `MySqlConnectorPythonCommands.query_first()` calls both hooks and keeps its required `fetchall()` unread-result drain; MySQL `query_single` reset/drain and psycopg3 sync/async cursor normalization are unchanged, with tests proving the psycopg3 sync-returning async cursor factory does not bypass the hooks.

## Example

```python
class AcmeCommands(Commands):
    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()

    def _prepare_cursor(self, cursor, *, options):  # runs once per command-owned cursor
        ...

    def _prepare_command(self, cursor, handler, *, options):  # runs once per executed handler
        ...

pydapper.register_adapter("acmedb", commands=AcmeCommands, using_connection_predicate=...)
# a class declaring capabilities = {"transactions"} (mutable/raw string) now raises TypeError
# before the registry is mutated
```

## Tests

* New `tests/test_preparation_hooks.py` (service-free, recording cursors/commands): every sync and async family reaches both hooks exactly once in `enter → prepare_cursor → prepare_command → execute → fetch/map → exit` order; `query_multiple` does one cursor prep + one command prep per query with distinct handlers; omitted options arrive as `CommandOptions()` (never `None`) and a provided instance reaches both hooks by identity (including through `*_or_default` delegation and the MySQL override); validation, alias conflicts, missing params, list-params-for-read, and unsupported non-default options all fail before cursor acquisition and before either hook; cursor-prep and command-prep failures exit once, prevent later stages, beat cleanup failures by exception identity, are not suppressed by truthy exits, and hand native exit the active exception triple/traceback; cleanup failure after success still propagates; unbuffered generators defer hooks to first iteration and clean up on `close()`/`aclose()`; MySQL and psycopg3 (sync and async) overrides do not bypass the seam.
* `tests/test_main.py`: valid empty and distinct nonempty per-mode declarations; nine invalid declaration shapes × both modes rejected atomically with `capabilities` identifiable in the message; one-invalid-of-two-modes fails the whole registration; first-party declaration audit + coverage test.
* `tests/test_command_options.py` / `tests/test_commands_interface.py`: delegation tests updated to the forwarding contract as described above.
* `tests/type_tests.py`: hook signatures (sync/async, `None` returns, keyword-only `CommandOptions`), concrete first-party `capabilities` typing, existing root-export/`supports()` assertions intact. No 3.10-incompatible syntax.

## Commands run

* `poetry run pytest tests/test_main.py` — 92 passed
* `poetry run pytest tests/test_commands_interface.py -m "core"` — 435 passed
* `poetry run pytest tests/test_adapter_units.py -m "core"` — 29 passed
* `poetry run pytest tests/test_context.py` — 20 passed
* `poetry run pytest -m "core"` — 810 passed, 208 deselected
* `poetry run pytest -m "sqlite"` — 29 passed
* `poetry run mypy pydapper` — clean (27 files)
* `poetry run mypy tests/type_tests.py` — clean
* `poetry run black --check .` / `poetry run isort --check .` — clean
* `poetry run mkdocs build --strict` — build succeeded
* `git diff --check` — clean

Driver integrations (postgresql, mysql, mssql, oracle, bigquery) were **not** run: all optional driver packages are installed in this environment, but the Docker daemon is unavailable and those suites use testcontainers/emulators. The shared hook/lifecycle behavior they exercise is covered by the service-free recording tests above (including the MySQL and psycopg3 adapter seams).

## Impact

* Public/documented API: capability declaration validation in `register_adapter()`; documented compatibility-sensitive adapter-author hooks; `docs/adapter_registration.md` gains capability + hook sections, a first-party mode/capability table, and a complete third-party sync+async example; `docs/compatibility.md` names the hooks as an explicit exception to the underscore rule; release-note entry added.
* Compatibility-sensitive change: `*_or_default` now forwards `options=` to `query_first`/`query_single` overrides (see above; noted in release notes).
* No new dependencies, no lockfile changes, no optional capability implemented, no `CommandOptions` behavior change beyond carrying normalized context, no registry mutation API, nothing from #468/#499/#538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
