### PR TITLE
feat: replace dsnparse with an owned URL DSN parser

### DIFF
--- a/docs/database_support/intro.md
+++ b/docs/database_support/intro.md
@@ -24,6 +24,89 @@ There are four core concepts to understand about each dbapi *pydapper* supports:
 
 
 
+## DSN format
+
+Connections managed by *pydapper* use URL-style DSNs with this grammar:
+
+```text
+<database>[+<adapter>]://[<user>[:<password>]@][<host>][:<port>]/<target>[?<query>][#<fragment>]
+```
+
+The scheme must follow the RFC URL-scheme rules: it starts with an ASCII letter and then contains only ASCII letters,
+digits, `+`, `-`, or `.`. A scheme has either one database component or one database and one adapter component. Empty
+components, underscores, and additional `+` components are invalid.
+
+A one-component scheme selects the database's default adapter:
+
+| database     | default adapter |
+|--------------|-----------------|
+| `postgresql` | `psycopg2`      |
+| `sqlite`     | `sqlite3`       |
+| `mssql`      | `pymssql`       |
+| `mysql`      | `mysql`         |
+| `oracle`     | `oracledb`      |
+| `bigquery`   | `google`        |
+
+These default database names should be written exactly as shown. An explicit scheme such as
+`postgresql+psycopg://...` uses the adapter component exactly as written. Adapter registration names are case-sensitive,
+so the explicit adapter spelling must exactly match the registered name. Explicit third-party schemes are supported:
+for example, `acme+acmedb://...` selects an adapter registered as `acmedb`, even though `acme` has no built-in default.
+An unknown one-component scheme is invalid because *pydapper* cannot derive an adapter. See
+[Adapter registration](../adapter_registration.md) for the registration and selection contract.
+
+Place the port after the host, not in the user information:
+
+```text
+postgresql+psycopg://myuser:mypassword@localhost:5432/mydb
+```
+
+Bracket IPv6 hosts so their colons cannot be confused with the port separator:
+
+```text
+postgresql://myuser:mypassword@[2001:db8::1]:5432/mydb
+```
+
+### Percent encoding
+
+URL delimiters are recognized before components are percent-decoded. Percent-encode reserved characters when they are
+data: for example, use `%40` for `@`, `%3A` for `:`, `%2F` for `/`, and `%20` for a space in credentials or paths. A
+literal colon after the first username/password separator remains part of the password, but encoding reserved characters
+is often clearer. Usernames, passwords, hosts, and paths are decoded before adapters receive them. A plus sign in a path
+or credential remains a plus sign; it is not decoded as a space.
+
+Percent-encoding does not make authority delimiters valid hostname data. After decoding, network hosts must still be
+valid hostnames, IPv4 addresses, or bracketed IPv6 literals; control characters and Unicode characters that normalize
+to delimiters such as `/`, `:`, `?`, `#`, or `@` are rejected.
+
+Queries use URL-query decoding rules. Keys and values are percent-decoded, `+` becomes a space, and `%2B` represents a
+literal plus sign. A key seen once maps to a string, a repeated key maps to a list in encounter order, and a blank value
+remains an empty string. Numeric-looking and boolean-looking values are not converted:
+
+```text
+?mode=read+only&tag=one&tag=two&empty=&code=001&enabled=true
+```
+
+produces:
+
+```python
+{
+    "mode": "read only",
+    "tag": ["one", "two"],
+    "empty": "",
+    "code": "001",
+    "enabled": "true",
+}
+```
+
+The parse result's `query` and `query_str` fields retain the original encoded substring without the leading `?`, while
+`query_params` contains the decoded mapping.
+
+### Credential safety
+
+Parsed credentials are available to adapters, but the parse result's representation and parser-generated errors redact
+them. The original DSN is still retained in the result's `dsn` field for equality and routing, so treat both the DSN and
+parse result as sensitive values and do not log them directly.
+
 ## Connection Management
 *pydapper* supports BYOC (bring your own connection) via the `using` entry point or will manage the connection
 lifecyle for you using `connect`.
@@ -32,7 +115,9 @@ lifecyle for you using `connect`.
 *connect* will manage the connection for you.  When instantiating connect using a context manager, *connect* will use
 the context manager that is implemented on the dbapi you are using.
 
-You can optionally not pass the dsn into *connect* and set the `PYDAPPER_DSN` environment variable instead.
+When no DSN argument is supplied, both *connect* and *connect_async* fall back to the `PYDAPPER_DSN` environment
+variable. An explicit DSN always takes precedence. Explicit empty or malformed input raises an error and is not silently
+replaced by the environment value.
 
 Below is a generic example of using *pydapper* to connect to `sqlite`.
 

--- a/docs/database_support/mssql.md
+++ b/docs/database_support/mssql.md
@@ -28,12 +28,12 @@ Supported drivers:
 
 === "Example"
     ```python
-    dsn = "mssql+pymssql://myuser:mypassword:1433@localhost/mydb"
+    dsn = "mssql+pymssql://myuser:mypassword@localhost:1433/mydb"
     ```
 
 === "Example (Default Driver)"
     ```python
-    dsn = "mssql://myuser:mypassword:1433@localhost/mydb"
+    dsn = "mssql://myuser:mypassword@localhost:1433/mydb"
     ```
 
 

--- a/docs/database_support/mysql.md
+++ b/docs/database_support/mysql.md
@@ -39,12 +39,12 @@ because that is the name of the actual package that is installed.
 
 === "Example"
     ```python
-    dsn = "mysql+mysql://myuser:mypassword:3306@localhost/mydb"
+    dsn = "mysql+mysql://myuser:mypassword@localhost:3306/mydb"
     ```
 
 === "Example (Default Driver)"
     ```python
-    dsn = "mysql://myuser:mypassword:3306@localhost/mydb"
+    dsn = "mysql://myuser:mypassword@localhost:3306/mydb"
     ```
 
 !!! note
@@ -63,4 +63,3 @@ Use *pydapper* with a `mysql-connector-python` connection pool.
 ```python
 {!docs/../docs_src/connections/mysql_connector_python_using.py!}
 ```
-

--- a/docs/database_support/oracle.md
+++ b/docs/database_support/oracle.md
@@ -30,12 +30,12 @@ Supported drivers:
 
 === "Example"
     ```python
-    dsn = "oracle+oracledb://myuser:mypassword:1521@localhost/myservicename"
+    dsn = "oracle+oracledb://myuser:mypassword@localhost:1521/myservicename"
     ```
 
 === "Example (Default Driver)"
     ```python
-    dsn = "oracle://myuser:mypassword:1521@localhost/myservicename"
+    dsn = "oracle://myuser:mypassword@localhost:1521/myservicename"
     ```
 
 !!! note

--- a/docs/database_support/postgresql.md
+++ b/docs/database_support/postgresql.md
@@ -29,12 +29,12 @@ Supported drivers:
 
 === "Example"
     ```python
-    dsn = "postgresql+psycopg2://myuser:mypassword:1521@localhost/mydb"
+    dsn = "postgresql+psycopg2://myuser:mypassword@localhost:5432/mydb"
     ```
 
 === "Example (Default Driver)"
     ```python
-    dsn = "postgresql://myuser:mypassword:1521@localhost/mydb"
+    dsn = "postgresql://myuser:mypassword@localhost:5432/mydb"
     ```
 
 ### Example - `connect`
@@ -88,7 +88,7 @@ async mode.
 
 === "Example"
     ```python
-    dsn = "postgresql+psycopg://myuser:mypassword:1521@localhost/mydb"
+    dsn = "postgresql+psycopg://myuser:mypassword@localhost:5432/mydb"
     ```
 
 ### Example - `connect`
@@ -151,7 +151,7 @@ separately from the `psycopg`, and is called `psycopg_pool`; it supports both sy
 
 === "Example"
     ```python
-    dsn = "postgresql+aiopg://myuser:mypassword:1521@localhost/mydb"
+    dsn = "postgresql+aiopg://myuser:mypassword@localhost:5432/mydb"
     ```
 
 ### Example - `connect_async`

--- a/docs/database_support/sqlite.md
+++ b/docs/database_support/sqlite.md
@@ -23,7 +23,7 @@ Supported drivers:
 ### DSN format
 === "Template"
     ```python
-    dsn = f"sqlite+sqlite3://{path_to_db}"
+    dsn = f"sqlite+sqlite3:///{relative_or_absolute_path_to_db}"
     ```
 
 === "Example"
@@ -35,6 +35,22 @@ Supported drivers:
     ```python
     dsn = "sqlite://my.db"
     ```
+
+SQLite slash counts distinguish relative and absolute paths. The connection target below is the value available as
+`database` / `dbname` and passed to `sqlite3.connect()`; the parse result's `path` remains the decoded URL path before
+this convenience normalization.
+
+| DSN                                      | SQLite connection target |
+|------------------------------------------|--------------------------|
+| `sqlite://relative.db`                   | `relative.db`            |
+| `sqlite+sqlite3://relative.db`           | `relative.db`            |
+| `sqlite:///relative/path.db`             | `relative/path.db`       |
+| `sqlite:////absolute/path.db`             | `/absolute/path.db`      |
+| `sqlite:///:memory:`                      | `:memory:`               |
+| `sqlite://`                               | empty string             |
+
+Paths are percent-decoded without treating plus signs as spaces. For example,
+`sqlite:///data/my%20database%23one.db` connects to `data/my database#one.db`.
 
 
 ### Example - `connect`

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 ## Latest Changes
 
