### PR TITLE
feat: add private lazy entry-point discovery catalog for pydapper.adapters

### DIFF
--- a/pydapper/_adapter_discovery.py
+++ b/pydapper/_adapter_discovery.py
@@ -1,0 +1,115 @@
+"""Private lazy discovery catalog for the ``pydapper.adapters`` entry-point group.
+
+This module only discovers and caches entry-point *metadata*. It never calls
+``EntryPoint.load()``, never invokes provider callbacks, and never mutates the
+adapter registry. Later #468 slices consume the catalog to load providers.
+
+Everything here is private; nothing is exported from the package root.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+_ENTRY_POINT_GROUP = "pydapper.adapters"
+
+
+@dataclass(frozen=True)
+class _AdapterProviderDescriptor:
+    """Metadata for one installed provider of an adapter entry point.
+
+    Retains the original entry point so a later slice can load it, plus the
+    exact adapter name and the provider distribution's display name for
+    precedence decisions and error reporting.
+    """
+
+    name: str
+    distribution: str
+    entry_point: importlib.metadata.EntryPoint
+
+
+_catalog: Mapping[str, tuple[_AdapterProviderDescriptor, ...]] | None = None
+_catalog_lock = threading.Lock()
+
+
+def _validate_provider_name(name: object) -> str:
+    if not isinstance(name, str):
+        raise TypeError(
+            f"Adapter entry-point name in group {_ENTRY_POINT_GROUP!r} must be a string, got {type(name).__name__}"
+        )
+    if not name or name != name.strip():
+        raise ValueError(
+            f"Adapter entry-point name {name!r} in group {_ENTRY_POINT_GROUP!r} "
+            "must be non-empty and have no surrounding whitespace"
+        )
+    return name
+
+
+def _distribution_display_name(entry_point: importlib.metadata.EntryPoint) -> str:
+    dist = getattr(entry_point, "dist", None)
+    dist_name = getattr(dist, "name", None) if dist is not None else None
+    if not isinstance(dist_name, str) or not dist_name or dist_name != dist_name.strip():
+        raise ValueError(
+            f"Entry point {getattr(entry_point, 'name', None)!r} in group {_ENTRY_POINT_GROUP!r} "
+            "has no usable distribution name"
+        )
+    return dist_name
+
+
+def _enumerate_entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
+    try:
+        # the group keyword is supported on every project Python version (3.10+) and avoids the
+        # deprecated dict-shaped no-argument result
+        entry_points = importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP)
+    except Exception as exc:
+        raise ValueError(f"Failed to enumerate entry points for group {_ENTRY_POINT_GROUP!r}") from exc
+    return tuple(entry_points)
+
+
+def _build_catalog() -> Mapping[str, tuple[_AdapterProviderDescriptor, ...]]:
+    grouped: dict[str, list[_AdapterProviderDescriptor]] = {}
+    for entry_point in _enumerate_entry_points():
+        if entry_point.group != _ENTRY_POINT_GROUP:
+            continue
+        name = _validate_provider_name(entry_point.name)
+        descriptor = _AdapterProviderDescriptor(
+            name=name,
+            distribution=_distribution_display_name(entry_point),
+            entry_point=entry_point,
+        )
+        grouped.setdefault(name, []).append(descriptor)
+
+    # sort by stable metadata so enumeration order can never influence later selection; duplicates
+    # are retained for the later collision-resolution slice
+    return MappingProxyType(
+        {
+            name: tuple(sorted(providers, key=lambda d: (d.distribution, d.entry_point.value)))
+            for name, providers in sorted(grouped.items())
+        }
+    )
+
+
+def _get_provider_catalog() -> Mapping[str, tuple[_AdapterProviderDescriptor, ...]]:
+    """Return the cached provider catalog, building it on first access.
+
+    Discovery is serialized by a lock so concurrent first access enumerates
+    metadata exactly once. A failed build raises without caching anything.
+    """
+    global _catalog
+    catalog = _catalog
+    if catalog is not None:
+        return catalog
+    with _catalog_lock:
+        if _catalog is None:
+            _catalog = _build_catalog()
+        return _catalog
+
+
+def _reset_provider_catalog_for_tests() -> None:
+    global _catalog
+    with _catalog_lock:
+        _catalog = None

--- a/pydapper/_adapter_discovery.py
+++ b/pydapper/_adapter_discovery.py
@@ -50,8 +50,14 @@ def _validate_provider_name(name: object) -> str:
 
 
 def _distribution_display_name(entry_point: importlib.metadata.EntryPoint) -> str:
-    dist = getattr(entry_point, "dist", None)
-    dist_name = getattr(dist, "name", None) if dist is not None else None
+    try:
+        dist = getattr(entry_point, "dist", None)
+        dist_name = getattr(dist, "name", None) if dist is not None else None
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to read distribution metadata for entry point {getattr(entry_point, 'name', None)!r} "
+            f"in group {_ENTRY_POINT_GROUP!r}"
+        ) from exc
     if not isinstance(dist_name, str) or not dist_name or dist_name != dist_name.strip():
         raise ValueError(
             f"Entry point {getattr(entry_point, 'name', None)!r} in group {_ENTRY_POINT_GROUP!r} "
@@ -64,10 +70,9 @@ def _enumerate_entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
     try:
         # the group keyword is supported on every project Python version (3.10+) and avoids the
         # deprecated dict-shaped no-argument result
-        entry_points = importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP)
+        return tuple(importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP))
     except Exception as exc:
         raise ValueError(f"Failed to enumerate entry points for group {_ENTRY_POINT_GROUP!r}") from exc
-    return tuple(entry_points)
 
 
 def _build_catalog() -> Mapping[str, tuple[_AdapterProviderDescriptor, ...]]:

--- a/tests/test_adapter_discovery.py
+++ b/tests/test_adapter_discovery.py
@@ -1,0 +1,249 @@
+import importlib.metadata
+import sys
+import threading
+from dataclasses import dataclass
+from dataclasses import field
+
+import pytest
+
+import pydapper
+from pydapper import _adapter_discovery
+from pydapper.main import _adapter_registry
+
+pytestmark = pytest.mark.core
+
+GROUP = "pydapper.adapters"
+
+
+@dataclass
+class FakeDistribution:
+    name: object
+
+
+@dataclass
+class FakeEntryPoint:
+    name: object
+    value: str = "pydapper_fake_provider_should_not_import.plugin:register"
+    group: str = GROUP
+    dist: object = field(default_factory=lambda: FakeDistribution("acme-adapter"))
+    load_calls: int = 0
+
+    def load(self):
+        self.load_calls += 1
+        raise AssertionError("EntryPoint.load() must not be called during discovery")
+
+
+class FakeEntryPoints:
+    """Stands in for importlib.metadata.entry_points; records group requests."""
+
+    def __init__(self, entries):
+        self.entries = list(entries)
+        self.calls = []
+
+    def __call__(self, *, group):
+        self.calls.append(group)
+        return [ep for ep in self.entries if ep.group == group]
+
+
+@pytest.fixture(autouse=True)
+def reset_catalog():
+    _adapter_discovery._reset_provider_catalog_for_tests()
+    yield
+    _adapter_discovery._reset_provider_catalog_for_tests()
+
+
+@pytest.fixture
+def install_entry_points(monkeypatch):
+    def install(entries):
+        fake = FakeEntryPoints(entries)
+        monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+        return fake
+
+    return install
+
+
+def test_only_exact_group_is_selected(install_entry_points):
+    fake = install_entry_points(
+        [
+            FakeEntryPoint("acmedb"),
+            FakeEntryPoint("otherdb", group="pydapper.adapters.extra"),
+            FakeEntryPoint("console", group="console_scripts"),
+        ]
+    )
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert fake.calls == [GROUP]
+    assert set(catalog) == {"acmedb"}
+
+
+def test_mixed_group_enumeration_result_is_filtered(monkeypatch):
+    entries = [FakeEntryPoint("acmedb"), FakeEntryPoint("stray", group="console_scripts")]
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda *, group: list(entries))
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert set(catalog) == {"acmedb"}
+
+
+def test_discovery_never_loads_imports_or_registers(install_entry_points):
+    entries = [FakeEntryPoint("acmedb"), FakeEntryPoint("acmedb", dist=FakeDistribution("other-dist"))]
+    install_entry_points(entries)
+    registry_before = dict(_adapter_registry)
+
+    _adapter_discovery._get_provider_catalog()
+
+    assert all(ep.load_calls == 0 for ep in entries)
+    assert "pydapper_fake_provider_should_not_import" not in sys.modules
+    assert "pydapper_fake_provider_should_not_import.plugin" not in sys.modules
+    assert dict(_adapter_registry) == registry_before
+
+
+def test_successful_catalog_is_cached_without_reenumeration(install_entry_points):
+    fake = install_entry_points([FakeEntryPoint("acmedb")])
+    first = _adapter_discovery._get_provider_catalog()
+    second = _adapter_discovery._get_provider_catalog()
+    assert first is second
+    assert fake.calls == [GROUP]
+
+
+def test_cached_catalog_is_protected_from_mutation(install_entry_points):
+    install_entry_points([FakeEntryPoint("acmedb")])
+    catalog = _adapter_discovery._get_provider_catalog()
+    with pytest.raises(TypeError):
+        catalog["acmedb"] = ()  # type: ignore[index]
+    assert isinstance(catalog["acmedb"], tuple)
+    with pytest.raises(Exception):
+        catalog["acmedb"][0].name = "other"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("bad_name", ["", " acmedb", "acmedb ", "\tacmedb\n"])
+def test_invalid_names_fail(install_entry_points, bad_name):
+    install_entry_points([FakeEntryPoint(bad_name)])
+    with pytest.raises(ValueError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert repr(bad_name) in str(excinfo.value) or GROUP in str(excinfo.value)
+
+
+def test_non_string_name_fails_with_type_error(install_entry_points):
+    install_entry_points([FakeEntryPoint(123)])
+    with pytest.raises(TypeError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert GROUP in str(excinfo.value)
+
+
+def test_case_hyphen_and_underscore_names_stay_distinct(install_entry_points):
+    install_entry_points(
+        [
+            FakeEntryPoint("AcmeDB"),
+            FakeEntryPoint("acmedb"),
+            FakeEntryPoint("acme-db"),
+            FakeEntryPoint("acme_db"),
+        ]
+    )
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert set(catalog) == {"AcmeDB", "acmedb", "acme-db", "acme_db"}
+    assert all(len(providers) == 1 for providers in catalog.values())
+
+
+def test_duplicate_exact_names_retain_every_provider(install_entry_points):
+    install_entry_points(
+        [
+            FakeEntryPoint("acmedb", dist=FakeDistribution("zeta-dist")),
+            FakeEntryPoint("acmedb", dist=FakeDistribution("alpha-dist")),
+        ]
+    )
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert [p.distribution for p in catalog["acmedb"]] == ["alpha-dist", "zeta-dist"]
+    assert all(isinstance(p.entry_point, FakeEntryPoint) for p in catalog["acmedb"])
+
+
+def test_enumeration_order_does_not_change_catalog(install_entry_points):
+    entries = [
+        FakeEntryPoint("acmedb", dist=FakeDistribution("zeta-dist")),
+        FakeEntryPoint("acmedb", dist=FakeDistribution("alpha-dist")),
+        FakeEntryPoint("otherdb", dist=FakeDistribution("other-dist")),
+    ]
+    install_entry_points(entries)
+    forward = _adapter_discovery._get_provider_catalog()
+
+    _adapter_discovery._reset_provider_catalog_for_tests()
+    install_entry_points(list(reversed(entries)))
+    reversed_order = _adapter_discovery._get_provider_catalog()
+
+    assert list(forward) == list(reversed_order) == ["acmedb", "otherdb"]
+    assert [p.distribution for p in forward["acmedb"]] == [p.distribution for p in reversed_order["acmedb"]]
+
+
+def test_distribution_provenance_is_retained(install_entry_points):
+    install_entry_points([FakeEntryPoint("acmedb", dist=FakeDistribution("acme-adapter"))])
+    provider = _adapter_discovery._get_provider_catalog()["acmedb"][0]
+    assert provider.distribution == "acme-adapter"
+    assert provider.name == "acmedb"
+
+
+@pytest.mark.parametrize("dist", [None, FakeDistribution(None), FakeDistribution(""), FakeDistribution(" pkg ")])
+def test_missing_or_malformed_distribution_fails(install_entry_points, dist):
+    install_entry_points([FakeEntryPoint("acmedb", dist=dist)])
+    with pytest.raises(ValueError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert "acmedb" in str(excinfo.value)
+
+
+def test_enumeration_failure_preserves_cause_and_is_not_cached(monkeypatch):
+    original = RuntimeError("metadata backend exploded")
+
+    def broken(*, group):
+        raise original
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", broken)
+    with pytest.raises(ValueError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert excinfo.value.__cause__ is original
+    assert GROUP in str(excinfo.value)
+
+    fake = FakeEntryPoints([FakeEntryPoint("acmedb")])
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert set(catalog) == {"acmedb"}
+
+
+def test_validation_failure_is_not_cached_and_retry_succeeds(monkeypatch):
+    fake = FakeEntryPoints([FakeEntryPoint("")])
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+    with pytest.raises(ValueError):
+        _adapter_discovery._get_provider_catalog()
+
+    fake.entries = [FakeEntryPoint("acmedb")]
+    catalog = _adapter_discovery._get_provider_catalog()
+    assert set(catalog) == {"acmedb"}
+    assert fake.calls == [GROUP, GROUP]
+
+
+def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
+    thread_count = 8
+    barrier = threading.Barrier(thread_count)
+    fake = FakeEntryPoints([FakeEntryPoint("acmedb")])
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait()
+            results.append(_adapter_discovery._get_provider_catalog())
+        except Exception as exc:  # pragma: no cover - failure reporting only
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert fake.calls == [GROUP]
+    assert all(catalog is results[0] for catalog in results)
+
+
+def test_no_public_package_root_symbol_added():
+    public_names = [name for name in vars(pydapper) if not name.startswith("_")]
+    assert not any("discover" in name.lower() or "catalog" in name.lower() for name in public_names)
+    assert "_adapter_discovery" not in getattr(pydapper, "__all__", [])

--- a/tests/test_adapter_discovery.py
+++ b/tests/test_adapter_discovery.py
@@ -156,9 +156,10 @@ def test_duplicate_exact_names_retain_every_provider(install_entry_points):
 
 def test_enumeration_order_does_not_change_catalog(install_entry_points):
     entries = [
-        FakeEntryPoint("acmedb", dist=FakeDistribution("zeta-dist")),
-        FakeEntryPoint("acmedb", dist=FakeDistribution("alpha-dist")),
-        FakeEntryPoint("otherdb", dist=FakeDistribution("other-dist")),
+        FakeEntryPoint("acmedb", value="zeta_mod:register", dist=FakeDistribution("zeta-dist")),
+        FakeEntryPoint("acmedb", value="beta_mod:register", dist=FakeDistribution("alpha-dist")),
+        FakeEntryPoint("acmedb", value="alpha_mod:register", dist=FakeDistribution("alpha-dist")),
+        FakeEntryPoint("otherdb", value="other_mod:register", dist=FakeDistribution("other-dist")),
     ]
     install_entry_points(entries)
     forward = _adapter_discovery._get_provider_catalog()
@@ -167,8 +168,20 @@ def test_enumeration_order_does_not_change_catalog(install_entry_points):
     install_entry_points(list(reversed(entries)))
     reversed_order = _adapter_discovery._get_provider_catalog()
 
+    def full_metadata(catalog):
+        return {
+            name: [(p.name, p.distribution, p.entry_point.value, p.entry_point.group) for p in providers]
+            for name, providers in catalog.items()
+        }
+
     assert list(forward) == list(reversed_order) == ["acmedb", "otherdb"]
-    assert [p.distribution for p in forward["acmedb"]] == [p.distribution for p in reversed_order["acmedb"]]
+    assert full_metadata(forward) == full_metadata(reversed_order)
+    # secondary entry-point-value key breaks the tie between same-distribution providers
+    assert [(p.distribution, p.entry_point.value) for p in forward["acmedb"]] == [
+        ("alpha-dist", "alpha_mod:register"),
+        ("alpha-dist", "beta_mod:register"),
+        ("zeta-dist", "zeta_mod:register"),
+    ]
 
 
 def test_distribution_provenance_is_retained(install_entry_points):
@@ -252,13 +265,32 @@ def test_validation_failure_is_not_cached_and_retry_succeeds(monkeypatch):
 
 def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
     # the first worker to win the discovery lock blocks inside enumeration until the main thread
-    # releases it, so every other worker is deterministically contending on the lock while the
-    # catalog is still unbuilt; a non-serialized implementation would enumerate more than once
+    # releases it, and the lock is instrumented to count acquire attempts, so enumeration is only
+    # released once every other worker is provably blocked on the lock with the catalog still
+    # unbuilt; a non-serialized implementation would then enumerate more than once
     thread_count = 4
     start_barrier = threading.Barrier(thread_count + 1)
     first_entered = threading.Event()
+    all_workers_at_lock = threading.Event()
     release = threading.Event()
     calls = []
+
+    class CountingLock:
+        def __init__(self, inner):
+            self._inner = inner
+            self._count_guard = threading.Lock()
+            self._acquire_attempts = 0
+
+        def __enter__(self):
+            with self._count_guard:
+                self._acquire_attempts += 1
+                if self._acquire_attempts >= thread_count:
+                    all_workers_at_lock.set()
+            self._inner.acquire()
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
 
     def blocking_entry_points(*, group):
         calls.append(group)
@@ -267,6 +299,7 @@ def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
         return [FakeEntryPoint("acmedb")]
 
     monkeypatch.setattr(importlib.metadata, "entry_points", blocking_entry_points)
+    monkeypatch.setattr(_adapter_discovery, "_catalog_lock", CountingLock(threading.Lock()))
 
     results = []
     errors = []
@@ -283,6 +316,7 @@ def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
         thread.start()
     start_barrier.wait(timeout=30)
     assert first_entered.wait(timeout=30)
+    assert all_workers_at_lock.wait(timeout=30)
     release.set()
     for thread in threads:
         thread.join()

--- a/tests/test_adapter_discovery.py
+++ b/tests/test_adapter_discovery.py
@@ -186,6 +186,40 @@ def test_missing_or_malformed_distribution_fails(install_entry_points, dist):
     assert "acmedb" in str(excinfo.value)
 
 
+def test_raising_distribution_metadata_access_is_wrapped_with_context(install_entry_points):
+    original = RuntimeError("metadata read failed")
+
+    class RaisingDistEntryPoint(FakeEntryPoint):
+        @property
+        def dist(self):
+            raise original
+
+        @dist.setter
+        def dist(self, value):  # allow dataclass __init__ assignment
+            pass
+
+    install_entry_points([RaisingDistEntryPoint("acmedb")])
+    with pytest.raises(ValueError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert excinfo.value.__cause__ is original
+    assert "acmedb" in str(excinfo.value)
+    assert GROUP in str(excinfo.value)
+
+
+def test_iteration_time_enumeration_failure_is_wrapped(monkeypatch):
+    original = RuntimeError("iteration exploded")
+
+    def failing_iterable():
+        yield FakeEntryPoint("acmedb")
+        raise original
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda *, group: failing_iterable())
+    with pytest.raises(ValueError) as excinfo:
+        _adapter_discovery._get_provider_catalog()
+    assert excinfo.value.__cause__ is original
+    assert GROUP in str(excinfo.value)
+
+
 def test_enumeration_failure_preserves_cause_and_is_not_cached(monkeypatch):
     original = RuntimeError("metadata backend exploded")
 
@@ -217,17 +251,29 @@ def test_validation_failure_is_not_cached_and_retry_succeeds(monkeypatch):
 
 
 def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
-    thread_count = 8
-    barrier = threading.Barrier(thread_count)
-    fake = FakeEntryPoints([FakeEntryPoint("acmedb")])
-    monkeypatch.setattr(importlib.metadata, "entry_points", fake)
+    # the first worker to win the discovery lock blocks inside enumeration until the main thread
+    # releases it, so every other worker is deterministically contending on the lock while the
+    # catalog is still unbuilt; a non-serialized implementation would enumerate more than once
+    thread_count = 4
+    start_barrier = threading.Barrier(thread_count + 1)
+    first_entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def blocking_entry_points(*, group):
+        calls.append(group)
+        first_entered.set()
+        assert release.wait(timeout=30)
+        return [FakeEntryPoint("acmedb")]
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", blocking_entry_points)
 
     results = []
     errors = []
 
     def worker():
         try:
-            barrier.wait()
+            start_barrier.wait(timeout=30)
             results.append(_adapter_discovery._get_provider_catalog())
         except Exception as exc:  # pragma: no cover - failure reporting only
             errors.append(exc)
@@ -235,11 +281,15 @@ def test_concurrent_first_discovery_enumerates_exactly_once(monkeypatch):
     threads = [threading.Thread(target=worker) for _ in range(thread_count)]
     for thread in threads:
         thread.start()
+    start_barrier.wait(timeout=30)
+    assert first_entered.wait(timeout=30)
+    release.set()
     for thread in threads:
         thread.join()
 
     assert not errors
-    assert fake.calls == [GROUP]
+    assert calls == [GROUP]
+    assert len(results) == thread_count
     assert all(catalog is results[0] for catalog in results)
 
 


### PR DESCRIPTION
## What changed and why

First internal slice of #468 (v1 Milestone 2): a private, lazy discovery catalog for the exact `pydapper.adapters` entry-point group, built on the standard-library `importlib.metadata` API. Later slices will consume it for provider loading, precedence, and lazy `connect()`/`using()` integration — none of that is in this PR, and no public adapter-selection behavior changes.

- `pydapper/_adapter_discovery.py` — private module:
  - `_AdapterProviderDescriptor`: frozen dataclass retaining the exact entry-point name, the provider distribution's display name, and the original `EntryPoint` so the later loader slice can load it and apply first-party/external precedence.
  - `_get_provider_catalog()`: lazily builds and caches an immutable catalog (`MappingProxyType` of exact name → tuple of descriptors). Enumeration uses `entry_points(group="pydapper.adapters")` (valid on Python 3.10–3.14) plus an explicit `entry_point.group` post-filter.
  - Names mirror the #466 `register_adapter()` rules: strings only, non-empty, no surrounding whitespace; exact and case-sensitive, never normalized. Duplicate providers for one name are all retained; ordering is derived from stable metadata (`distribution`, then `entry_point.value`), so enumeration order can never influence later selection.
  - First discovery is serialized by a lock (exactly-once enumeration); failed or partially validated builds are never cached, and a corrected retry succeeds. Enumeration/metadata failures wrap in `ValueError` with the group or entry-point name and the original exception as `__cause__`.
  - Discovery never calls `EntryPoint.load()`, never invokes callbacks, never imports provider modules, and never mutates the adapter registry. Reset helper is private, for tests only.
- `tests/test_adapter_discovery.py` — 24 core-marked tests using local fakes and monkeypatched `importlib.metadata.entry_points`; covers exact group filtering, name rules (`AcmeDB` vs `acmedb`, `acme-db` vs `acme_db`), duplicate retention, order-independence with full-metadata comparison, provenance, cache immutability, failure-not-cached + retry, cause preservation, deterministic lock-contention concurrency proof (barriers/events, no sleeps), no-load/no-import/no-registry-mutation guarantees, and no new public package-root symbol.

## Behavior example

No public behavior changes. Internally, later slices can do:

```python
from pydapper._adapter_discovery import _get_provider_catalog
providers = _get_provider_catalog()["acmedb"]  # every provider retained, deterministic order
providers[0].entry_point  # original EntryPoint, ready for the loading slice
```

## Commands run

- `poetry run pytest tests/test_adapter_discovery.py` — 24 passed
- `poetry run pytest -m "core"` — 864 passed
- `poetry run pytest -m "sqlite"` — 29 passed
- `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
- `poetry run black --check .` / `poetry run isort --check .` — clean
- `git diff --check` — clean

Driver-specific suites (postgresql, mssql, mysql, oracle, bigquery) were skipped: this slice touches no backend code and needs no optional extras, containers, or services.

## Impact

No public API, typing, docs, packaging metadata, dependency, lockfile, or DSN-parsing changes. Coexists cleanly with concurrent #538 work (no shared files touched). Does not close #468 — remaining slices: provider loading/rollback, duplicate/precedence resolution, name-based lazy resolution in `connect()`/`using()`, automatic predicate selection, first-party entry-point conversion, and docs.

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)