### PR TITLE
feat: add private transactional loader for adapter provider entry points

### DIFF
--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import os
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from ._adapter_discovery import _AdapterProviderDescriptor
 from ._context import _AwaitableAsyncContextManager
 from .capabilities import AdapterCapability
 from .commands import BaseCommands
@@ -43,6 +46,33 @@ def _validate_capability_declaration(command_class: type[BaseCommands], argument
             )
 
 
+def _validate_registration_contents(
+    commands: type[Commands] | None,
+    async_commands: type[CommandsAsync] | None,
+    using_connection_predicate: Callable[[object], bool],
+) -> None:
+    """Validate registration contents without touching the registry.
+
+    Shared by register_adapter() and provider-load postcondition checks so both
+    paths enforce one definition of a valid registration. Check order and
+    exception types are part of register_adapter()'s public behavior.
+    """
+    if commands is None and async_commands is None:
+        raise ValueError("At least one sync or async command class is required")
+    if commands is not None and (not isinstance(commands, type) or not issubclass(commands, Commands)):
+        raise TypeError("commands must be a Commands subclass")
+    if async_commands is not None and (
+        not isinstance(async_commands, type) or not issubclass(async_commands, CommandsAsync)
+    ):
+        raise TypeError("async_commands must be a CommandsAsync subclass")
+    if not callable(using_connection_predicate):
+        raise TypeError("using_connection_predicate must be callable")
+    if commands is not None:
+        _validate_capability_declaration(commands, "commands")
+    if async_commands is not None:
+        _validate_capability_declaration(async_commands, "async_commands")
+
+
 def register_adapter(
     name: str,
     *,
@@ -67,22 +97,9 @@ def register_adapter(
         raise ValueError("Adapter name must be non-empty and have no surrounding whitespace")
     if name in _adapter_registry:
         raise ValueError(f"Adapter {name!r} is already registered")
-    if commands is None and async_commands is None:
-        raise ValueError("At least one sync or async command class is required")
-    if commands is not None and (not isinstance(commands, type) or not issubclass(commands, Commands)):
-        raise TypeError("commands must be a Commands subclass")
-    if async_commands is not None and (
-        not isinstance(async_commands, type) or not issubclass(async_commands, CommandsAsync)
-    ):
-        raise TypeError("async_commands must be a CommandsAsync subclass")
-    if not callable(using_connection_predicate):
-        raise TypeError("using_connection_predicate must be callable")
-    # both declarations must validate before the registry mutates so an invalid mode never leaves a
+    # everything validates before the registry mutates so an invalid registration never leaves a
     # partially registered adapter behind
-    if commands is not None:
-        _validate_capability_declaration(commands, "commands")
-    if async_commands is not None:
-        _validate_capability_declaration(async_commands, "async_commands")
+    _validate_registration_contents(commands, async_commands, using_connection_predicate)
 
     _adapter_registry[name] = _AdapterRegistration(
         name=name,
@@ -90,6 +107,135 @@ def register_adapter(
         async_commands=async_commands,
         using_connection_predicate=using_connection_predicate,
     )
+
+
+# provider loading is serialized by one private lock so concurrent loads of the same provider cannot
+# invoke a callback twice, observe partial registry state, or corrupt the success cache; successful
+# loads are cached per exact provider identity (name, distribution, entry-point value), never
+# normalized, and failed attempts are never cached so they stay retryable
+_provider_load_lock = threading.Lock()
+_loaded_provider_registrations: dict[tuple[str, str, str], _AdapterRegistration] = {}
+
+
+def _provider_load_state_key(descriptor: _AdapterProviderDescriptor) -> tuple[str, str, str]:
+    return (descriptor.name, descriptor.distribution, descriptor.entry_point.value)
+
+
+def _provider_error_context(descriptor: _AdapterProviderDescriptor) -> str:
+    return f"adapter provider {descriptor.name!r} (distribution {descriptor.distribution!r})"
+
+
+def _restore_registry(snapshot: dict[str, _AdapterRegistration]) -> None:
+    registry = _adapter_registry
+    registry.clear()
+    registry.update(snapshot)
+
+
+def _verify_provider_registration_effect(
+    descriptor: _AdapterProviderDescriptor, snapshot: dict[str, _AdapterRegistration]
+) -> _AdapterRegistration:
+    context = _provider_error_context(descriptor)
+    removed = [name for name in snapshot if name not in _adapter_registry]
+    replaced = [
+        name for name in snapshot if name in _adapter_registry and _adapter_registry[name] is not snapshot[name]
+    ]
+    if removed or replaced:
+        raise ValueError(
+            f"Callback for {context} removed or replaced existing adapter registrations "
+            f"(removed: {removed!r}, replaced: {replaced!r})"
+        )
+    added = [name for name in _adapter_registry if name not in snapshot]
+    if not added:
+        raise ValueError(
+            f"Callback for {context} registered no adapter; expected exactly one registration named {descriptor.name!r}"
+        )
+    if added != [descriptor.name]:
+        raise ValueError(
+            f"Callback for {context} registered {added!r}; expected exactly one registration named {descriptor.name!r}"
+        )
+    registration = _adapter_registry[descriptor.name]
+    if not isinstance(registration, _AdapterRegistration):
+        raise ValueError(
+            f"Callback for {context} left an invalid registry record of type {type(registration).__name__} "
+            f"for adapter {descriptor.name!r}"
+        )
+    if registration.name != descriptor.name:
+        raise ValueError(
+            f"Callback for {context} left a registration named {registration.name!r} "
+            f"under adapter name {descriptor.name!r}"
+        )
+    try:
+        _validate_registration_contents(
+            registration.commands, registration.async_commands, registration.using_connection_predicate
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Callback for {context} produced an invalid registration for {descriptor.name!r}") from exc
+    return registration
+
+
+def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRegistration:
+    """Load one already-selected provider entry point and return its registration.
+
+    The caller (a later resolution slice) is responsible for choosing the
+    descriptor; this helper never consults the discovery catalog. The whole
+    attempt — registry snapshot, EntryPoint.load(), callback invocation,
+    postcondition validation, rollback, and success caching — is one serialized
+    operation, so a concurrent caller observes either the completed success or
+    the completed rollback. Any failure restores the registry to its exact
+    pre-attempt contents and stays retryable; a success is cached so the
+    callback runs at most once per process.
+    """
+    context = _provider_error_context(descriptor)
+    key = _provider_load_state_key(descriptor)
+    with _provider_load_lock:
+        cached = _loaded_provider_registrations.get(key)
+        if cached is not None:
+            if _adapter_registry.get(descriptor.name) is not cached:
+                raise ValueError(f"Previously loaded {context} no longer matches the adapter registry")
+            return cached
+
+        if descriptor.name in _adapter_registry:
+            raise ValueError(
+                f"Adapter {descriptor.name!r} is already registered; "
+                f"refusing to load {context} over the existing registration"
+            )
+
+        snapshot = dict(_adapter_registry)
+        try:
+            try:
+                callback = descriptor.entry_point.load()
+            except Exception as exc:
+                raise ValueError(f"Failed to load {context}") from exc
+            if not callable(callback):
+                raise ValueError(f"Entry point for {context} must resolve to a callable, got {type(callback).__name__}")
+            if inspect.iscoroutinefunction(callback) or inspect.isasyncgenfunction(callback):
+                raise ValueError(f"Callback for {context} must be synchronous; async callbacks are not supported")
+            try:
+                result = callback()
+            except Exception as exc:
+                raise ValueError(f"Callback for {context} failed") from exc
+            if inspect.isawaitable(result):
+                close = getattr(result, "close", None)
+                if callable(close):
+                    close()
+                raise ValueError(
+                    f"Callback for {context} returned an awaitable; async provider initialization is not supported"
+                )
+            if result is not None:
+                raise ValueError(f"Callback for {context} must return None, got {type(result).__name__}")
+            registration = _verify_provider_registration_effect(descriptor, snapshot)
+        except BaseException:
+            _restore_registry(snapshot)
+            raise
+        _loaded_provider_registrations[key] = registration
+        return registration
+
+
+def _reset_provider_load_state_for_tests() -> None:
+    # clears only private loader success state; callers are responsible for separately
+    # snapshotting/restoring the adapter registry itself
+    with _provider_load_lock:
+        _loaded_provider_registrations.clear()
 
 
 def parse_dsn(dsn: str | None) -> PydapperParseResult:

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -112,7 +112,9 @@ def register_adapter(
 # provider loading is serialized by one private lock so concurrent loads of the same provider cannot
 # invoke a callback twice, observe partial registry state, or corrupt the success cache; successful
 # loads are cached per exact provider identity (name, distribution, entry-point value), never
-# normalized, and failed attempts are never cached so they stay retryable
+# normalized, and failed attempts are never cached so they stay retryable. Both the registry and the
+# success cache are restored by object identity (binding and contents) so a hostile callback cannot
+# corrupt loader state by rebinding or mutating the module globals.
 _provider_load_lock = threading.Lock()
 _loaded_provider_registrations: dict[tuple[str, str, str], _AdapterRegistration] = {}
 
@@ -125,26 +127,39 @@ def _provider_error_context(descriptor: _AdapterProviderDescriptor) -> str:
     return f"adapter provider {descriptor.name!r} (distribution {descriptor.distribution!r})"
 
 
-def _restore_registry(snapshot: dict[str, _AdapterRegistration]) -> None:
-    registry = _adapter_registry
+def _restore_registry(registry: dict[str, _AdapterRegistration], snapshot: dict[str, _AdapterRegistration]) -> None:
+    global _adapter_registry
+    _adapter_registry = registry
     registry.clear()
     registry.update(snapshot)
 
 
+def _restore_provider_cache(
+    cache: dict[tuple[str, str, str], _AdapterRegistration],
+    snapshot: dict[tuple[str, str, str], _AdapterRegistration],
+) -> None:
+    global _loaded_provider_registrations
+    _loaded_provider_registrations = cache
+    cache.clear()
+    cache.update(snapshot)
+
+
 def _verify_provider_registration_effect(
-    descriptor: _AdapterProviderDescriptor, snapshot: dict[str, _AdapterRegistration]
+    descriptor: _AdapterProviderDescriptor,
+    registry: dict[str, _AdapterRegistration],
+    snapshot: dict[str, _AdapterRegistration],
 ) -> _AdapterRegistration:
     context = _provider_error_context(descriptor)
-    removed = [name for name in snapshot if name not in _adapter_registry]
-    replaced = [
-        name for name in snapshot if name in _adapter_registry and _adapter_registry[name] is not snapshot[name]
-    ]
+    if _adapter_registry is not registry:
+        raise ValueError(f"Callback for {context} replaced the adapter registry itself")
+    removed = [name for name in snapshot if name not in registry]
+    replaced = [name for name in snapshot if name in registry and registry[name] is not snapshot[name]]
     if removed or replaced:
         raise ValueError(
             f"Callback for {context} removed or replaced existing adapter registrations "
             f"(removed: {removed!r}, replaced: {replaced!r})"
         )
-    added = [name for name in _adapter_registry if name not in snapshot]
+    added = [name for name in registry if name not in snapshot]
     if not added:
         raise ValueError(
             f"Callback for {context} registered no adapter; expected exactly one registration named {descriptor.name!r}"
@@ -153,7 +168,9 @@ def _verify_provider_registration_effect(
         raise ValueError(
             f"Callback for {context} registered {added!r}; expected exactly one registration named {descriptor.name!r}"
         )
-    registration = _adapter_registry[descriptor.name]
+    if list(registry) != list(snapshot) + [descriptor.name]:
+        raise ValueError(f"Callback for {context} reordered existing adapter registrations")
+    registration = registry[descriptor.name]
     if not isinstance(registration, _AdapterRegistration):
         raise ValueError(
             f"Callback for {context} left an invalid registry record of type {type(registration).__name__} "
@@ -168,7 +185,7 @@ def _verify_provider_registration_effect(
         _validate_registration_contents(
             registration.commands, registration.async_commands, registration.using_connection_predicate
         )
-    except (TypeError, ValueError) as exc:
+    except Exception as exc:
         raise ValueError(f"Callback for {context} produced an invalid registration for {descriptor.name!r}") from exc
     return registration
 
@@ -181,26 +198,30 @@ def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRe
     attempt — registry snapshot, EntryPoint.load(), callback invocation,
     postcondition validation, rollback, and success caching — is one serialized
     operation, so a concurrent caller observes either the completed success or
-    the completed rollback. Any failure restores the registry to its exact
-    pre-attempt contents and stays retryable; a success is cached so the
-    callback runs at most once per process.
+    the completed rollback. Any failure restores the registry and the loader
+    success cache to their exact pre-attempt bindings and contents and stays
+    retryable; a success is cached so the callback runs at most once per
+    process, discarding any loader-state tampering by the callback.
     """
     context = _provider_error_context(descriptor)
     key = _provider_load_state_key(descriptor)
     with _provider_load_lock:
-        cached = _loaded_provider_registrations.get(key)
+        registry = _adapter_registry
+        cache = _loaded_provider_registrations
+        cached = cache.get(key)
         if cached is not None:
-            if _adapter_registry.get(descriptor.name) is not cached:
+            if registry.get(descriptor.name) is not cached:
                 raise ValueError(f"Previously loaded {context} no longer matches the adapter registry")
             return cached
 
-        if descriptor.name in _adapter_registry:
+        if descriptor.name in registry:
             raise ValueError(
                 f"Adapter {descriptor.name!r} is already registered; "
                 f"refusing to load {context} over the existing registration"
             )
 
-        snapshot = dict(_adapter_registry)
+        snapshot = dict(registry)
+        cache_snapshot = dict(cache)
         try:
             try:
                 callback = descriptor.entry_point.load()
@@ -223,11 +244,13 @@ def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRe
                 )
             if result is not None:
                 raise ValueError(f"Callback for {context} must return None, got {type(result).__name__}")
-            registration = _verify_provider_registration_effect(descriptor, snapshot)
+            registration = _verify_provider_registration_effect(descriptor, registry, snapshot)
         except BaseException:
-            _restore_registry(snapshot)
+            _restore_registry(registry, snapshot)
+            _restore_provider_cache(cache, cache_snapshot)
             raise
-        _loaded_provider_registrations[key] = registration
+        _restore_provider_cache(cache, cache_snapshot)
+        cache[key] = registration
         return registration
 
 

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -73,6 +73,43 @@ def _validate_registration_contents(
         _validate_capability_declaration(async_commands, "async_commands")
 
 
+# registry mutation and provider loading are serialized by one private reentrant lock so concurrent
+# loads of the same provider cannot invoke a callback twice, observe partial registry state, or
+# corrupt the success cache, and a direct register_adapter() on another thread during a provider
+# load waits for the attempt to finish instead of racing the snapshot and being silently dropped by
+# rollback (reentrancy is required because provider callbacks register from inside the loader's
+# critical section). The lock is bound into every acquiring function at definition time and never
+# acquired through this global at call time, so a hostile provider callback rebinding it cannot
+# hand a concurrent caller a different lock; the loader reads the global only to snapshot it and
+# restores the binding after every attempt so it keeps pointing at the real lock for any future
+# call-time reader. (A callback that rewrites this module's functions is beyond any in-process
+# defense.)
+_provider_load_lock = threading.RLock()
+
+
+def _register_adapter_under_lock(
+    name: str,
+    commands: type[Commands] | None,
+    async_commands: type[CommandsAsync] | None,
+    using_connection_predicate: Callable[[object], bool],
+    *,
+    _lock: threading.RLock = _provider_load_lock,
+) -> None:
+    with _lock:
+        if name in _adapter_registry:
+            raise ValueError(f"Adapter {name!r} is already registered")
+        # everything validates before the registry mutates so an invalid registration never leaves a
+        # partially registered adapter behind
+        _validate_registration_contents(commands, async_commands, using_connection_predicate)
+
+        _adapter_registry[name] = _AdapterRegistration(
+            name=name,
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=using_connection_predicate,
+        )
+
+
 def register_adapter(
     name: str,
     *,
@@ -95,37 +132,14 @@ def register_adapter(
         raise TypeError("Adapter name must be a string")
     if not name or name != name.strip():
         raise ValueError("Adapter name must be non-empty and have no surrounding whitespace")
-    # the provider load lock is reentrant, so provider callbacks registering from inside a
-    # serialized load attempt re-enter it; a direct registration on another thread instead waits
-    # for the attempt to finish and cannot be clobbered by its snapshot rollback
-    with _provider_load_lock:
-        if name in _adapter_registry:
-            raise ValueError(f"Adapter {name!r} is already registered")
-        # everything validates before the registry mutates so an invalid registration never leaves a
-        # partially registered adapter behind
-        _validate_registration_contents(commands, async_commands, using_connection_predicate)
-
-        _adapter_registry[name] = _AdapterRegistration(
-            name=name,
-            commands=commands,
-            async_commands=async_commands,
-            using_connection_predicate=using_connection_predicate,
-        )
+    _register_adapter_under_lock(name, commands, async_commands, using_connection_predicate)
 
 
-# provider loading is serialized by one private reentrant lock so concurrent loads of the same
-# provider cannot invoke a callback twice, observe partial registry state, or corrupt the success
-# cache. register_adapter() serializes registry mutation on the same lock (reentrantly, since
-# provider callbacks call it inside the loader's critical section), so a direct registration on
-# another thread during a provider load waits for the attempt to finish instead of racing the
-# snapshot and being silently dropped by rollback. Successful loads are cached per exact provider
-# identity (name, distribution, entry-point value), never normalized, and failed attempts are never
-# cached so they stay retryable. The registry, the success cache, and this lock binding are all
-# restored by object identity after every attempt so a hostile callback cannot corrupt loader state
-# by rebinding or mutating these module globals; the loader itself only ever acquires the lock
-# bound in at definition time and never reads this global at call time. (A callback that rewrites
-# this module's functions is beyond any in-process defense.)
-_provider_load_lock = threading.RLock()
+# successful loads are cached per exact provider identity (name, distribution, entry-point value),
+# never normalized; failed attempts are never cached so they stay retryable. The success cache and
+# the lock binding are restored by object identity after every load attempt, and the registry after
+# every failed one, so a hostile callback cannot corrupt loader state by rebinding or mutating
+# these module globals.
 _loaded_provider_registrations: dict[tuple[str, str, str], _AdapterRegistration] = {}
 
 
@@ -140,6 +154,19 @@ def _provider_error_context(descriptor: _AdapterProviderDescriptor) -> str:
 def _restore_registry(registry: dict[str, _AdapterRegistration], snapshot: dict[str, _AdapterRegistration]) -> None:
     global _adapter_registry
     _adapter_registry = registry
+    names = list(registry)
+    snapshot_names = list(snapshot)
+    if names[: len(snapshot_names)] == snapshot_names and all(
+        registry[name] is record for name, record in snapshot.items()
+    ):
+        # the pre-existing entries are untouched and in order, so drop only what the attempt
+        # appended; registry readers run without the load lock, and this path never lets them
+        # observe a long-registered adapter as transiently missing
+        for name in names[len(snapshot_names) :]:
+            del registry[name]
+        return
+    # pre-existing entries were removed, replaced, or reordered: an exact restore requires a full
+    # rebuild, briefly emptying the dict — only hostile callback tampering reaches this path
     registry.clear()
     registry.update(snapshot)
 
@@ -150,6 +177,8 @@ def _restore_provider_cache(
 ) -> None:
     global _loaded_provider_registrations
     _loaded_provider_registrations = cache
+    if list(cache) == list(snapshot) and all(cache[key] is record for key, record in snapshot.items()):
+        return
     cache.clear()
     cache.update(snapshot)
 
@@ -219,7 +248,8 @@ def _load_adapter_provider(
     operation, so a concurrent caller observes either the completed success or
     the completed rollback. Any failure restores the registry and the loader
     success cache to their exact pre-attempt bindings and contents and stays
-    retryable; a success is cached so the callback runs at most once per
+    retryable, so a failed callback may run again on a later attempt; a success
+    is cached so a callback that has succeeded never runs again in this
     process, discarding any loader-state tampering by the callback.
 
     ``_lock`` defaults to the module lock captured at definition time — it is
@@ -260,12 +290,18 @@ def _load_adapter_provider(
             except Exception as exc:
                 raise ValueError(f"Callback for {context} failed") from exc
             if inspect.isawaitable(result):
-                close = getattr(result, "close", None)
-                if callable(close):
-                    close()
+                # close unstarted coroutines to avoid unawaited-coroutine warnings; a hostile
+                # awaitable whose close attribute or call raises must not escape unwrapped
+                cleanup_error: Exception | None = None
+                try:
+                    close = getattr(result, "close", None)
+                    if callable(close):
+                        close()
+                except Exception as exc:
+                    cleanup_error = exc
                 raise ValueError(
                     f"Callback for {context} returned an awaitable; async provider initialization is not supported"
-                )
+                ) from cleanup_error
             if result is not None:
                 raise ValueError(f"Callback for {context} must return None, got {type(result).__name__}")
             registration = _verify_provider_registration_effect(descriptor, registry, snapshot)

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -95,30 +95,37 @@ def register_adapter(
         raise TypeError("Adapter name must be a string")
     if not name or name != name.strip():
         raise ValueError("Adapter name must be non-empty and have no surrounding whitespace")
-    if name in _adapter_registry:
-        raise ValueError(f"Adapter {name!r} is already registered")
-    # everything validates before the registry mutates so an invalid registration never leaves a
-    # partially registered adapter behind
-    _validate_registration_contents(commands, async_commands, using_connection_predicate)
+    # the provider load lock is reentrant, so provider callbacks registering from inside a
+    # serialized load attempt re-enter it; a direct registration on another thread instead waits
+    # for the attempt to finish and cannot be clobbered by its snapshot rollback
+    with _provider_load_lock:
+        if name in _adapter_registry:
+            raise ValueError(f"Adapter {name!r} is already registered")
+        # everything validates before the registry mutates so an invalid registration never leaves a
+        # partially registered adapter behind
+        _validate_registration_contents(commands, async_commands, using_connection_predicate)
 
-    _adapter_registry[name] = _AdapterRegistration(
-        name=name,
-        commands=commands,
-        async_commands=async_commands,
-        using_connection_predicate=using_connection_predicate,
-    )
+        _adapter_registry[name] = _AdapterRegistration(
+            name=name,
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=using_connection_predicate,
+        )
 
 
-# provider loading is serialized by one private lock so concurrent loads of the same provider cannot
-# invoke a callback twice, observe partial registry state, or corrupt the success cache; successful
-# loads are cached per exact provider identity (name, distribution, entry-point value), never
-# normalized, and failed attempts are never cached so they stay retryable. Both the registry and the
-# success cache are restored by object identity (binding and contents) so a hostile callback cannot
-# corrupt loader state by rebinding or mutating those module globals. The lock itself is bound into
-# the loader and reset helper at definition time and must never be read at call time, so a callback
-# rebinding this global cannot hand a concurrent caller a different lock; the rebound global is
-# simply inert. (A callback that rewrites this module's functions is beyond any in-process defense.)
-_provider_load_lock = threading.Lock()
+# provider loading is serialized by one private reentrant lock so concurrent loads of the same
+# provider cannot invoke a callback twice, observe partial registry state, or corrupt the success
+# cache. register_adapter() serializes registry mutation on the same lock (reentrantly, since
+# provider callbacks call it inside the loader's critical section), so a direct registration on
+# another thread during a provider load waits for the attempt to finish instead of racing the
+# snapshot and being silently dropped by rollback. Successful loads are cached per exact provider
+# identity (name, distribution, entry-point value), never normalized, and failed attempts are never
+# cached so they stay retryable. The registry, the success cache, and this lock binding are all
+# restored by object identity after every attempt so a hostile callback cannot corrupt loader state
+# by rebinding or mutating these module globals; the loader itself only ever acquires the lock
+# bound in at definition time and never reads this global at call time. (A callback that rewrites
+# this module's functions is beyond any in-process defense.)
+_provider_load_lock = threading.RLock()
 _loaded_provider_registrations: dict[tuple[str, str, str], _AdapterRegistration] = {}
 
 
@@ -145,6 +152,11 @@ def _restore_provider_cache(
     _loaded_provider_registrations = cache
     cache.clear()
     cache.update(snapshot)
+
+
+def _restore_load_lock_binding(lock: threading.RLock) -> None:
+    global _provider_load_lock
+    _provider_load_lock = lock
 
 
 def _verify_provider_registration_effect(
@@ -196,7 +208,7 @@ def _verify_provider_registration_effect(
 def _load_adapter_provider(
     descriptor: _AdapterProviderDescriptor,
     *,
-    _lock: threading.Lock = _provider_load_lock,
+    _lock: threading.RLock = _provider_load_lock,
 ) -> _AdapterRegistration:
     """Load one already-selected provider entry point and return its registration.
 
@@ -231,6 +243,7 @@ def _load_adapter_provider(
                 f"refusing to load {context} over the existing registration"
             )
 
+        lock_binding = _provider_load_lock
         snapshot = dict(registry)
         cache_snapshot = dict(cache)
         try:
@@ -259,13 +272,15 @@ def _load_adapter_provider(
         except BaseException:
             _restore_registry(registry, snapshot)
             _restore_provider_cache(cache, cache_snapshot)
+            _restore_load_lock_binding(lock_binding)
             raise
         _restore_provider_cache(cache, cache_snapshot)
+        _restore_load_lock_binding(lock_binding)
         cache[key] = registration
         return registration
 
 
-def _reset_provider_load_state_for_tests(*, _lock: threading.Lock = _provider_load_lock) -> None:
+def _reset_provider_load_state_for_tests(*, _lock: threading.RLock = _provider_load_lock) -> None:
     # clears only private loader success state; callers are responsible for separately
     # snapshotting/restoring the adapter registry itself. The lock is captured at definition
     # time for the same rebinding defense as _load_adapter_provider.

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -114,7 +114,10 @@ def register_adapter(
 # loads are cached per exact provider identity (name, distribution, entry-point value), never
 # normalized, and failed attempts are never cached so they stay retryable. Both the registry and the
 # success cache are restored by object identity (binding and contents) so a hostile callback cannot
-# corrupt loader state by rebinding or mutating the module globals.
+# corrupt loader state by rebinding or mutating those module globals. The lock itself is bound into
+# the loader and reset helper at definition time and must never be read at call time, so a callback
+# rebinding this global cannot hand a concurrent caller a different lock; the rebound global is
+# simply inert. (A callback that rewrites this module's functions is beyond any in-process defense.)
 _provider_load_lock = threading.Lock()
 _loaded_provider_registrations: dict[tuple[str, str, str], _AdapterRegistration] = {}
 
@@ -190,7 +193,11 @@ def _verify_provider_registration_effect(
     return registration
 
 
-def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRegistration:
+def _load_adapter_provider(
+    descriptor: _AdapterProviderDescriptor,
+    *,
+    _lock: threading.Lock = _provider_load_lock,
+) -> _AdapterRegistration:
     """Load one already-selected provider entry point and return its registration.
 
     The caller (a later resolution slice) is responsible for choosing the
@@ -202,10 +209,14 @@ def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRe
     success cache to their exact pre-attempt bindings and contents and stays
     retryable; a success is cached so the callback runs at most once per
     process, discarding any loader-state tampering by the callback.
+
+    ``_lock`` defaults to the module lock captured at definition time — it is
+    never read from the module global at call time — and exists as a parameter
+    only so tests can inject an instrumented lock deterministically.
     """
     context = _provider_error_context(descriptor)
     key = _provider_load_state_key(descriptor)
-    with _provider_load_lock:
+    with _lock:
         registry = _adapter_registry
         cache = _loaded_provider_registrations
         cached = cache.get(key)
@@ -254,10 +265,11 @@ def _load_adapter_provider(descriptor: _AdapterProviderDescriptor) -> _AdapterRe
         return registration
 
 
-def _reset_provider_load_state_for_tests() -> None:
+def _reset_provider_load_state_for_tests(*, _lock: threading.Lock = _provider_load_lock) -> None:
     # clears only private loader success state; callers are responsible for separately
-    # snapshotting/restoring the adapter registry itself
-    with _provider_load_lock:
+    # snapshotting/restoring the adapter registry itself. The lock is captured at definition
+    # time for the same rebinding defense as _load_adapter_provider.
+    with _lock:
         _loaded_provider_registrations.clear()
 
 

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -65,12 +65,24 @@ def registering_callback(name, *, commands=MockCommands, async_commands=None, pr
     return register, calls
 
 
+class MustNotAcquireLock:
+    """Stands in for a hostile replacement of the private load lock."""
+
+    def __enter__(self):  # pragma: no cover - must never run
+        raise AssertionError("replacement load lock must never be acquired")
+
+    def __exit__(self, *exc_info):  # pragma: no cover - must never run
+        raise AssertionError("replacement load lock must never be released")
+
+
 @pytest.fixture(autouse=True)
 def isolated_registry(monkeypatch):
     registry = main._adapter_registry.copy()
     monkeypatch.setattr(main, "_adapter_registry", registry)
+    original_lock = main._provider_load_lock
     main._reset_provider_load_state_for_tests()
     yield registry
+    main._provider_load_lock = original_lock
     main._reset_provider_load_state_for_tests()
 
 
@@ -207,7 +219,7 @@ def test_success_cache_is_per_provider_identity_not_per_name():
     assert main._adapter_registry["acmedb"] is loaded
 
 
-def test_concurrent_loads_invoke_load_and_callback_exactly_once(monkeypatch):
+def test_concurrent_loads_invoke_load_and_callback_exactly_once():
     # the first worker to win the load lock blocks inside the provider callback until the main
     # thread releases it, and the lock is instrumented to count acquire attempts, so the callback
     # is only released once every other worker is provably blocked on the lock mid-load; a
@@ -244,7 +256,7 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once(monkeypatch):
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
 
     descriptor = make_descriptor("acmedb", loaded=register)
-    monkeypatch.setattr(main, "_provider_load_lock", CountingLock(threading.Lock()))
+    shared_lock = CountingLock(threading.Lock())
 
     results = []
     errors = []
@@ -252,7 +264,7 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once(monkeypatch):
     def worker():
         try:
             start_barrier.wait(timeout=30)
-            results.append(main._load_adapter_provider(descriptor))
+            results.append(main._load_adapter_provider(descriptor, _lock=shared_lock))
         except Exception as exc:  # pragma: no cover - failure reporting only
             errors.append(exc)
 
@@ -271,6 +283,116 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once(monkeypatch):
     assert descriptor.entry_point.load_calls == 1
     assert len(results) == thread_count
     assert all(result is results[0] for result in results)
+    assert main._adapter_registry["acmedb"] is results[0]
+
+
+def test_callback_rebinding_the_load_lock_is_inert_for_later_loads():
+    original_lock = main._provider_load_lock
+    # production callers share the original lock through the definition-time default, so a
+    # rebound module global is never read at call time
+    assert main._load_adapter_provider.__kwdefaults__["_lock"] is original_lock
+    assert main._reset_provider_load_state_for_tests.__kwdefaults__["_lock"] is original_lock
+
+    def register():
+        main._provider_load_lock = MustNotAcquireLock()
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    registration = main._load_adapter_provider(descriptor)
+
+    # the cached-hit path, a fresh load, and the test reset would all raise if any of them
+    # acquired the hostile replacement instead of the definition-time lock
+    assert main._load_adapter_provider(descriptor) is registration
+    other_callback, other_calls = registering_callback("otherdb")
+    main._load_adapter_provider(make_descriptor("otherdb", loaded=other_callback))
+    assert other_calls == ["called"]
+    main._reset_provider_load_state_for_tests()
+    assert isinstance(main._provider_load_lock, MustNotAcquireLock)
+
+
+def test_failing_callback_rebinding_the_load_lock_keeps_future_loads_usable():
+    behavior = {"fail": True}
+
+    def register():
+        if behavior["fail"]:
+            main._provider_load_lock = MustNotAcquireLock()
+            raise RuntimeError("fail after swapping the lock")
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+
+    behavior["fail"] = False
+    registration = main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_concurrent_caller_is_not_unblocked_by_lock_rebinding_during_callback():
+    # deterministic repro of the reported attack: while the first caller holds the original
+    # load lock inside a callback that rebinds main._provider_load_lock, a second caller for
+    # the same provider must still serialize on the original lock (which production callers
+    # share via the definition-time default) and must never acquire the replacement
+    in_callback = threading.Event()
+    second_attempt = threading.Event()
+    release = threading.Event()
+    callback_calls = []
+
+    class CountingLock:
+        def __init__(self, inner):
+            self._inner = inner
+            self._count_guard = threading.Lock()
+            self._acquire_attempts = 0
+
+        def __enter__(self):
+            with self._count_guard:
+                self._acquire_attempts += 1
+                if self._acquire_attempts >= 2:
+                    second_attempt.set()
+            self._inner.acquire()
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
+
+    shared_lock = CountingLock(threading.Lock())
+
+    def register():
+        callback_calls.append("called")
+        main._provider_load_lock = MustNotAcquireLock()
+        in_callback.set()
+        assert release.wait(timeout=30)
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            results.append(main._load_adapter_provider(descriptor, _lock=shared_lock))
+        except Exception as exc:  # pragma: no cover - failure reporting only
+            errors.append(exc)
+
+    first = threading.Thread(target=worker)
+    first.start()
+    assert in_callback.wait(timeout=30)
+    second = threading.Thread(target=worker)
+    second.start()
+    # the second caller is provably attempting the original lock, not the replacement, while
+    # the first caller is still paused inside the callback after the rebinding
+    assert second_attempt.wait(timeout=30)
+    release.set()
+    first.join(timeout=30)
+    second.join(timeout=30)
+
+    assert not errors
+    assert callback_calls == ["called"]
+    assert descriptor.entry_point.load_calls == 1
+    assert len(results) == 2
+    assert results[0] is results[1]
     assert main._adapter_registry["acmedb"] is results[0]
 
 

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -1,0 +1,724 @@
+import importlib.metadata
+import threading
+
+import pytest
+
+import pydapper
+import pydapper.main as main
+from pydapper import _adapter_discovery
+from pydapper._adapter_discovery import _AdapterProviderDescriptor
+from tests.mocks import MockAsyncCommands
+from tests.mocks import MockCommands
+
+pytestmark = pytest.mark.core
+
+GROUP = "pydapper.adapters"
+
+
+class FakeEntryPoint:
+    """Loading-slice sibling of the discovery test fakes: load() actually returns a callback."""
+
+    def __init__(self, name, loaded=None, value="fake_provider_module:register", group=GROUP, load_error=None):
+        self.name = name
+        self.loaded = loaded
+        self.value = value
+        self.group = group
+        self.load_error = load_error
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        if self.load_error is not None:
+            raise self.load_error
+        return self.loaded
+
+
+def make_descriptor(
+    name="acmedb",
+    *,
+    loaded=None,
+    distribution="acme-adapter",
+    load_error=None,
+    value="fake_provider_module:register",
+):
+    entry_point = FakeEntryPoint(name, loaded=loaded, value=value, load_error=load_error)
+    return _AdapterProviderDescriptor(name=name, distribution=distribution, entry_point=entry_point)
+
+
+def never_matches(connection):
+    return False
+
+
+def registering_callback(name, *, commands=MockCommands, async_commands=None, predicate=never_matches):
+    calls = []
+
+    def register():
+        calls.append("called")
+        pydapper.register_adapter(
+            name,
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=predicate,
+        )
+
+    return register, calls
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch):
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    main._reset_provider_load_state_for_tests()
+    yield registry
+    main._reset_provider_load_state_for_tests()
+
+
+def assert_registry_exactly(before):
+    assert list(main._adapter_registry) == list(before)
+    for name, registration in before.items():
+        assert main._adapter_registry[name] is registration
+
+
+def assert_failed_attempt(excinfo, before, *, name, distribution, cause=None):
+    message = str(excinfo.value)
+    assert repr(name) in message
+    assert repr(distribution) in message
+    assert "://" not in message
+    if cause is not None:
+        assert excinfo.value.__cause__ is cause
+    assert_registry_exactly(before)
+    assert main._loaded_provider_registrations == {}
+
+
+# ---------------------------------------------------------------------------- successful behavior
+
+
+def test_successful_load_calls_load_and_callback_exactly_once():
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback)
+
+    registration = main._load_adapter_provider(descriptor)
+
+    assert descriptor.entry_point.load_calls == 1
+    assert calls == ["called"]
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_sync_only_registration_succeeds():
+    callback, _ = registering_callback("acmedb", commands=MockCommands)
+
+    registration = main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert isinstance(registration, main._AdapterRegistration)
+    assert registration.name == "acmedb"
+    assert registration.commands is MockCommands
+    assert registration.async_commands is None
+
+
+def test_async_only_registration_succeeds():
+    callback, _ = registering_callback("acmedb", commands=None, async_commands=MockAsyncCommands)
+
+    registration = main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert registration.commands is None
+    assert registration.async_commands is MockAsyncCommands
+
+
+def test_combined_registration_succeeds():
+    callback, _ = registering_callback("acmedb", commands=MockCommands, async_commands=MockAsyncCommands)
+
+    registration = main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert registration.commands is MockCommands
+    assert registration.async_commands is MockAsyncCommands
+
+
+def test_returned_registration_is_the_registered_record():
+    callback, _ = registering_callback("acmedb")
+
+    registration = main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_repeated_load_returns_cached_registration_without_reinvoking():
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback)
+
+    first = main._load_adapter_provider(descriptor)
+    second = main._load_adapter_provider(descriptor)
+
+    assert first is second
+    assert descriptor.entry_point.load_calls == 1
+    assert calls == ["called"]
+
+
+def test_successful_load_preserves_unrelated_registrations():
+    before = dict(main._adapter_registry)
+    callback, _ = registering_callback("acmedb")
+
+    main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert set(main._adapter_registry) == set(before) | {"acmedb"}
+    for name, registration in before.items():
+        assert main._adapter_registry[name] is registration
+
+
+def test_cached_success_must_stay_coherent_with_registry():
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback)
+    main._load_adapter_provider(descriptor)
+
+    del main._adapter_registry["acmedb"]
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+    assert calls == ["called"]
+    assert repr("acmedb") in str(excinfo.value)
+    assert repr("acme-adapter") in str(excinfo.value)
+
+
+def test_provider_identity_is_never_normalized():
+    hyphen_callback, hyphen_calls = registering_callback("acme-db")
+    underscore_callback, underscore_calls = registering_callback("acme_db")
+
+    hyphen = main._load_adapter_provider(make_descriptor("acme-db", loaded=hyphen_callback))
+    underscore = main._load_adapter_provider(make_descriptor("acme_db", loaded=underscore_callback))
+
+    assert hyphen_calls == ["called"]
+    assert underscore_calls == ["called"]
+    assert main._adapter_registry["acme-db"] is hyphen
+    assert main._adapter_registry["acme_db"] is underscore
+
+
+def test_success_cache_is_per_provider_identity_not_per_name():
+    callback, _ = registering_callback("acmedb")
+    loaded = main._load_adapter_provider(
+        make_descriptor("acmedb", loaded=callback, distribution="first-dist", value="first_mod:register")
+    )
+
+    other_callback, other_calls = registering_callback("acmedb")
+    other = make_descriptor("acmedb", loaded=other_callback, distribution="second-dist", value="second_mod:register")
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(other)
+    assert other_calls == []
+    assert main._adapter_registry["acmedb"] is loaded
+
+
+def test_concurrent_loads_invoke_load_and_callback_exactly_once(monkeypatch):
+    # the first worker to win the load lock blocks inside the provider callback until the main
+    # thread releases it, and the lock is instrumented to count acquire attempts, so the callback
+    # is only released once every other worker is provably blocked on the lock mid-load; a
+    # non-serialized implementation would invoke the callback more than once or trip an
+    # incidental duplicate-registration error
+    thread_count = 4
+    start_barrier = threading.Barrier(thread_count + 1)
+    first_entered = threading.Event()
+    all_workers_at_lock = threading.Event()
+    release = threading.Event()
+    callback_calls = []
+
+    class CountingLock:
+        def __init__(self, inner):
+            self._inner = inner
+            self._count_guard = threading.Lock()
+            self._acquire_attempts = 0
+
+        def __enter__(self):
+            with self._count_guard:
+                self._acquire_attempts += 1
+                if self._acquire_attempts >= thread_count:
+                    all_workers_at_lock.set()
+            self._inner.acquire()
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
+
+    def register():
+        callback_calls.append("called")
+        first_entered.set()
+        assert release.wait(timeout=30)
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    monkeypatch.setattr(main, "_provider_load_lock", CountingLock(threading.Lock()))
+
+    results = []
+    errors = []
+
+    def worker():
+        try:
+            start_barrier.wait(timeout=30)
+            results.append(main._load_adapter_provider(descriptor))
+        except Exception as exc:  # pragma: no cover - failure reporting only
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    start_barrier.wait(timeout=30)
+    assert first_entered.wait(timeout=30)
+    assert all_workers_at_lock.wait(timeout=30)
+    release.set()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert callback_calls == ["called"]
+    assert descriptor.entry_point.load_calls == 1
+    assert len(results) == thread_count
+    assert all(result is results[0] for result in results)
+    assert main._adapter_registry["acmedb"] is results[0]
+
+
+# ---------------------------------------------------------------------------- load/callback failures
+
+
+def test_load_failure_is_wrapped_with_context_and_cause():
+    original = ImportError("no module named fake_provider_module")
+    descriptor = make_descriptor("acmedb", load_error=original)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
+def test_non_callable_loaded_object_fails_without_registry_mutation():
+    descriptor = make_descriptor("acmedb", loaded=object())
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_requiring_an_argument_fails_with_typeerror_cause():
+    def register(required):  # pragma: no cover - never invocable without an argument
+        raise AssertionError("should never run")
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert isinstance(excinfo.value.__cause__, TypeError)
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_internal_typeerror_is_reported_as_callback_failure():
+    original = TypeError("internal type problem")
+
+    def register():
+        raise original
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
+def test_callback_exception_is_preserved_as_cause():
+    original = RuntimeError("provider blew up")
+
+    def register():
+        raise original
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
+def test_callback_exception_after_registration_rolls_back():
+    original = RuntimeError("post-registration failure")
+
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        raise original
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_async_callback_is_rejected_without_invocation():
+    ran = []
+
+    async def register():  # pragma: no cover - must never be invoked
+        ran.append("ran")
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert ran == []
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_awaitable_callback_return_is_rejected_safely_and_rolled_back():
+    async def async_register():  # pragma: no cover - never awaited
+        return None
+
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        return async_register()
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_non_none_return_is_rejected_and_rolled_back():
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        return "unexpected"
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+# ---------------------------------------------------------------------------- registry postconditions
+
+
+def test_callback_registering_nothing_fails():
+    descriptor = make_descriptor("acmedb", loaded=lambda: None)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_registering_a_different_name_fails_and_is_removed():
+    wrong_callback, _ = registering_callback("not-acmedb")
+    descriptor = make_descriptor("acmedb", loaded=wrong_callback)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "not-acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_registering_multiple_names_fails_and_removes_all():
+    def register():
+        pydapper.register_adapter("acmedb-one", commands=MockCommands, using_connection_predicate=never_matches)
+        pydapper.register_adapter("acmedb-two", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb-one" not in main._adapter_registry
+    assert "acmedb-two" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_registering_expected_name_plus_extra_fails_and_removes_both():
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        pydapper.register_adapter("acmedb-extra", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert "acmedb-extra" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_removing_an_existing_registration_fails_and_restores_it():
+    removed_name = "sqlite3"
+    original_record = main._adapter_registry[removed_name]
+
+    def register():
+        del main._adapter_registry[removed_name]
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry[removed_name] is original_record
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_replacing_an_existing_registration_fails_and_restores_it():
+    target = "sqlite3"
+    original_record = main._adapter_registry[target]
+
+    def register():
+        main._adapter_registry[target] = main._AdapterRegistration(
+            name=target,
+            commands=MockCommands,
+            async_commands=None,
+            using_connection_predicate=never_matches,
+        )
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry[target] is original_record
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_direct_insertion_of_an_invalid_registry_object_fails_and_rolls_back():
+    def register():
+        main._adapter_registry["acmedb"] = object()
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_direct_insertion_with_invalid_contents_fails_and_preserves_cause():
+    def register():
+        main._adapter_registry["acmedb"] = main._AdapterRegistration(
+            name="acmedb",
+            commands=MockCommands,
+            async_commands=None,
+            using_connection_predicate=None,
+        )
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert isinstance(excinfo.value.__cause__, TypeError)
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_direct_insertion_with_mismatched_internal_name_fails():
+    def register():
+        main._adapter_registry["acmedb"] = main._AdapterRegistration(
+            name="other-name",
+            commands=MockCommands,
+            async_commands=None,
+            using_connection_predicate=never_matches,
+        )
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+class BadCapabilityCommands(MockCommands):
+    capabilities = ["not-a-frozenset"]
+
+
+def test_invalid_capabilities_via_register_adapter_fail_and_preserve_cause():
+    def register():
+        pydapper.register_adapter("acmedb", commands=BadCapabilityCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert isinstance(excinfo.value.__cause__, TypeError)
+    assert "capabilities" in str(excinfo.value.__cause__)
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_duplicate_registration_failure_leaves_registry_unchanged():
+    def register():
+        pydapper.register_adapter("sqlite3", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_directly_registered_name_is_not_overwritten_or_claimed_as_provider_success():
+    pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+    direct_record = main._adapter_registry["acmedb"]
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert descriptor.entry_point.load_calls == 0
+    assert calls == []
+    assert main._adapter_registry["acmedb"] is direct_record
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+# ---------------------------------------------------------------------------- retryability
+
+
+def test_load_failure_is_retryable():
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback, load_error=RuntimeError("import exploded"))
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+    assert main._loaded_provider_registrations == {}
+
+    descriptor.entry_point.load_error = None
+    registration = main._load_adapter_provider(descriptor)
+
+    assert descriptor.entry_point.load_calls == 2
+    assert calls == ["called"]
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_callback_failure_is_retryable_and_retry_invokes_the_callback():
+    behavior = {"fail": True}
+    calls = []
+
+    def register():
+        calls.append("called")
+        if behavior["fail"]:
+            raise RuntimeError("first attempt fails")
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+    assert main._loaded_provider_registrations == {}
+
+    behavior["fail"] = False
+    registration = main._load_adapter_provider(descriptor)
+
+    assert calls == ["called", "called"]
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_postcondition_failure_is_retryable():
+    behavior = {"name": "wrong-name"}
+
+    def register():
+        pydapper.register_adapter(behavior["name"], commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+    assert "wrong-name" not in main._adapter_registry
+    assert main._loaded_provider_registrations == {}
+
+    behavior["name"] = "acmedb"
+    registration = main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry["acmedb"] is registration
+    assert "wrong-name" not in main._adapter_registry
+
+
+# ---------------------------------------------------------------------------- privacy and separation
+
+
+def test_loading_does_not_enumerate_the_catalog(monkeypatch):
+    _adapter_discovery._reset_provider_catalog_for_tests()
+
+    def fail_enumeration(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("provider loading must not enumerate entry points")
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fail_enumeration)
+    callback, calls = registering_callback("acmedb")
+
+    main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert calls == ["called"]
+    assert _adapter_discovery._catalog is None
+
+
+def test_loading_one_descriptor_ignores_same_name_duplicates():
+    other_callback, other_calls = registering_callback("acmedb")
+    other = make_descriptor("acmedb", loaded=other_callback, distribution="other-dist", value="other_mod:register")
+    chosen_callback, chosen_calls = registering_callback("acmedb")
+    chosen = make_descriptor("acmedb", loaded=chosen_callback)
+
+    main._load_adapter_provider(chosen)
+
+    assert chosen_calls == ["called"]
+    assert other_calls == []
+    assert other.entry_point.load_calls == 0
+
+
+def test_loading_never_calls_connection_paths_or_predicates(monkeypatch):
+    def must_not_run(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("connection selection must not run during provider loading")
+
+    for method in ("from_dsn", "from_dsn_async", "from_connection", "from_connection_async"):
+        monkeypatch.setattr(main.CommandFactory, method, must_not_run)
+
+    def predicate_must_not_run(connection):  # pragma: no cover - must never run
+        raise AssertionError("predicate must not run during provider loading")
+
+    callback, _ = registering_callback("acmedb", predicate=predicate_must_not_run)
+
+    registration = main._load_adapter_provider(make_descriptor("acmedb", loaded=callback))
+
+    assert registration.using_connection_predicate is predicate_must_not_run
+
+
+def test_no_new_public_package_root_api():
+    public_names = [name for name in vars(pydapper) if not name.startswith("_")]
+    assert not any(
+        keyword in name.lower() for name in public_names for keyword in ("load", "provider", "discover", "catalog")
+    )

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -286,28 +286,28 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once():
     assert main._adapter_registry["acmedb"] is results[0]
 
 
-def test_callback_rebinding_the_load_lock_is_inert_for_later_loads():
+def test_callback_rebinding_the_load_lock_is_restored_and_never_acquired_by_the_loader():
     original_lock = main._provider_load_lock
-    # production callers share the original lock through the definition-time default, so a
-    # rebound module global is never read at call time
+    # the loader and reset helper hold the original lock through the definition-time default and
+    # never read the rebindable module global at call time
     assert main._load_adapter_provider.__kwdefaults__["_lock"] is original_lock
     assert main._reset_provider_load_state_for_tests.__kwdefaults__["_lock"] is original_lock
 
     def register():
-        main._provider_load_lock = MustNotAcquireLock()
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        main._provider_load_lock = MustNotAcquireLock()
 
     descriptor = make_descriptor("acmedb", loaded=register)
     registration = main._load_adapter_provider(descriptor)
 
-    # the cached-hit path, a fresh load, and the test reset would all raise if any of them
-    # acquired the hostile replacement instead of the definition-time lock
+    # the binding is restored with the rest of the loader state, so later direct registrations
+    # and loads never acquire the hostile replacement (which raises on any acquire)
+    assert main._provider_load_lock is original_lock
     assert main._load_adapter_provider(descriptor) is registration
     other_callback, other_calls = registering_callback("otherdb")
     main._load_adapter_provider(make_descriptor("otherdb", loaded=other_callback))
     assert other_calls == ["called"]
     main._reset_provider_load_state_for_tests()
-    assert isinstance(main._provider_load_lock, MustNotAcquireLock)
 
 
 def test_failing_callback_rebinding_the_load_lock_keeps_future_loads_usable():
@@ -320,9 +320,12 @@ def test_failing_callback_rebinding_the_load_lock_keeps_future_loads_usable():
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
 
     descriptor = make_descriptor("acmedb", loaded=register)
+    original_lock = main._provider_load_lock
 
     with pytest.raises(ValueError):
         main._load_adapter_provider(descriptor)
+
+    assert main._provider_load_lock is original_lock
 
     behavior["fail"] = False
     registration = main._load_adapter_provider(descriptor)
@@ -358,10 +361,11 @@ def test_concurrent_caller_is_not_unblocked_by_lock_rebinding_during_callback():
             self._inner.release()
 
     shared_lock = CountingLock(threading.Lock())
+    original_lock = main._provider_load_lock
 
     def register():
         callback_calls.append("called")
-        main._provider_load_lock = MustNotAcquireLock()
+        main._provider_load_lock = threading.Lock()
         in_callback.set()
         assert release.wait(timeout=30)
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
@@ -394,6 +398,77 @@ def test_concurrent_caller_is_not_unblocked_by_lock_rebinding_during_callback():
     assert len(results) == 2
     assert results[0] is results[1]
     assert main._adapter_registry["acmedb"] is results[0]
+    assert main._provider_load_lock is original_lock
+
+
+def test_direct_registration_during_failing_provider_load_is_serialized_and_never_dropped(monkeypatch):
+    # register_adapter() serializes on the same lock as the loader, so a direct registration on
+    # another thread waits for the whole load attempt and cannot be clobbered when the failing
+    # attempt's rollback restores the pre-load snapshot
+    in_callback = threading.Event()
+    direct_attempt = threading.Event()
+    release = threading.Event()
+
+    class CountingRLock:
+        def __init__(self):
+            self._inner = threading.RLock()
+            self._count_guard = threading.Lock()
+            self._acquire_attempts = 0
+
+        def __enter__(self):
+            with self._count_guard:
+                self._acquire_attempts += 1
+                if self._acquire_attempts >= 2:
+                    direct_attempt.set()
+            self._inner.acquire()
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
+
+    shared_lock = CountingRLock()
+    monkeypatch.setattr(main, "_provider_load_lock", shared_lock)
+
+    def register():
+        in_callback.set()
+        assert release.wait(timeout=30)
+        # registers the wrong name so the load attempt fails postconditions and rolls back
+        pydapper.register_adapter("wrong-name", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    load_errors = []
+    direct_errors = []
+
+    def loading_worker():
+        try:
+            main._load_adapter_provider(descriptor, _lock=shared_lock)
+        except ValueError as exc:
+            load_errors.append(exc)
+
+    def direct_worker():
+        try:
+            pydapper.register_adapter("direct-name", commands=MockCommands, using_connection_predicate=never_matches)
+        except Exception as exc:  # pragma: no cover - failure reporting only
+            direct_errors.append(exc)
+
+    loader = threading.Thread(target=loading_worker)
+    loader.start()
+    assert in_callback.wait(timeout=30)
+    direct = threading.Thread(target=direct_worker)
+    direct.start()
+    # the direct registration is provably waiting on the shared lock while the load attempt is
+    # still paused inside its callback
+    assert direct_attempt.wait(timeout=30)
+    release.set()
+    loader.join(timeout=30)
+    direct.join(timeout=30)
+
+    assert not direct_errors
+    assert len(load_errors) == 1
+    assert "wrong-name" not in main._adapter_registry
+    assert "acmedb" not in main._adapter_registry
+    assert "direct-name" in main._adapter_registry
+    assert main._loaded_provider_registrations == {}
 
 
 # ---------------------------------------------------------------------------- load/callback failures

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import inspect
 import threading
 import types
 
@@ -219,6 +220,43 @@ def test_success_cache_is_per_provider_identity_not_per_name():
     assert main._adapter_registry["acmedb"] is loaded
 
 
+def test_success_cache_key_includes_entry_point_value():
+    callback, _ = registering_callback("acmedb")
+    main._load_adapter_provider(make_descriptor("acmedb", loaded=callback, value="first_mod:register"))
+
+    # same name and distribution but a different entry-point value is a different provider: it
+    # must not silently claim the first provider's cached success
+    other_callback, other_calls = registering_callback("acmedb")
+    other = make_descriptor("acmedb", loaded=other_callback, value="second_mod:register")
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(other)
+    assert other_calls == []
+    assert other.entry_point.load_calls == 0
+
+
+def test_cached_success_coherence_uses_object_identity_not_equality():
+    callback, calls = registering_callback("acmedb")
+    descriptor = make_descriptor("acmedb", loaded=callback)
+    registration = main._load_adapter_provider(descriptor)
+
+    clone = main._AdapterRegistration(
+        name=registration.name,
+        commands=registration.commands,
+        async_commands=registration.async_commands,
+        using_connection_predicate=registration.using_connection_predicate,
+    )
+    assert clone == registration
+    assert clone is not registration
+    main._adapter_registry["acmedb"] = clone
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+    assert calls == ["called"]
+    assert repr("acmedb") in str(excinfo.value)
+    assert repr("acme-adapter") in str(excinfo.value)
+
+
 def test_concurrent_loads_invoke_load_and_callback_exactly_once():
     # the first worker to win the load lock blocks inside the provider callback until the main
     # thread releases it, and the lock is instrumented to count acquire attempts, so the callback
@@ -276,7 +314,8 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once():
     assert all_workers_at_lock.wait(timeout=30)
     release.set()
     for thread in threads:
-        thread.join()
+        thread.join(timeout=30)
+    assert not any(thread.is_alive() for thread in threads)
 
     assert not errors
     assert callback_calls == ["called"]
@@ -286,22 +325,25 @@ def test_concurrent_loads_invoke_load_and_callback_exactly_once():
     assert main._adapter_registry["acmedb"] is results[0]
 
 
-def test_callback_rebinding_the_load_lock_is_restored_and_never_acquired_by_the_loader():
+def test_callback_rebinding_the_load_lock_is_restored_and_never_acquired():
     original_lock = main._provider_load_lock
-    # the loader and reset helper hold the original lock through the definition-time default and
-    # never read the rebindable module global at call time
+    # every acquiring function holds the original lock through its definition-time default and
+    # never reads the rebindable module global at call time
     assert main._load_adapter_provider.__kwdefaults__["_lock"] is original_lock
+    assert main._register_adapter_under_lock.__kwdefaults__["_lock"] is original_lock
     assert main._reset_provider_load_state_for_tests.__kwdefaults__["_lock"] is original_lock
 
     def register():
-        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        # rebinding before registering proves register_adapter() itself is immune: the hostile
+        # replacement raises on any acquire
         main._provider_load_lock = MustNotAcquireLock()
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
 
     descriptor = make_descriptor("acmedb", loaded=register)
     registration = main._load_adapter_provider(descriptor)
 
-    # the binding is restored with the rest of the loader state, so later direct registrations
-    # and loads never acquire the hostile replacement (which raises on any acquire)
+    # the binding is restored with the rest of the loader state, so any future call-time reader
+    # of the global still finds the real lock
     assert main._provider_load_lock is original_lock
     assert main._load_adapter_provider(descriptor) is registration
     other_callback, other_calls = registering_callback("otherdb")
@@ -365,7 +407,7 @@ def test_concurrent_caller_is_not_unblocked_by_lock_rebinding_during_callback():
 
     def register():
         callback_calls.append("called")
-        main._provider_load_lock = threading.Lock()
+        main._provider_load_lock = MustNotAcquireLock()
         in_callback.set()
         assert release.wait(timeout=30)
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
@@ -391,6 +433,8 @@ def test_concurrent_caller_is_not_unblocked_by_lock_rebinding_during_callback():
     release.set()
     first.join(timeout=30)
     second.join(timeout=30)
+    assert not first.is_alive()
+    assert not second.is_alive()
 
     assert not errors
     assert callback_calls == ["called"]
@@ -427,7 +471,8 @@ def test_direct_registration_during_failing_provider_load_is_serialized_and_neve
             self._inner.release()
 
     shared_lock = CountingRLock()
-    monkeypatch.setattr(main, "_provider_load_lock", shared_lock)
+    # swap the definition-time default so direct registrations serialize on the instrumented lock
+    monkeypatch.setitem(main._register_adapter_under_lock.__kwdefaults__, "_lock", shared_lock)
 
     def register():
         in_callback.set()
@@ -462,6 +507,8 @@ def test_direct_registration_during_failing_provider_load_is_serialized_and_neve
     release.set()
     loader.join(timeout=30)
     direct.join(timeout=30)
+    assert not loader.is_alive()
+    assert not direct.is_alive()
 
     assert not direct_errors
     assert len(load_errors) == 1
@@ -570,6 +617,9 @@ def test_async_callback_is_rejected_without_invocation():
         main._load_adapter_provider(descriptor)
 
     assert ran == []
+    # rejection must come from the pre-invocation guard, not from the awaitable-return check that
+    # would fire if the callback had actually been called
+    assert "synchronous" in str(excinfo.value)
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
 
@@ -584,6 +634,7 @@ def test_async_generator_callback_is_rejected_without_invocation():
     with pytest.raises(ValueError) as excinfo:
         main._load_adapter_provider(descriptor)
 
+    assert "synchronous" in str(excinfo.value)
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
 
@@ -605,12 +656,16 @@ def test_base_exception_from_callback_rolls_back_and_propagates():
 
 @pytest.mark.filterwarnings("error::RuntimeWarning")
 def test_awaitable_callback_return_is_rejected_safely_and_rolled_back():
+    created = []
+
     async def async_register():  # pragma: no cover - never awaited
         return None
 
     def register():
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
-        return async_register()
+        coro = async_register()
+        created.append(coro)
+        return coro
 
     descriptor = make_descriptor("acmedb", loaded=register)
     before = dict(main._adapter_registry)
@@ -618,6 +673,10 @@ def test_awaitable_callback_return_is_rejected_safely_and_rolled_back():
     with pytest.raises(ValueError) as excinfo:
         main._load_adapter_provider(descriptor)
 
+    assert "awaitable" in str(excinfo.value)
+    # the returned coroutine must be explicitly closed — a GC-time "never awaited" warning could
+    # escape the filterwarnings mark, so prove closure directly
+    assert inspect.getcoroutinestate(created[0]) == "CORO_CLOSED"
     assert "acmedb" not in main._adapter_registry
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
@@ -639,6 +698,62 @@ def test_awaitable_return_without_close_is_rejected_safely_and_rolled_back():
     with pytest.raises(ValueError) as excinfo:
         main._load_adapter_provider(descriptor)
 
+    assert "awaitable" in str(excinfo.value)
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+class AwaitableWithRaisingClose:
+    def __init__(self, error):
+        self.error = error
+
+    def __await__(self):  # pragma: no cover - must never be awaited
+        yield
+
+    def close(self):
+        raise self.error
+
+
+class AwaitableWithRaisingCloseAttribute:
+    def __await__(self):  # pragma: no cover - must never be awaited
+        yield
+
+    @property
+    def close(self):
+        raise RuntimeError("close attribute access exploded")
+
+
+def test_awaitable_return_with_raising_close_is_wrapped_and_rolled_back():
+    original = RuntimeError("close exploded")
+
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        return AwaitableWithRaisingClose(original)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "awaitable" in str(excinfo.value)
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
+def test_awaitable_return_with_raising_close_attribute_is_wrapped_and_rolled_back():
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        return AwaitableWithRaisingCloseAttribute()
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "awaitable" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
     assert "acmedb" not in main._adapter_registry
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
@@ -775,6 +890,51 @@ def test_callback_reordering_existing_registrations_fails_and_restores_order():
     assert next(iter(main._adapter_registry)) == first_name
     assert main._adapter_registry[first_name] is original_record
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+class ClearRecordingDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.clear_calls = 0
+
+    def clear(self):
+        self.clear_calls += 1
+        super().clear()
+
+
+def test_rollback_never_clears_the_live_registry_unless_existing_entries_were_tampered_with(monkeypatch):
+    # registry readers (_get_registration/_select_registration) run without the load lock, so a
+    # clear()+update() restore would let a concurrent reader observe long-registered adapters as
+    # transiently missing; untouched and append-only rollbacks must never empty the live dict
+    registry = ClearRecordingDict(main._adapter_registry)
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    before = dict(registry)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(make_descriptor("acmedb", load_error=RuntimeError("load exploded")))
+    assert registry.clear_calls == 0
+
+    def register_wrong_names():
+        pydapper.register_adapter("acmedb-one", commands=MockCommands, using_connection_predicate=never_matches)
+        pydapper.register_adapter("acmedb-two", commands=MockCommands, using_connection_predicate=never_matches)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(make_descriptor("acmedb", loaded=register_wrong_names))
+    assert registry.clear_calls == 0
+    assert dict(registry) == before
+    assert list(registry) == list(before)
+
+    # tampering with a pre-existing entry still forces the exact full rebuild
+    first_name = next(iter(registry))
+
+    def remove_existing():
+        del main._adapter_registry[first_name]
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(make_descriptor("acmedb", loaded=remove_existing))
+    assert registry.clear_calls == 1
+    assert dict(registry) == before
+    assert list(registry) == list(before)
 
 
 def test_callback_rebinding_the_registry_fails_and_restores_the_binding(isolated_registry):
@@ -965,6 +1125,22 @@ def test_failing_callback_cannot_poison_the_success_cache():
 
     assert calls == ["called", "called"]
     assert main._adapter_registry["acmedb"] is registration
+
+
+def test_failing_callback_rebinding_the_success_cache_is_restored():
+    original_cache = main._loaded_provider_registrations
+
+    def register():
+        main._loaded_provider_registrations = {("poison", "poison", "poison"): object()}
+        raise RuntimeError("fail after rebinding the cache")
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+
+    assert main._loaded_provider_registrations is original_cache
+    assert main._loaded_provider_registrations == {}
 
 
 def test_callback_tampering_with_the_success_cache_is_discarded_on_success():

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -547,6 +547,27 @@ def test_awaitable_callback_return_is_rejected_safely_and_rolled_back():
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
 
+class AwaitableWithoutClose:
+    def __await__(self):  # pragma: no cover - must never be awaited
+        yield
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_awaitable_return_without_close_is_rejected_safely_and_rolled_back():
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        return AwaitableWithoutClose()
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
 def test_non_none_return_is_rejected_and_rolled_back():
     def register():
         pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import threading
+import types
 
 import pytest
 
@@ -376,6 +377,36 @@ def test_async_callback_is_rejected_without_invocation():
 
 
 @pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_async_generator_callback_is_rejected_without_invocation():
+    async def register():  # pragma: no cover - must never be invoked
+        yield
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_base_exception_from_callback_rolls_back_and_propagates():
+    def register():
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+        raise KeyboardInterrupt
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(KeyboardInterrupt):
+        main._load_adapter_provider(descriptor)
+
+    assert "acmedb" not in main._adapter_registry
+    assert_registry_exactly(before)
+    assert main._loaded_provider_registrations == {}
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
 def test_awaitable_callback_return_is_rejected_safely_and_rolled_back():
     async def async_register():  # pragma: no cover - never awaited
         return None
@@ -507,6 +538,65 @@ def test_callback_replacing_an_existing_registration_fails_and_restores_it():
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
 
+def test_callback_reordering_existing_registrations_fails_and_restores_order():
+    assert len(main._adapter_registry) >= 2
+    first_name = next(iter(main._adapter_registry))
+    original_record = main._adapter_registry[first_name]
+
+    def register():
+        record = main._adapter_registry.pop(first_name)
+        main._adapter_registry[first_name] = record
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert next(iter(main._adapter_registry)) == first_name
+    assert main._adapter_registry[first_name] is original_record
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_rebinding_the_registry_fails_and_restores_the_binding(isolated_registry):
+    def register():
+        main._adapter_registry = {
+            "acmedb": main._AdapterRegistration(
+                name="acmedb",
+                commands=MockCommands,
+                async_commands=None,
+                using_connection_predicate=never_matches,
+            )
+        }
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(isolated_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry is isolated_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_callback_rebinding_the_registry_and_raising_still_rolls_back(isolated_registry):
+    original = RuntimeError("provider exploded after rebinding")
+
+    def register():
+        main._adapter_registry = None
+        raise original
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(isolated_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert main._adapter_registry is isolated_registry
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter", cause=original)
+
+
 def test_direct_insertion_of_an_invalid_registry_object_fails_and_rolls_back():
     def register():
         main._adapter_registry["acmedb"] = object()
@@ -558,6 +648,34 @@ def test_direct_insertion_with_mismatched_internal_name_fails():
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
 
 
+class RaisingCapabilitiesDescriptor:
+    def __get__(self, obj, objtype=None):
+        raise RuntimeError("capabilities read exploded")
+
+
+class ExplodingCapabilityCommands(MockCommands):
+    capabilities = RaisingCapabilitiesDescriptor()
+
+
+def test_unexpected_validation_exception_is_wrapped_with_context_and_rolled_back():
+    def register():
+        main._adapter_registry["acmedb"] = main._AdapterRegistration(
+            name="acmedb",
+            commands=ExplodingCapabilityCommands,
+            async_commands=None,
+            using_connection_predicate=never_matches,
+        )
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+    before = dict(main._adapter_registry)
+
+    with pytest.raises(ValueError) as excinfo:
+        main._load_adapter_provider(descriptor)
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
 class BadCapabilityCommands(MockCommands):
     capabilities = ["not-a-frozenset"]
 
@@ -605,6 +723,45 @@ def test_directly_registered_name_is_not_overwritten_or_claimed_as_provider_succ
     assert calls == []
     assert main._adapter_registry["acmedb"] is direct_record
     assert_failed_attempt(excinfo, before, name="acmedb", distribution="acme-adapter")
+
+
+def test_failing_callback_cannot_poison_the_success_cache():
+    behavior = {"fail": True}
+    calls = []
+
+    def register():
+        calls.append("called")
+        if behavior["fail"]:
+            main._loaded_provider_registrations[main._provider_load_state_key(descriptor)] = object()
+            raise RuntimeError("fail after poisoning the cache")
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    with pytest.raises(ValueError):
+        main._load_adapter_provider(descriptor)
+    assert main._loaded_provider_registrations == {}
+
+    behavior["fail"] = False
+    registration = main._load_adapter_provider(descriptor)
+
+    assert calls == ["called", "called"]
+    assert main._adapter_registry["acmedb"] is registration
+
+
+def test_callback_tampering_with_the_success_cache_is_discarded_on_success():
+    original_cache = main._loaded_provider_registrations
+
+    def register():
+        main._loaded_provider_registrations = {("poison", "poison", "poison"): object()}
+        pydapper.register_adapter("acmedb", commands=MockCommands, using_connection_predicate=never_matches)
+
+    descriptor = make_descriptor("acmedb", loaded=register)
+
+    registration = main._load_adapter_provider(descriptor)
+
+    assert main._loaded_provider_registrations is original_cache
+    assert main._loaded_provider_registrations == {main._provider_load_state_key(descriptor): registration}
 
 
 # ---------------------------------------------------------------------------- retryability
@@ -718,7 +875,48 @@ def test_loading_never_calls_connection_paths_or_predicates(monkeypatch):
 
 
 def test_no_new_public_package_root_api():
-    public_names = [name for name in vars(pydapper) if not name.startswith("_")]
-    assert not any(
-        keyword in name.lower() for name in public_names for keyword in ("load", "provider", "discover", "catalog")
-    )
+    public_names = {
+        name
+        for name, value in vars(pydapper).items()
+        if not name.startswith("_") and not isinstance(value, types.ModuleType)
+    }
+    assert public_names == {
+        "AdapterCapability",
+        "CommandKind",
+        "CommandOptions",
+        "Mapper",
+        "RawRow",
+        "connect",
+        "connect_async",
+        "register_adapter",
+        "using",
+        "using_async",
+    }
+
+
+def test_shared_validation_order_is_preserved_with_multiple_invalid_fields():
+    # pins the check order of the validation shared by register_adapter() and provider
+    # postconditions so the extraction cannot silently reorder public behavior
+    with pytest.raises(ValueError) as excinfo:
+        pydapper.register_adapter("sqlite3", commands=object, using_connection_predicate=None)
+    assert "already registered" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        pydapper.register_adapter("new-name", using_connection_predicate=None)
+    assert "At least one sync or async command class" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        pydapper.register_adapter("new-name", commands=object, async_commands=object, using_connection_predicate=None)
+    assert "commands must be a Commands subclass" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        pydapper.register_adapter(
+            "new-name", commands=MockCommands, async_commands=object, using_connection_predicate=None
+        )
+    assert "async_commands must be a CommandsAsync subclass" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        pydapper.register_adapter("new-name", commands=BadCapabilityCommands, using_connection_predicate=None)
+    assert "using_connection_predicate must be callable" in str(excinfo.value)
+
+    assert "new-name" not in main._adapter_registry


### PR DESCRIPTION
## What changed and why

Second internal slice of #468 (v1 Milestone 2), building on the discovery catalog from #556: a private loader that takes one already-selected `_AdapterProviderDescriptor`, loads and invokes its registration callback, verifies the callback's complete registry effect, and rolls the private registry back exactly on every failure. No provider selection, precedence, or `connect()`/`using()` integration yet — those are later slices.

- `pydapper/main.py`:
  - `_load_adapter_provider(descriptor)` — private loader next to `_adapter_registry`/`register_adapter()` (no import cycle). Calls `descriptor.entry_point.load()`, requires a synchronous zero-argument callback returning `None`, invokes it exactly once per attempt, and returns the resulting `_AdapterRegistration` so the later name-resolution slice can do sync/async mode checks without re-invoking the provider.
  - Postconditions: nothing removed/replaced (object identity), exactly one new name equal to `descriptor.name`, original insertion order preserved, record is a valid `_AdapterRegistration` whose internal name matches, contents pass the same validation as `register_adapter()` (extracted verbatim into `_validate_registration_contents()`, preserving public check order, exception types, and atomicity).
  - Transactional rollback: registry snapshot before `EntryPoint.load()`; any failure (`BaseException` included) restores the registry **and** the loader success cache to their exact pre-attempt bindings and contents — hostile callbacks that rebind `main._adapter_registry`, rebind/poison the success cache, reorder existing keys via pop-and-reinsert, or swap the load lock are all defended and tested. The load lock is bound at definition time and never read from the module global at call time, so a callback cannot hand a concurrent caller a different lock.
  - Success caching: keyed by exact `(name, distribution, entry_point.value)`, never normalized; repeat calls skip `load()` and the callback and verify cache/registry coherence. Failures are never cached and stay retryable.
  - Concurrency: snapshot → load → callback → postconditions → rollback/cache update is one critical section under one private lock; concurrent same-provider loads invoke the callback exactly once.
  - Direct registrations win: an already-registered name fails the load before `EntryPoint.load()` and is never overwritten or claimed as provider success.
  - Errors carry the exact adapter name and provider distribution, preserve the original exception as `__cause__`, and never contain DSNs or credentials. Async callbacks and awaitable returns are rejected without invocation/awaiting and without unawaited-coroutine warnings.
- `tests/test_adapter_loading.py` — 51 core-marked tests: success paths (sync-only/async-only/combined, caching, unrelated registrations untouched), every failure/rollback class, retryability, deterministic barrier/event concurrency proofs (including a repro of the lock-swap attack), catalog/connection-path isolation, and an exact public package-root surface assertion.

## Behavior example

No public behavior changes. Internally, the later resolution slice can do:

```python
from pydapper._adapter_discovery import _get_provider_catalog
from pydapper.main import _load_adapter_provider

descriptor = _get_provider_catalog()["acmedb"][0]  # selection is a later slice
registration = _load_adapter_provider(descriptor)  # loads, validates, caches; rolls back on failure
```

## Commands run

- `poetry run pytest tests/test_adapter_loading.py` — 51 passed
- `poetry run pytest tests/test_adapter_discovery.py tests/test_main.py` — 116 passed
- `poetry run pytest -m "core"` — 915 passed
- `poetry run pytest -m "sqlite"` — 29 passed
- `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` — clean
- `poetry run black --check .` / `poetry run isort --check .` — clean
- `git diff --check` — clean

Driver-specific suites (postgresql, mssql, mysql, oracle, bigquery) were skipped: no backend code is touched and no optional extras, containers, or services are needed.

## Impact

No public API, typing, docs, packaging metadata, dependency, lockfile, or DSN-parsing changes; nothing new is exported from `pydapper.__init__`. `_builtin_adapters` bootstrap and PR #556's catalog semantics are unchanged. Coexists with concurrent #538 work.

**#468 was closed prematurely when #556 merged and should be reopened** — remaining slices: duplicate/precedence resolution, name-based lazy resolution in `connect()`/`connect_async()`/`using()`/`using_async()`, automatic predicate selection, first-party entry-point conversion and removal of eager bootstrap, packaging metadata, and docs.

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)