+* v1: pydapper now owns its narrow URL-style DSN parser using the standard library's `urllib.parse`. A direct
+  implementation is smaller and lower risk than vendoring a generic parser API that pydapper does not consume. This
+  removes the mandatory `dsnparse` dependency, so it is no longer installed with pydapper, while preserving default and
+  exact explicit adapter routing, including third-party adapters. Parse-result fields now have accurate public types,
+  and representations and parser-generated errors no longer expose credential-bearing DSNs or passwords. Decoded
+  network hosts are revalidated so encoded controls and Unicode delimiter lookalikes cannot bypass authority parsing.
 * feat: add private lazy entry-point discovery catalog for pydapper.adapters. PR [#556](https://github.com/zschumacher/pydapper/pull/556) by [@zschumacher](https://github.com/zschumacher).
 * feat: validate capability declarations and add command preparation hooks. PR [#555](https://github.com/zschumacher/pydapper/pull/555) by [@zschumacher](https://github.com/zschumacher).
 * feat: validate adapter capability declarations and add command preparation hooks.
@@ -40,6 +46,16 @@
 
 ### Breaking Changes
 
+* DSNs now follow the focused `<database>[+<adapter>]://...` v1 grammar. Incidental inherited conveniences such as
+  `name=value` strings, constructor default injection, dict-like mutation, tuple-style iteration or indexing,
+  environment helpers, and multiple hosts are intentionally not reproduced. Multi-plus input such as
+  `db+adapter+extra://...` previously invented the adapter name `adapter_extra`; it is now rejected. Query values are no
+  longer implicitly coerced: for example,
+  `?code=001&enabled=true` previously produced `1` and `True` but now preserves `"001"` and `"true"`; a bare query key
+  such as `?flag` now maps to `{"flag": ""}` instead of raising. Corrected DSN examples place ports after the host;
+  literal and percent-encoded colons in passwords remain valid. SQLite slash counts are now explicit:
+  `sqlite:///relative/path.db` targets `relative/path.db`; use `sqlite:////absolute/path.db` for `/absolute/path.db`
+  (the three-slash form previously targeted `/relative/path.db`).
 * Command delegation: `query_first_or_default`, `query_single_or_default`, and their async
   equivalents now forward the normalized `options=` keyword to `query_first` /
   `query_single` (and the async equivalents) instead of validating and discarding it.

--- a/poetry.lock
+++ b/poetry.lock
@@ -669,17 +669,6 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
-name = "dsnparse"
-version = "0.2.1"
-description = "parse dsn urls"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "dsnparse-0.2.1.tar.gz", hash = "sha256:90956235967569c875994adbad0928c347a1592b5fc8ecd9c1b1a20397dae697"},
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -3167,4 +3156,4 @@ pymssql = ["pymssql", "types-pymssql"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "ac98938cc988dae3a7da6f361d464b8ebc7a1929060342029d34348b53e80a20"
+content-hash = "00d3c8097e31b6274d9e21a54c1c0841b6fb7e4d5dadcec1992555d874ead24d"

--- a/pydapper/dsn_parser.py
+++ b/pydapper/dsn_parser.py
@@ -1,9 +1,12 @@
-from typing import Dict
-
-import dsnparse
+import re
+import unicodedata
+from ipaddress import IPv6Address
+from urllib.parse import SplitResult as _SplitResult
+from urllib.parse import parse_qsl
+from urllib.parse import unquote
+from urllib.parse import urlsplit
 
 _DEFAULT_DB_API = {
-    # if the desired dbapi is not provided in scheme, fall back on sane defaults
     "postgresql": "psycopg2",
     "sqlite": "sqlite3",
     "mssql": "pymssql",
@@ -12,45 +15,280 @@ _DEFAULT_DB_API = {
     "bigquery": "google",
 }
 
+_RAW_SCHEME = re.compile(r"^([^:/?#]+):")
+_VALID_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
+_REG_NAME_ASCII_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&'()*+;=")
+_UNSAFE_HOST_CHARACTERS = frozenset("/?:#@[],\\")
+_IDNA_DOT_EQUIVALENTS = str.maketrans({"\u3002": ".", "\uff61": "."})
 
-class PydapperParseResult(dsnparse.ParseResult):
-    # noinspection PyUnresolvedReferences
-    def __init__(self, dsn: str, **defaults):
-        super().__init__(dsn, **defaults)
-        # make linters and editors happy
-        self.dsn: str = dsn
-        self.scheme: str = self.scheme
-        self.path: str = self.path
-        self.hostname: str = self.hostname
-        self.username: str = self.username
-        self.password: str = self.password
-        self.query_str: str = self.query
-        self.query_params: Dict[str, str] = self.query_params
-        self.port: str = self.port
-        self.fragment: str = self.fragment
 
-    def __repr__(self):
-        result = [f"instance({self.__class__.__name__}):"]
-        for k, v in vars(self).items():
-            result.append(f"\t{k}: {v!r}")
-        return "\n".join(result)
+def _split_url(dsn: str) -> _SplitResult:
+    invalid_authority = False
+    try:
+        result = urlsplit(dsn)
+    except (UnicodeError, ValueError):
+        invalid_authority = True
 
-    def __eq__(self, other):
+    if invalid_authority:
+        # urllib errors can include the complete netloc, including credentials.
+        # Raise outside the except block so the unsafe error is not retained as
+        # exception context.
+        raise ValueError("Invalid DSN authority")
+
+    return result
+
+
+def _parse_port(result: _SplitResult) -> int | None:
+    invalid_port = False
+    try:
+        port = result.port
+    except ValueError:
+        invalid_port = True
+
+    # urlsplit accepts a trailing colon as an absent port. In a pydapper DSN it
+    # is a supplied but structurally invalid port component.
+    if result.netloc.endswith(":"):
+        invalid_port = True
+
+    if invalid_port:
+        raise ValueError("Invalid DSN port")
+
+    return port
+
+
+def _parse_query_params(query: str) -> dict[str, str | list[str]]:
+    params: dict[str, str | list[str]] = {}
+    for key, value in parse_qsl(query, keep_blank_values=True):
+        if key not in params:
+            params[key] = value
+        else:
+            existing = params[key]
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                params[key] = [existing, value]
+    return params
+
+
+def _validate_hostname(hostname: str, encoded_hostname: str, netloc: str) -> None:
+    if any(unicodedata.category(character) in {"Cc", "Cf", "Cs"} for character in hostname):
+        raise ValueError("Invalid DSN authority; controls are not allowed in a host")
+    if any(character.isspace() for character in hostname):
+        raise ValueError("Invalid DSN authority; whitespace is not allowed in a host")
+
+    # urllib applies this safety check to the original authority, but encoded
+    # Unicode characters are still encoded at that point. Apply it again after
+    # decoding so NFKC-equivalent delimiters cannot bypass authority parsing.
+    normalized_without_colons = unicodedata.normalize("NFKC", hostname.replace(":", ""))
+    if any(character in _UNSAFE_HOST_CHARACTERS for character in normalized_without_colons):
+        raise ValueError("Invalid DSN authority; invalid delimiter in host")
+
+    if ":" in hostname or "[" in netloc or "]" in netloc:
+        invalid_ipv6 = False
+        try:
+            IPv6Address(hostname)
+        except ValueError:
+            invalid_ipv6 = True
+        # A colon introduced only by percent-decoding was data in an
+        # unbracketed reg-name, not valid IPv6 authority syntax.
+        if invalid_ipv6 or ":" not in encoded_hostname:
+            raise ValueError("Invalid DSN authority; IPv6 hosts must be bracketed literals")
+        return
+
+    normalized_hostname = unicodedata.normalize("NFKC", hostname).translate(_IDNA_DOT_EQUIVALENTS)
+    if any(character.isascii() and character not in _REG_NAME_ASCII_CHARACTERS for character in normalized_hostname):
+        raise ValueError("Invalid DSN authority; invalid character in host")
+
+    if not normalized_hostname.isascii():
+        if any(
+            not character.isascii() and unicodedata.category(character)[0] not in {"L", "M", "N"}
+            for character in normalized_hostname
+        ):
+            raise ValueError("Invalid DSN authority; invalid Unicode host")
+
+        invalid_idna = False
+        idna_hostname = ""
+        try:
+            idna_hostname = normalized_hostname.encode("idna").decode("ascii")
+        except UnicodeError:
+            invalid_idna = True
+        if invalid_idna or any(character not in _REG_NAME_ASCII_CHARACTERS for character in idna_hostname):
+            # Raise outside the except block so the rejected hostname is not
+            # kept in exception context.
+            raise ValueError("Invalid DSN authority; invalid Unicode host")
+
+
+class PydapperParseResult:
+    """The parsed, typed subset of URL-style DSNs supported by pydapper."""
+
+    __slots__ = (
+        "_database",
+        "_dbapi",
+        "_dbms",
+        "dsn",
+        "fragment",
+        "hostname",
+        "password",
+        "path",
+        "port",
+        "query",
+        "query_params",
+        "scheme",
+        "schemes",
+        "username",
+    )
+
+    dsn: str
+    scheme: str
+    schemes: list[str]
+    username: str | None
+    password: str | None
+    hostname: str | None
+    port: int | None
+    path: str
+    query: str
+    query_params: dict[str, str | list[str]]
+    fragment: str
+    _dbms: str
+    _dbapi: str
+    _database: str
+
+    def __init__(self, dsn: str):
+        if not isinstance(dsn, str):
+            raise TypeError("dsn must be a string")
+        if any(ord(character) < 32 or ord(character) == 127 for character in dsn):
+            raise ValueError("Invalid DSN syntax; raw control characters are not allowed")
+
+        scheme_match = _RAW_SCHEME.match(dsn)
+        if scheme_match is None:
+            raise ValueError("Invalid or missing DSN scheme")
+
+        scheme = scheme_match.group(1)
+        if _VALID_SCHEME.fullmatch(scheme) is None:
+            raise ValueError("Invalid DSN scheme")
+        if not dsn[scheme_match.end() :].startswith("//"):
+            raise ValueError("Invalid DSN scheme delimiter")
+
+        schemes = scheme.split("+")
+        if len(schemes) > 2 or any(not component for component in schemes):
+            raise ValueError("Invalid DSN scheme components; expected database[+adapter]")
+
+        dbms = schemes[0]
+        if len(schemes) == 2:
+            dbapi = schemes[1]
+        else:
+            dbapi = _DEFAULT_DB_API.get(dbms, "")
+            if not dbapi:
+                raise ValueError("Unknown DSN database scheme; no default adapter is available")
+
+        result = _split_url(dsn)
+        hostname = result.hostname
+        port = _parse_port(result)
+        if port is not None and hostname is None:
+            raise ValueError("Invalid DSN authority; a port requires a host")
+        decoded_hostname = unquote(hostname) if hostname is not None else None
+        sqlite_scheme = dbms.lower() == "sqlite"
+        if not sqlite_scheme and decoded_hostname is not None:
+            assert hostname is not None
+            if "," in decoded_hostname:
+                raise ValueError("Invalid DSN authority; multiple hosts are not supported")
+            _validate_hostname(decoded_hostname, hostname, result.netloc)
+
+        self.dsn = dsn
+        self.scheme = scheme
+        self.schemes = schemes
+        self._dbms = dbms
+        self._dbapi = dbapi
+        self.username = unquote(result.username) if result.username is not None else None
+        self.password = unquote(result.password) if result.password is not None else None
+        self.hostname = decoded_hostname
+        self.port = port
+        self.path = unquote(result.path)
+        self.query = result.query
+        self.query_params = _parse_query_params(result.query)
+        self.fragment = result.fragment
+        sqlite_authority = None
+        if (
+            sqlite_scheme
+            and result.netloc
+            and result.username is None
+            and result.password is None
+            and self.port is None
+            and ":" not in result.netloc
+        ):
+            # A SQLite authority is also the first filesystem path component.
+            # urlsplit correctly parses it as a host, but its hostname property
+            # is lowercased. Use the already parsed authority when it contains
+            # only that host so case-sensitive filenames retain their spelling.
+            sqlite_authority = unquote(result.netloc)
+        self._database = self._normalize_database(result.path, sqlite_authority)
+
+    def _normalize_database(self, encoded_path: str, sqlite_authority: str | None) -> str:
+        if self.dbms.lower() != "sqlite":
+            if self.hostname is None:
+                return self.path
+            return unquote(encoded_path.strip("/"))
+
+        if self.hostname is None:
+            # With an empty authority, the first slash belongs to URL syntax.
+            # Each additional slash is part of the SQLite filesystem target.
+            normalized_path = encoded_path[1:] if encoded_path.startswith("/") else encoded_path
+            return unquote(normalized_path)
+
+        authority = sqlite_authority if sqlite_authority is not None else self.hostname
+        assert authority is not None
+        path = unquote(encoded_path.strip("/"))
+        if not path:
+            return authority
+        return f"{authority}/{path}"
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(dsn='<redacted>', scheme={self.scheme!r}, "
+            f"dbms={self.dbms!r}, dbapi={self.dbapi!r}, hostname={self.hostname!r}, port={self.port!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PydapperParseResult):
+            return NotImplemented
         return self.dsn == other.dsn
 
     @property
     def dbms(self) -> str:
-        return self.schemes[0]
+        return self._dbms
 
     @property
     def dbapi(self) -> str:
-        if len(self.schemes) == 1:
-            dbapi = _DEFAULT_DB_API.get(self.dbms)
-        else:
-            dbapi = "_".join(self.schemes[1:])
-        if not dbapi:
-            raise ValueError(f"Could not derive dbapi from schemes {self.schemes}")
-        return dbapi
+        return self._dbapi
+
+    @property
+    def user(self) -> str | None:
+        return self.username
+
+    @property
+    def host(self) -> str | None:
+        return self.hostname
+
+    @property
+    def hostloc(self) -> str:
+        if self.hostname is None:
+            return ""
+        host = f"[{self.hostname}]" if ":" in self.hostname else self.hostname
+        if self.port is not None:
+            return f"{host}:{self.port}"
+        return host
+
+    @property
+    def database(self) -> str:
+        return self._database
+
+    @property
+    def dbname(self) -> str:
+        return self.database
+
+    @property
+    def query_str(self) -> str:
+        return self.query
 
 
 parse = PydapperParseResult

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -93,7 +93,8 @@ def register_adapter(
 
 
 def parse_dsn(dsn: str | None) -> PydapperParseResult:
-    dsn = dsn or os.getenv("PYDAPPER_DSN")
+    if dsn is None:
+        dsn = os.getenv("PYDAPPER_DSN")
     if dsn is None:  # pragma: no cover
         raise ValueError("dsn must be passed to connect or env var `PYDAPPER_DSN` must be set.")
     return PydapperParseResult(dsn)

--- a/pydapper/postgresql/aiopg.py
+++ b/pydapper/postgresql/aiopg.py
@@ -40,7 +40,7 @@ class AiopgCommands(CommandsAsync):
             user=parsed_dsn.username,
             password=parsed_dsn.password,
             host=parsed_dsn.host,
-            port=parsed_dsn.port if parsed_dsn.port else "5432",
+            port=parsed_dsn.port if parsed_dsn.port is not None else "5432",
             **connect_kwargs,
         )
         commands = cls(conn)

--- a/pydapper/postgresql/psycopg2.py
+++ b/pydapper/postgresql/psycopg2.py
@@ -21,7 +21,7 @@ class Psycopg2Commands(Commands):
             user=parsed_dsn.username,
             password=parsed_dsn.password,
             host=parsed_dsn.host,
-            port=parsed_dsn.port if parsed_dsn.port else "5432",
+            port=parsed_dsn.port if parsed_dsn.port is not None else "5432",
             **connect_kwargs,
         )
         return cls(conn)

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -23,7 +23,7 @@ class Psycopg3Commands(Commands):
             user=parsed_dsn.username,
             password=parsed_dsn.password,
             host=parsed_dsn.host,
-            port=parsed_dsn.port if parsed_dsn.port else "5432",
+            port=parsed_dsn.port if parsed_dsn.port is not None else "5432",
             **connect_kwargs,
         )
         return cls(conn)
@@ -40,7 +40,7 @@ class Psycopg3CommandsAsync(CommandsAsync):
             user=parsed_dsn.username,
             password=parsed_dsn.password,
             host=parsed_dsn.host,
-            port=parsed_dsn.port if parsed_dsn.port else "5432",
+            port=parsed_dsn.port if parsed_dsn.port is not None else "5432",
             **connect_kwargs,
         )
         return cls(conn)

--- a/pydapper/sqlite/sqlite3.py
+++ b/pydapper/sqlite/sqlite3.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 from sqlite3 import Cursor
 from typing import TYPE_CHECKING
@@ -21,9 +20,5 @@ class Sqlite3Commands(Commands):
 
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
-        db_path = parsed_dsn.host or ""
-        if parsed_dsn.database:
-            db_path = os.path.join(db_path, parsed_dsn.database)
-
-        conn = sqlite3.connect(db_path, **connect_kwargs)
+        conn = sqlite3.connect(parsed_dsn.database, **connect_kwargs)
         return cls(conn)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-dsnparse = "^0.2.1"
 
 ## postgresql
 psycopg = { extras = ["binary"], version = "^3.3.3", optional = true }
@@ -166,7 +165,3 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
 no_implicit_optional = false
-
-[[tool.mypy.overrides]]
-module = "dsnparse.*"
-ignore_missing_imports = true

--- a/tests/test_adapter_units.py
+++ b/tests/test_adapter_units.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from pydapper.bigquery import google_bigquery_client as bigquery_module
+from pydapper.dsn_parser import PydapperParseResult
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import NoResultException
 from pydapper.mssql import pymssql as mssql_module
@@ -71,7 +72,7 @@ def test_bigquery_connect_imports_dbapi_and_wraps_connection(monkeypatch):
     import_calls = patch_dbapi_import(monkeypatch, bigquery_module, "google.cloud.bigquery.dbapi", dbapi)
     client = object()
 
-    commands = bigquery_module.GoogleBigqueryClientCommands.connect(parsed_dsn(), client=client)
+    commands = bigquery_module.GoogleBigqueryClientCommands.connect(PydapperParseResult("bigquery:////"), client=client)
 
     assert isinstance(commands, bigquery_module.GoogleBigqueryClientCommands)
     assert commands.connection is dbapi.connection
@@ -119,6 +120,24 @@ def test_pymssql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
         }
     ]
     assert import_calls == ["pymssql"]
+
+
+@pytest.mark.parametrize(
+    ("module", "commands_class", "dbapi_name", "dsn"),
+    [
+        (mssql_module, mssql_module.PymssqlCommands, "pymssql", "mssql://host/database"),
+        (mysql_module, mysql_module.MySqlConnectorPythonCommands, "mysql.connector", "mysql://host/database"),
+    ],
+)
+def test_network_adapters_preserve_driver_default_behavior_for_an_absent_port(
+    monkeypatch, module, commands_class, dbapi_name, dsn
+):
+    dbapi = RecordingDbApi()
+    patch_dbapi_import(monkeypatch, module, dbapi_name, dbapi)
+
+    commands_class.connect(PydapperParseResult(dsn))
+
+    assert dbapi.calls[0]["port"] is None
 
 
 def test_mysql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
@@ -412,6 +431,22 @@ def test_oracledb_connect_imports_dbapi_and_wraps_connection(monkeypatch):
     assert import_calls == ["oracledb"]
 
 
+def test_oracledb_connect_forwards_ipv6_hostloc_and_decoded_parser_fields(monkeypatch):
+    dbapi = RecordingDbApi()
+    patch_dbapi_import(monkeypatch, oracle_module, "oracledb", dbapi)
+    dsn = PydapperParseResult("oracle+oracledb://ora%40user:p%3Ass%2Fword@[2001:db8::1]:1521/service%20name")
+
+    oracle_module.OracledbCommands.connect(dsn)
+
+    assert dbapi.calls == [
+        {
+            "user": "ora@user",
+            "password": "p:ss/word",
+            "dsn": "[2001:db8::1]:1521/service name",
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_aiopg_param_handler_emulates_executemany():
     class TrackingCursor:
@@ -476,6 +511,25 @@ async def test_aiopg_connect_imports_dbapi_and_wraps_connection(monkeypatch):
     assert import_calls == ["aiopg"]
 
 
+@pytest.mark.asyncio
+async def test_aiopg_connect_forwards_decoded_parser_fields_and_integer_port(monkeypatch):
+    dbapi = RecordingAsyncDbApi()
+    patch_dbapi_import(monkeypatch, aiopg_module, "aiopg", dbapi)
+    dsn = PydapperParseResult("postgresql+aiopg://async%40user:p%3Ass%2Fword@async-db.example:6544/async%20database")
+
+    await aiopg_module.AiopgCommands.connect_async(dsn)
+
+    assert dbapi.calls == [
+        {
+            "dbname": "async database",
+            "user": "async@user",
+            "password": "p:ss/word",
+            "host": "async-db.example",
+            "port": 6544,
+        }
+    ]
+
+
 def test_psycopg2_connect_imports_dbapi_and_wraps_connection(monkeypatch):
     dbapi = RecordingDbApi()
     import_calls = patch_dbapi_import(monkeypatch, psycopg2_module, "psycopg2", dbapi)
@@ -495,6 +549,42 @@ def test_psycopg2_connect_imports_dbapi_and_wraps_connection(monkeypatch):
         }
     ]
     assert import_calls == ["psycopg2"]
+
+
+def test_psycopg2_connect_forwards_decoded_parser_fields_and_integer_port(monkeypatch):
+    dbapi = RecordingDbApi()
+    patch_dbapi_import(monkeypatch, psycopg2_module, "psycopg2", dbapi)
+    dsn = PydapperParseResult("postgresql+psycopg2://sync%40user:p%3Ass%2Fword@sync-db.example:6543/sync%20database")
+
+    psycopg2_module.Psycopg2Commands.connect(dsn)
+
+    assert dbapi.calls == [
+        {
+            "dbname": "sync database",
+            "user": "sync@user",
+            "password": "p:ss/word",
+            "host": "sync-db.example",
+            "port": 6543,
+        }
+    ]
+
+
+def test_psycopg2_connect_preserves_a_supplied_zero_port(monkeypatch):
+    dbapi = RecordingDbApi()
+    patch_dbapi_import(monkeypatch, psycopg2_module, "psycopg2", dbapi)
+
+    psycopg2_module.Psycopg2Commands.connect(PydapperParseResult("postgresql://host:0/database"))
+
+    assert dbapi.calls[0]["port"] == 0
+
+
+def test_psycopg2_connect_preserves_its_default_for_a_real_parser_without_a_port(monkeypatch):
+    dbapi = RecordingDbApi()
+    patch_dbapi_import(monkeypatch, psycopg2_module, "psycopg2", dbapi)
+
+    psycopg2_module.Psycopg2Commands.connect(PydapperParseResult("postgresql://host/database"))
+
+    assert dbapi.calls[0]["port"] == "5432"
 
 
 def test_psycopg3_connect_imports_dbapi_and_wraps_connection(monkeypatch):
@@ -582,8 +672,13 @@ def test_sqlite_param_handler_uses_question_mark_placeholder():
 @pytest.mark.parametrize(
     "dsn, expected_path",
     [
-        (parsed_dsn(host="/tmp", database="app.db"), "/tmp/app.db"),
-        (parsed_dsn(host="/tmp/app.db", database=""), "/tmp/app.db"),
+        ("sqlite://relative.db", "relative.db"),
+        ("sqlite+sqlite3://relative.db", "relative.db"),
+        ("sqlite:///relative/path.db", "relative/path.db"),
+        ("sqlite:////absolute/path.db", "/absolute/path.db"),
+        ("sqlite:///:memory:", ":memory:"),
+        ("sqlite://", ""),
+        ("sqlite:///relative/my%20database.db", "relative/my database.db"),
     ],
 )
 def test_sqlite_connect_wraps_connection(monkeypatch, dsn, expected_path):
@@ -596,7 +691,7 @@ def test_sqlite_connect_wraps_connection(monkeypatch, dsn, expected_path):
 
     monkeypatch.setattr(sqlite_module.sqlite3, "connect", connect)
 
-    commands = sqlite_module.Sqlite3Commands.connect(dsn, isolation_level=None)
+    commands = sqlite_module.Sqlite3Commands.connect(PydapperParseResult(dsn), isolation_level=None)
 
     assert isinstance(commands, sqlite_module.Sqlite3Commands)
     assert commands.connection is connection

--- a/tests/test_dsn_parser.py
+++ b/tests/test_dsn_parser.py
@@ -46,6 +46,12 @@ def test_every_existing_and_documented_dsn_constructs(dsn):
     assert parsed.dsn == dsn
 
 
+@pytest.mark.parametrize("dsn", [None, 1, object()])
+def test_non_string_dsn_is_rejected(dsn):
+    with pytest.raises(TypeError):
+        PydapperParseResult(dsn)
+
+
 @pytest.mark.parametrize(
     ("dsn", "scheme", "schemes", "dbms", "dbapi"),
     [
@@ -354,6 +360,23 @@ def test_standard_idna_dot_equivalents_remain_valid(dsn):
     assert parsed.hostname in {"例え。テスト", "例え｡テスト"}
 
 
+def test_idna_encoding_error_is_credential_safe():
+    encoded_secret = "idna%3Asecret%2Fsentinel"
+    decoded_secret = "idna:secret/sentinel"
+    overlong_unicode_label = "é" * 64
+    dsn = f"postgresql://user:{encoded_secret}@{overlong_unicode_label}/database"
+
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    error_text = repr(exc_info.value)
+    assert "host" in error_text.lower() or "authority" in error_text.lower()
+    assert dsn not in error_text
+    assert encoded_secret not in error_text
+    assert decoded_secret not in error_text
+    assert exc_info.value.__context__ is None
+
+
 @pytest.mark.parametrize("hostname", ["a" * 64, "a..b", "foo_bar"])
 def test_valid_ascii_reg_names_are_not_restricted_by_dns_rules(hostname):
     parsed = PydapperParseResult(f"postgresql://{hostname}/database")
@@ -384,7 +407,8 @@ def test_path_uses_url_decoding_without_treating_plus_as_space():
 
 def test_query_text_and_decoded_parameters_preserve_strings_repeats_and_blanks():
     query = (
-        "single=value&repeat=first&repeat=second&blank=&bare&unicode=caf%C3%A9&space=a+b&literal_plus=a%2Bb"
+        "single=value&repeat=first&repeat=second&repeat=third&blank=&bare&unicode=caf%C3%A9&space=a+b"
+        "&literal_plus=a%2Bb"
         "&integer=001&decimal=1.5&true=true&false=false"
     )
     parsed = PydapperParseResult(f"postgresql://host/database?{query}")
@@ -393,7 +417,7 @@ def test_query_text_and_decoded_parameters_preserve_strings_repeats_and_blanks()
     assert parsed.query_str == query
     assert parsed.query_params == {
         "single": "value",
-        "repeat": ["first", "second"],
+        "repeat": ["first", "second", "third"],
         "blank": "",
         "bare": "",
         "unicode": "café",

--- a/tests/test_dsn_parser.py
+++ b/tests/test_dsn_parser.py
@@ -1,5 +1,3 @@
-from contextlib import ExitStack
-
 import pytest
 
 from pydapper.dsn_parser import PydapperParseResult
@@ -12,11 +10,13 @@ PYMSSQL_DSN = "mssql+pymssql://sa:pydapper!PYDAPPER@localhost:1433/master"
 MYSQL_CONNECTOR_PYTHON_DSN = "mysql+mysql://pydapper:pydapper@localhost:3307/pydapper"
 ORACLEDB_DSN = "oracle+oracledb://pydapper:pydapper@localhost:1522/pydapper"
 AIOPG_DSN = "postgresql+aiopg://pydapper:pydapper@localhost:5433/postgres"
+BIGQUERY_DSN = "bigquery+google:////"
 SQLITE_DEFAULT_DSN = "sqlite://some.db"
 POSTGRES_DEFAULT_DSN = "postgresql://pydapper:password@localhost:5433/postgres"
 MSSQL_DEFAULT_DSN = "mssql://sa:pydapper!PYDAPPER@localhost:1433/master"
 MYSQL_DEFAULT_DSN = "mysql://pydapper:pyapper@localhost:3307/pydapper"
 ORACLE_DEFAULT_DSN = "oracle://pydapper:pydapper@localhost:1522/pydapper"
+BIGQUERY_DEFAULT_DSN = "bigquery:////"
 
 
 ALL_DSNS = [
@@ -27,70 +27,466 @@ ALL_DSNS = [
     MYSQL_CONNECTOR_PYTHON_DSN,
     ORACLEDB_DSN,
     AIOPG_DSN,
+    BIGQUERY_DSN,
     SQLITE_DEFAULT_DSN,
     POSTGRES_DEFAULT_DSN,
     MSSQL_DEFAULT_DSN,
     MYSQL_DEFAULT_DSN,
     ORACLE_DEFAULT_DSN,
+    BIGQUERY_DEFAULT_DSN,
 ]
 
 pytestmark = pytest.mark.core
 
 
-class TestPydapperParseResult:
-    @pytest.mark.parametrize("dsn", ALL_DSNS)
-    def test__repr__(self, dsn):
-        parsed_dsn = PydapperParseResult(dsn)
-        assert parsed_dsn.__repr__()
-
-    @pytest.mark.parametrize(
-        "dsn, expected",
-        [
-            (SQLITE3_DSN, "sqlite"),
-            (PSYCOPG2_DSN, "postgresql"),
-            (PSYCOPG3_DSN, "postgresql"),
-            (PYMSSQL_DSN, "mssql"),
-            (MYSQL_CONNECTOR_PYTHON_DSN, "mysql"),
-            (ORACLEDB_DSN, "oracle"),
-            (AIOPG_DSN, "postgresql"),
-            (SQLITE_DEFAULT_DSN, "sqlite"),
-            (POSTGRES_DEFAULT_DSN, "postgresql"),
-            (MSSQL_DEFAULT_DSN, "mssql"),
-            (MYSQL_DEFAULT_DSN, "mysql"),
-            (ORACLE_DEFAULT_DSN, "oracle"),
-        ],
-    )
-    def test_dbms(self, dsn, expected):
-        parsed_dsn = PydapperParseResult(dsn)
-        assert parsed_dsn.dbms == expected
-
-    @pytest.mark.parametrize(
-        "dsn, expected",
-        [
-            (SQLITE3_DSN, "sqlite3"),
-            (PSYCOPG2_DSN, "psycopg2"),
-            (PSYCOPG3_DSN, "psycopg"),
-            (PYMSSQL_DSN, "pymssql"),
-            (MYSQL_CONNECTOR_PYTHON_DSN, "mysql"),
-            (ORACLEDB_DSN, "oracledb"),
-            (AIOPG_DSN, "aiopg"),
-            (SQLITE_DEFAULT_DSN, "sqlite3"),
-            (POSTGRES_DEFAULT_DSN, "psycopg2"),
-            (MSSQL_DEFAULT_DSN, "pymssql"),
-            (MYSQL_DEFAULT_DSN, "mysql"),
-            (ORACLE_DEFAULT_DSN, "oracledb"),
-            ("postgresql+://locahost:5432/postgres", ValueError),
-        ],
-    )
-    def test_db_api(self, dsn, expected):
-        parsed_dsn = PydapperParseResult(dsn)
-        with ExitStack() as stack:
-            if not isinstance(expected, str) and issubclass(expected, Exception):
-                stack.enter_context(pytest.raises(expected))
-            assert parsed_dsn.dbapi == expected
-
-
 @pytest.mark.parametrize("dsn", ALL_DSNS)
-def test_parse(dsn):
+def test_every_existing_and_documented_dsn_constructs(dsn):
     parsed = PydapperParseResult(dsn)
-    assert parsed == parse(dsn)
+
+    assert parsed.dsn == dsn
+
+
+@pytest.mark.parametrize(
+    ("dsn", "scheme", "schemes", "dbms", "dbapi"),
+    [
+        (SQLITE3_DSN, "sqlite+sqlite3", ["sqlite", "sqlite3"], "sqlite", "sqlite3"),
+        (PSYCOPG2_DSN, "postgresql+psycopg2", ["postgresql", "psycopg2"], "postgresql", "psycopg2"),
+        (PSYCOPG3_DSN, "postgresql+psycopg", ["postgresql", "psycopg"], "postgresql", "psycopg"),
+        (AIOPG_DSN, "postgresql+aiopg", ["postgresql", "aiopg"], "postgresql", "aiopg"),
+        (PYMSSQL_DSN, "mssql+pymssql", ["mssql", "pymssql"], "mssql", "pymssql"),
+        (MYSQL_CONNECTOR_PYTHON_DSN, "mysql+mysql", ["mysql", "mysql"], "mysql", "mysql"),
+        (ORACLEDB_DSN, "oracle+oracledb", ["oracle", "oracledb"], "oracle", "oracledb"),
+        (BIGQUERY_DSN, "bigquery+google", ["bigquery", "google"], "bigquery", "google"),
+        (SQLITE_DEFAULT_DSN, "sqlite", ["sqlite"], "sqlite", "sqlite3"),
+        (POSTGRES_DEFAULT_DSN, "postgresql", ["postgresql"], "postgresql", "psycopg2"),
+        (MSSQL_DEFAULT_DSN, "mssql", ["mssql"], "mssql", "pymssql"),
+        (MYSQL_DEFAULT_DSN, "mysql", ["mysql"], "mysql", "mysql"),
+        (ORACLE_DEFAULT_DSN, "oracle", ["oracle"], "oracle", "oracledb"),
+        (BIGQUERY_DEFAULT_DSN, "bigquery", ["bigquery"], "bigquery", "google"),
+    ],
+)
+def test_default_and_explicit_adapter_routing(dsn, scheme, schemes, dbms, dbapi):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.scheme == scheme
+    assert parsed.schemes == schemes
+    assert parsed.dbms == dbms
+    assert parsed.dbapi == dbapi
+
+
+def test_explicit_third_party_adapter_preserves_exact_scheme_spelling():
+    parsed = PydapperParseResult("Acme+AcmeDB://Host/Database")
+
+    assert parsed.scheme == "Acme+AcmeDB"
+    assert parsed.schemes == ["Acme", "AcmeDB"]
+    assert parsed.dbms == "Acme"
+    assert parsed.dbapi == "AcmeDB"
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "",
+        "relative.db",
+        "://host/database",
+        "1postgresql://host/database",
+        "some_db+tests://host/database",
+        "postgresql+://host/database",
+        "postgresql++psycopg://host/database",
+        "postgresql+psycopg+extra://host/database",
+        "postgresql:/database",
+        "postgresql:database",
+        "PostgreSQL://host/database",
+        "dbname=postgres user=pydapper",
+    ],
+)
+def test_missing_or_malformed_schemes_are_rejected_during_construction(dsn):
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    assert "scheme" in str(exc_info.value).lower()
+
+
+def test_unknown_one_component_scheme_is_rejected_during_construction():
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult("unknown://host/database")
+
+    assert "scheme" in str(exc_info.value).lower()
+    assert "adapter" in str(exc_info.value).lower()
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected_path", "expected_database"),
+    [
+        ("sqlite://relative.db", "", "relative.db"),
+        ("sqlite+sqlite3://relative.db", "", "relative.db"),
+        ("sqlite:///relative/path.db", "/relative/path.db", "relative/path.db"),
+        ("sqlite:////absolute/path.db", "//absolute/path.db", "/absolute/path.db"),
+        ("sqlite:///:memory:", "/:memory:", ":memory:"),
+        ("sqlite://", "", ""),
+        ("sqlite:///relative/my%20file%2Bname.db", "/relative/my file+name.db", "relative/my file+name.db"),
+        ("sqlite://Relative%20File.db", "", "Relative File.db"),
+        ("sqlite://directory/nested%20file.db", "/nested file.db", "directory/nested file.db"),
+    ],
+)
+def test_sqlite_database_is_the_final_normalized_connection_target(dsn, expected_path, expected_database):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.path == expected_path
+    assert parsed.database == expected_database
+    assert parsed.dbname == expected_database
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected_host", "expected_path", "expected_database"),
+    [
+        ("postgresql://host/database", "host", "/database", "database"),
+        ("mysql://host/", "host", "/", ""),
+        ("mssql://host", "host", "", ""),
+        ("oracle://host/service%20name", "host", "/service name", "service name"),
+        ("bigquery:////", None, "//", "//"),
+        ("postgresql:///local%20database", None, "/local database", "/local database"),
+        ("acme+driver://host/database%2Fname", "host", "/database/name", "database/name"),
+    ],
+)
+def test_non_sqlite_database_normalization_preserves_host_distinctions(
+    dsn, expected_host, expected_path, expected_database
+):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.host == expected_host
+    assert parsed.path == expected_path
+    assert parsed.database == expected_database
+    assert parsed.dbname == expected_database
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected_path", "expected_database"),
+    [
+        ("postgresql://host/%2Fdatabase%2F", "//database/", "/database/"),
+        ("sqlite:///%2Frelative%2F", "//relative/", "/relative/"),
+        ("sqlite://directory/%2Ffile%2F", "//file/", "directory//file/"),
+    ],
+)
+def test_database_normalization_removes_url_delimiters_before_percent_decoding(dsn, expected_path, expected_database):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.path == expected_path
+    assert parsed.database == expected_database
+
+
+@pytest.mark.parametrize(
+    ("authority", "expected_username", "expected_password"),
+    [
+        ("host", None, None),
+        ("user@host", "user", None),
+        ("user:@host", "user", ""),
+        (":password@host", "", "password"),
+        ("@host", "", None),
+        ("user:part:secret@host", "user", "part:secret"),
+        ("user:part%3Asecret@host", "user", "part:secret"),
+        ("user%3Aname:password@host", "user:name", "password"),
+        ("us%40er:p%40ss%3Aword%2Fend@host", "us@er", "p@ss:word/end"),
+        ("user%2Fname:p%C3%A4ssword@host", "user/name", "pässword"),
+    ],
+)
+def test_user_information_is_delimited_before_percent_decoding(authority, expected_username, expected_password):
+    parsed = PydapperParseResult(f"postgresql://{authority}/database")
+
+    assert parsed.username == expected_username
+    assert parsed.user == expected_username
+    assert parsed.password == expected_password
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected_hostname", "expected_port", "expected_hostloc"),
+    [
+        ("postgresql://Example.COM/database", "example.com", None, "example.com"),
+        ("postgresql://127.0.0.1:5432/database", "127.0.0.1", 5432, "127.0.0.1:5432"),
+        ("postgresql://db%2Dhost:0/database", "db-host", 0, "db-host:0"),
+        ("postgresql://host:65535/database", "host", 65535, "host:65535"),
+        ("oracle://[2001:db8::1]:1521/service", "2001:db8::1", 1521, "[2001:db8::1]:1521"),
+        ("oracle://[2001:db8::1]/service", "2001:db8::1", None, "[2001:db8::1]"),
+        ("bigquery:////", None, None, ""),
+    ],
+)
+def test_host_port_and_hostloc(dsn, expected_hostname, expected_port, expected_hostloc):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.hostname == expected_hostname
+    assert parsed.host == expected_hostname
+    assert parsed.port == expected_port
+    assert parsed.hostloc == expected_hostloc
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://host:not-a-number/database",
+        "postgresql://host:-1/database",
+        "postgresql://host:65536/database",
+        "postgresql://host:12:34/database",
+        "postgresql://host:/database",
+        "postgresql://:5432/database",
+    ],
+)
+def test_invalid_ports_are_rejected_during_construction(dsn):
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    message = str(exc_info.value).lower()
+    assert "port" in message or "authority" in message
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://host:\n5432/database",
+        "postgresql://host:54\t32/database",
+        "postgresql://host:\r5432/database",
+        "postgresql://user:control\x00secret@host/database",
+    ],
+)
+def test_raw_control_characters_are_rejected_before_url_parsing(dsn):
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    error_text = repr(exc_info.value)
+    assert "control" in error_text.lower() or "syntax" in error_text.lower()
+    assert "control\x00secret" not in error_text
+    assert exc_info.value.__context__ is None
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://host name/database",
+        "postgresql://host%20name/database",
+        "postgresql://[v1.future]:5432/database",
+        "postgresql://[v1.foo:bar]/database",
+        "postgresql://host%3A5432/database",
+        "postgresql://2001%3Adb8%3A%3A1/database",
+        "postgresql://%5Bnot-ip%5D/database",
+        "postgresql://host%2Fname/database",
+        "postgresql://host%40name/database",
+    ],
+)
+def test_unsupported_or_malformed_host_syntax_is_rejected(dsn):
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    assert "host" in str(exc_info.value).lower() or "authority" in str(exc_info.value).lower()
+
+
+@pytest.mark.parametrize(
+    "encoded_host",
+    [
+        "host%EF%BC%9A5432",
+        "host%EF%BC%8Fname",
+        "host%EF%BC%9Fquery",
+        "host%EF%BC%83fragment",
+        "host%EF%BC%A0name",
+        "host%EF%BC%8Cother",
+        "%EF%BC%BBnot-ip%EF%BC%BD",
+        "host%EF%BC%BCname",
+        "host%E2%84%80name",
+        "host%5Bname",
+        "host%5Dname",
+        "host%5Cname",
+        "host%3Fname",
+        "host%23name",
+        "host%00name",
+        "host%1Fname",
+        "host%7Fname",
+        "host%C2%85name",
+        "host%ED%A0%80name",
+        "host%FFname",
+        "host%ZZname",
+        "%F0%9F%98%80.example",
+        "a%E2%81%84b.example",
+        "a%E2%88%95b.example",
+    ],
+)
+def test_encoded_unicode_delimiters_and_controls_are_rejected_safely(encoded_host):
+    encoded_secret = "unicode%3Asecret%2Fsentinel"
+    decoded_secret = "unicode:secret/sentinel"
+    dsn = f"postgresql://user:{encoded_secret}@{encoded_host}/database"
+
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    error_text = repr(exc_info.value)
+    assert "host" in error_text.lower() or "authority" in error_text.lower()
+    assert dsn not in error_text
+    assert encoded_secret not in error_text
+    assert decoded_secret not in error_text
+    assert exc_info.value.__context__ is None
+
+
+def test_literal_surrogate_in_host_is_rejected_safely():
+    dsn = "postgresql://user:surrogate-secret@host\ud800/database"
+
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    assert "host" in str(exc_info.value).lower() or "authority" in str(exc_info.value).lower()
+    assert "surrogate-secret" not in repr(exc_info.value)
+    assert exc_info.value.__context__ is None
+
+
+def test_encoded_unicode_hostname_remains_decoded():
+    parsed = PydapperParseResult("postgresql://m%C3%BCnich.example/database")
+
+    assert parsed.hostname == "münich.example"
+    assert parsed.hostloc == "münich.example"
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://例え。テスト/database",
+        "postgresql://%E4%BE%8B%E3%81%88%EF%BD%A1%E3%83%86%E3%82%B9%E3%83%88/database",
+    ],
+)
+def test_standard_idna_dot_equivalents_remain_valid(dsn):
+    parsed = PydapperParseResult(dsn)
+
+    assert parsed.hostname in {"例え。テスト", "例え｡テスト"}
+
+
+@pytest.mark.parametrize("hostname", ["a" * 64, "a..b", "foo_bar"])
+def test_valid_ascii_reg_names_are_not_restricted_by_dns_rules(hostname):
+    parsed = PydapperParseResult(f"postgresql://{hostname}/database")
+
+    assert parsed.hostname == hostname
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://host-one,host-two/database",
+        "postgresql://host-one%2Chost-two/database",
+    ],
+)
+def test_multiple_hosts_are_not_supported(dsn):
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    assert "host" in str(exc_info.value).lower() or "authority" in str(exc_info.value).lower()
+
+
+def test_path_uses_url_decoding_without_treating_plus_as_space():
+    parsed = PydapperParseResult("postgresql://host/my+database%20name")
+
+    assert parsed.path == "/my+database name"
+    assert parsed.database == "my+database name"
+
+
+def test_query_text_and_decoded_parameters_preserve_strings_repeats_and_blanks():
+    query = (
+        "single=value&repeat=first&repeat=second&blank=&bare&unicode=caf%C3%A9&space=a+b&literal_plus=a%2Bb"
+        "&integer=001&decimal=1.5&true=true&false=false"
+    )
+    parsed = PydapperParseResult(f"postgresql://host/database?{query}")
+
+    assert parsed.query == query
+    assert parsed.query_str == query
+    assert parsed.query_params == {
+        "single": "value",
+        "repeat": ["first", "second"],
+        "blank": "",
+        "bare": "",
+        "unicode": "café",
+        "space": "a b",
+        "literal_plus": "a+b",
+        "integer": "001",
+        "decimal": "1.5",
+        "true": "true",
+        "false": "false",
+    }
+    assert all(
+        isinstance(value, (str, list)) and (not isinstance(value, list) or all(isinstance(item, str) for item in value))
+        for value in parsed.query_params.values()
+    )
+
+
+def test_query_keys_are_decoded_and_repeated_in_encounter_order():
+    parsed = PydapperParseResult("postgresql://host/database?na%6De=one&name=two&%E2%9C%93=yes")
+
+    assert parsed.query_params == {"name": ["one", "two"], "✓": "yes"}
+
+
+def test_fragment_is_preserved_as_encoded_text():
+    parsed = PydapperParseResult("postgresql://host/database#fragment%20value")
+
+    assert parsed.fragment == "fragment%20value"
+
+
+def test_equality_uses_the_raw_dsn_and_handles_unrelated_objects():
+    dsn = "postgresql://host/database"
+
+    assert PydapperParseResult(dsn) == PydapperParseResult(dsn)
+    assert PydapperParseResult(dsn) != PydapperParseResult(f"{dsn}?option=value")
+    assert PydapperParseResult(dsn) != object()
+
+
+def test_repr_redacts_raw_encoded_and_decoded_credentials():
+    encoded_secret = "repr%3Asecret%2Fsentinel"
+    decoded_secret = "repr:secret/sentinel"
+    dsn = f"postgresql://user:{encoded_secret}@database.example/app"
+
+    representation = repr(PydapperParseResult(dsn))
+
+    assert "PydapperParseResult" in representation
+    assert "<redacted>" in representation
+    assert dsn not in representation
+    assert encoded_secret not in representation
+    assert decoded_secret not in representation
+
+
+@pytest.mark.parametrize(
+    ("dsn", "component"),
+    [
+        ("some_bad://user:error%3Asecret%2Fsentinel@host/database", "scheme"),
+        ("postgresql://user:error%3Asecret%2Fsentinel@host:bad/database", "port"),
+        ("postgresql://user:error%3Asecret%2Fsentinel@[2001:db8::1/database", "authority"),
+        ("postgresql://user:error%3Asecret%2Fsentinel@host／unsafe/database", "authority"),
+    ],
+)
+def test_parser_errors_identify_the_component_without_retaining_credentials(dsn, component):
+    encoded_secret = "error%3Asecret%2Fsentinel"
+    decoded_secret = "error:secret/sentinel"
+
+    with pytest.raises(ValueError) as exc_info:
+        PydapperParseResult(dsn)
+
+    error_text = repr(exc_info.value)
+    assert component in error_text.lower()
+    assert dsn not in error_text
+    assert encoded_secret not in error_text
+    assert decoded_secret not in error_text
+    assert exc_info.value.__context__ is None
+
+
+def test_parse_is_the_public_class_alias():
+    dsn = "postgresql://host/database"
+
+    assert parse is PydapperParseResult
+    assert isinstance(parse(dsn), PydapperParseResult)
+    assert parse(dsn) == PydapperParseResult(dsn)
+
+
+def test_unconsumed_dsnparse_conveniences_are_not_part_of_the_result():
+    parsed = PydapperParseResult("postgresql://host/database")
+
+    for name in ("fields", "geturl", "parser", "paths", "setdefault"):
+        assert not hasattr(parsed, name)
+    with pytest.raises(TypeError):
+        iter(parsed)
+    with pytest.raises(TypeError):
+        parsed[0]  # type: ignore[index]
+
+
+def test_constructor_default_injection_is_not_supported():
+    with pytest.raises(TypeError):
+        PydapperParseResult("postgresql://host/database", port=5432)  # type: ignore[call-arg]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ from tests.mocks import MockAsyncConnection
 from tests.mocks import MockCommands
 from tests.mocks import MockConnection
 
-DSN = "some_db+tests://localhost"
+DSN = "somedb+tests://localhost"
 
 pytestmark = pytest.mark.core
 
@@ -483,16 +483,155 @@ async def test_connect_async_uses_the_environment_dsn_fallback(adapter_registry,
     assert isinstance(await pydapper.connect_async(), MockAsyncCommands)
 
 
+def test_explicit_dsn_takes_precedence_over_environment_for_connect(adapter_registry, monkeypatch):
+    class EnvironmentCommands(MockCommands): ...
+
+    class ExplicitCommands(MockCommands): ...
+
+    pydapper.register_adapter(
+        "environment",
+        commands=EnvironmentCommands,
+        using_connection_predicate=never_matches,
+    )
+    pydapper.register_adapter(
+        "explicit",
+        commands=ExplicitCommands,
+        using_connection_predicate=never_matches,
+    )
+    monkeypatch.setenv("PYDAPPER_DSN", "somedb+environment://localhost")
+
+    assert isinstance(pydapper.connect("somedb+explicit://localhost"), ExplicitCommands)
+
+
+@pytest.mark.asyncio
+async def test_explicit_dsn_takes_precedence_over_environment_for_connect_async(adapter_registry, monkeypatch):
+    class EnvironmentCommands(MockAsyncCommands): ...
+
+    class ExplicitCommands(MockAsyncCommands): ...
+
+    pydapper.register_adapter(
+        "environment",
+        async_commands=EnvironmentCommands,
+        using_connection_predicate=never_matches,
+    )
+    pydapper.register_adapter(
+        "explicit",
+        async_commands=ExplicitCommands,
+        using_connection_predicate=never_matches,
+    )
+    monkeypatch.setenv("PYDAPPER_DSN", "somedb+environment://localhost")
+
+    assert isinstance(await pydapper.connect_async("somedb+explicit://localhost"), ExplicitCommands)
+
+
+@pytest.mark.parametrize("factory", [pydapper.connect, pydapper.connect_async])
+@pytest.mark.parametrize("invalid_dsn", ["", "missing-scheme"])
+def test_invalid_explicit_dsn_is_not_replaced_by_environment(
+    adapter_registry,
+    monkeypatch,
+    factory,
+    invalid_dsn,
+):
+    pydapper.register_adapter(
+        "environment",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
+    monkeypatch.setenv("PYDAPPER_DSN", "somedb+environment://localhost")
+
+    with pytest.raises(ValueError):
+        factory(invalid_dsn)
+
+
+@pytest.mark.parametrize("factory", [pydapper.connect, pydapper.connect_async])
+@pytest.mark.parametrize("environment_dsn", ["", "missing-scheme"])
+def test_invalid_environment_dsn_is_rejected(adapter_registry, monkeypatch, factory, environment_dsn):
+    monkeypatch.setenv("PYDAPPER_DSN", environment_dsn)
+
+    with pytest.raises(ValueError):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("dsn", "adapter_name"),
+    [
+        ("sqlite://routing.db", "sqlite3"),
+        ("postgresql://user:password@localhost/database", "psycopg2"),
+        ("mssql://user:password@localhost/database", "pymssql"),
+        ("mysql://user:password@localhost/database", "mysql"),
+        ("oracle://user:password@localhost/database", "oracledb"),
+        ("bigquery:////", "google"),
+        ("sqlite+sqlite3://routing.db", "sqlite3"),
+        ("postgresql+psycopg://user:password@localhost/database", "psycopg"),
+    ],
+)
+def test_connect_routes_default_and_explicit_dsn_adapter_names(adapter_registry, dsn, adapter_name):
+    registration = adapter_registry[adapter_name]
+    adapter_registry[adapter_name] = main._AdapterRegistration(
+        name=registration.name,
+        commands=MockCommands,
+        async_commands=registration.async_commands,
+        using_connection_predicate=registration.using_connection_predicate,
+    )
+
+    assert isinstance(pydapper.connect(dsn), MockCommands)
+
+
+@pytest.mark.parametrize(
+    ("dsn", "adapter_name"),
+    [
+        ("postgresql+psycopg://user:password@localhost/database", "psycopg"),
+        ("postgresql+aiopg://user:password@localhost/database", "aiopg"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_connect_async_routes_explicit_dsn_adapter_names(adapter_registry, dsn, adapter_name):
+    registration = adapter_registry[adapter_name]
+    adapter_registry[adapter_name] = main._AdapterRegistration(
+        name=registration.name,
+        commands=registration.commands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=registration.using_connection_predicate,
+    )
+
+    assert isinstance(await pydapper.connect_async(dsn), MockAsyncCommands)
+
+
+@pytest.mark.asyncio
+async def test_third_party_explicit_adapter_name_routes_exactly_for_sync_and_async(adapter_registry):
+    class AcmeCommands(MockCommands): ...
+
+    class AcmeCommandsAsync(MockAsyncCommands): ...
+
+    pydapper.register_adapter(
+        "AcmeDB",
+        commands=AcmeCommands,
+        async_commands=AcmeCommandsAsync,
+        using_connection_predicate=never_matches,
+    )
+
+    assert isinstance(pydapper.connect("acme+AcmeDB://localhost/database"), AcmeCommands)
+    assert isinstance(await pydapper.connect_async("acme+AcmeDB://localhost/database"), AcmeCommandsAsync)
+
+
+def test_default_dsn_adapter_still_checks_requested_mode(adapter_registry):
+    with pytest.raises(ValueError, match="psycopg2") as exc_info:
+        pydapper.connect_async("postgresql://user:password@localhost/database")
+
+    assert "async" in str(exc_info.value)
+
+
 def test_connect_rejects_an_unknown_dsn_adapter(adapter_registry):
     with pytest.raises(ValueError, match="unknown") as exc_info:
-        pydapper.connect("some_db+unknown://localhost")
+        pydapper.connect("somedb+unknown://localhost")
 
     assert "sync" in str(exc_info.value)
 
 
 def test_connect_async_rejects_an_unknown_dsn_adapter(adapter_registry):
     with pytest.raises(ValueError, match="unknown") as exc_info:
-        pydapper.connect_async("some_db+unknown://localhost")
+        pydapper.connect_async("somedb+unknown://localhost")
 
     assert "async" in str(exc_info.value)
 
@@ -501,7 +640,7 @@ def test_connect_async_rejects_an_adapter_without_async_support(adapter_registry
     pydapper.register_adapter("sync-only", commands=MockCommands, using_connection_predicate=never_matches)
 
     with pytest.raises(ValueError, match="sync-only") as exc_info:
-        pydapper.connect_async("some_db+sync-only://localhost")
+        pydapper.connect_async("somedb+sync-only://localhost")
 
     assert "async" in str(exc_info.value)
 
@@ -514,7 +653,7 @@ def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
     )
 
     with pytest.raises(ValueError, match="async-only") as exc_info:
-        pydapper.connect("some_db+async-only://localhost")
+        pydapper.connect("somedb+async-only://localhost")
 
     assert "sync" in str(exc_info.value)
 

--- a/tests/test_mssql/test_pymssql.py
+++ b/tests/test_mssql/test_pymssql.py
@@ -37,7 +37,7 @@ def test_using(server, database_name, db_port):
         assert isinstance(commands, PymssqlCommands)
 
 
-@pytest.mark.parametrize("driver", ["mssql", "mysql+pymssql"])
+@pytest.mark.parametrize("driver", ["mssql", "mssql+pymssql"])
 def test_connect(driver, database_name, server, db_port):
     with connect(f"{driver}://sa:pydapper!PYDAPPER@{server}:{db_port}/{database_name}") as commands:
         assert isinstance(commands, PymssqlCommands)

--- a/tests/test_sqlite/test_sqlite3.py
+++ b/tests/test_sqlite/test_sqlite3.py
@@ -33,7 +33,7 @@ def test_using(database_name):
 
 @pytest.mark.parametrize("driver", ["sqlite", "sqlite+sqlite3"])
 def test_connect_subfolder(driver, database_name, setup_sql_dir):
-    with connect(f"{driver}://{setup_sql_dir}{os.path.sep}{database_name}.db") as commands:
+    with connect(f"{driver}:///{setup_sql_dir}{os.path.sep}{database_name}.db") as commands:
         assert isinstance(commands, Sqlite3Commands)
 
 

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -18,6 +18,8 @@ import pydapper
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands as PydapperCommands
 from pydapper.commands import CommandsAsync as PydapperCommandsAsync
+from pydapper.dsn_parser import PydapperParseResult
+from pydapper.dsn_parser import parse
 from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
@@ -114,6 +116,34 @@ def public_exceptions() -> None:
     assert_type(InvalidParameterShapeException(), InvalidParameterShapeException)
     assert_type(UnsupportedFeatureError(), UnsupportedFeatureError)
     assert_type(RowMappingException(), RowMappingException)
+
+
+def dsn_parser_types() -> None:
+    parsed = PydapperParseResult("postgresql://user:password@localhost:5432/database?key=value")
+    parsed_from_alias = parse("postgresql+psycopg://localhost/database")
+
+    assert_type(parsed, PydapperParseResult)
+    assert_type(parsed_from_alias, PydapperParseResult)
+    assert_type(parsed.dsn, str)
+    assert_type(parsed.scheme, str)
+    assert_type(parsed.schemes, List[str])
+    assert_type(parsed.dbms, str)
+    assert_type(parsed.dbapi, str)
+    assert_type(parsed.username, Union[str, None])
+    assert_type(parsed.user, Union[str, None])
+    assert_type(parsed.password, Union[str, None])
+    assert_type(parsed.hostname, Union[str, None])
+    assert_type(parsed.host, Union[str, None])
+    assert_type(parsed.port, Union[int, None])
+    assert_type(parsed.hostloc, str)
+    assert_type(parsed.path, str)
+    assert_type(parsed.database, str)
+    assert_type(parsed.dbname, str)
+    assert_type(parsed.query, str)
+    assert_type(parsed.query_str, str)
+    assert_type(parsed.query_params, Dict[str, Union[str, List[str]]])
+    assert_type(parsed.fragment, str)
+    assert_type(parsed == parsed_from_alias, bool)
 
 
 def adapter_capability_types() -> None:


### PR DESCRIPTION
## Summary

- replace the mandatory `dsnparse` runtime dependency with a typed, pydapper-owned URL-style parser built on `urllib.parse`
- preserve documented default/explicit/third-party adapter routing, environment fallback, and first-party adapter forwarding while fixing SQLite target normalization
- make parse-result representations and parser-generated errors credential-safe, including malformed Unicode authority inputs

Closes #538.

## Design decision

This uses a direct standard-library implementation rather than vendoring `dsnparse`. Repository characterization found that pydapper consumes only a narrow URL-style contract; none of the generic connection-string, default-injection, mutable mapping, tuple, environment-helper, or multi-host APIs are used. Owning the small surface keeps the implementation and compatibility risk lower than copying the broader parser.

The parser separately validates the raw scheme because `urlsplit()` lowercases schemes, while explicit adapter names are exact and case-sensitive under the registry/discovery contract. Authority, credentials, hosts, and ports are still parsed through `urllib.parse` rather than manual splitting.

## Behavior and compatibility

- preserves `PydapperParseResult` and `parse` public imports, with `parse` remaining the class alias
- exposes explicitly typed DSN fields and aliases without exposing `SplitResult`
- preserves the exact default mapping for PostgreSQL, SQLite, SQL Server, MySQL, Oracle, and BigQuery
- permits explicit third-party `<database>+<adapter>` schemes and preserves exact adapter spelling
- rejects unknown one-component, missing, malformed, RFC-invalid, empty-component, and multi-plus schemes
- decodes credentials and paths after delimiter parsing, preserving literal/encoded colons in passwords
- validates ports during construction and reconstructs bracketed IPv6 `hostloc`
- preserves raw query text, blank/repeated values, encounter order, and string-valued query parameters without scalar coercion
- keeps `PYDAPPER_DSN` fallback in `main.parse_dsn()` and no longer substitutes the environment for explicit empty input
- preserves raw-DSN equality and safely compares unrelated objects

SQLite normalization is centralized in the parse result:

| DSN | target |
| --- | --- |
| `sqlite://relative.db` | `relative.db` |
| `sqlite+sqlite3://relative.db` | `relative.db` |
| `sqlite:///relative/path.db` | `relative/path.db` |
| `sqlite:////absolute/path.db` | `/absolute/path.db` |
| `sqlite:///:memory:` | `:memory:` |
| `sqlite://` | `""` |

## Credential and authority safety

- replaces the leaking field-iterating `repr` with a redacted representation
- wraps `urllib` failures with fixed component-level errors raised without unsafe exception context
- revalidates decoded network hosts against controls, surrogates, NFKC delimiter lookalikes, RFC reg-name characters, IPv6 syntax, Unicode categories, and IDNA output
- rejects percent-encoded fullwidth delimiters, brackets/backslashes, malformed escapes, controls, emoji, and slash-like Unicode symbols
- preserves valid decoded Unicode hosts and standard IDNA dot equivalents
- tests assert raw DSNs plus encoded and decoded sentinel secrets are absent from representations and errors

## Intentional pre-1.0 removals

The owned parser does not reproduce unused incidental `dsnparse` behavior: `name=value` strings, constructor default injection, dict-like/tuple mutation and indexing, `setdefault`, environment helpers, multiple hosts, scalar query coercion, or invented adapter names from multi-plus schemes. Release notes document concise before/after examples.

## Dependency, packaging, and documentation

- removes `dsnparse` from `pyproject.toml`, runtime/type-checking imports, the mypy override, lock metadata, wheel metadata, and sdist metadata
- Poetry lock diff removes only the `dsnparse 0.2.1` block and updates the content hash
- adds no replacement or mandatory dependency
- updates DSN grammar, encoding, IPv6, query, credential-safety, environment, and SQLite documentation
- corrects port placement in PostgreSQL, MySQL, SQL Server, and Oracle examples
- records the direct-implementation rationale and intentional differences in release notes

## Verification

- [x] `poetry run pytest tests/test_dsn_parser.py` — 143 passed
- [x] `poetry run pytest tests/test_main.py` — 114 passed
- [x] `poetry run pytest tests/test_adapter_units.py -m "core"` — 41 passed
- [x] `poetry run pytest -m "core"` — 992 passed, 208 deselected
- [x] `poetry run pytest -m "sqlite"` — 29 passed, 1171 deselected
- [x] `poetry run mypy pydapper`
- [x] `poetry run mypy tests/type_tests.py`
- [x] `poetry run black --check .`
- [x] `poetry run isort --check .`
- [x] `poetry run mkdocs build --strict`
- [x] `poetry check`
- [x] `poetry build`
- [x] `git diff --check`

Final wheel/sdist inspection confirmed that both contain the owned parser, neither contains or declares `dsnparse`, all remaining `Requires-Dist` entries are optional-extra-gated, and their parser copies match the source. A fresh Python 3.10 environment installed the wheel with `--no-deps`, proved `dsnparse` absent, exercised default and exact explicit routing, Unicode and IPv6 hosts, rejection of encoded delimiter/control hosts without credential leakage, SQLite normalization, and a real in-memory SQLite query.

Optional PostgreSQL, MySQL, SQL Server, Oracle, and BigQuery service integrations were not run because their driver packages are not installed. The service-free adapter tests cover their DSN routing and forwarding boundaries. No services or containers were started.

The branch was reconciled with the latest `main`, including the landed preparation-hook and private adapter-discovery work, without modifying those semantics.
