### PR TITLE
feat: resolve installed adapter providers from name-based public paths

### DIFF
--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -464,22 +464,23 @@ def parse_dsn(dsn: str | None) -> PydapperParseResult:
     return PydapperParseResult(dsn)
 
 
-def _get_registration(name: str, mode: str) -> _AdapterRegistration:
-    try:
-        return _adapter_registry[name]
-    except KeyError:
-        raise ValueError(f"No adapter named {name!r} is registered for {mode} mode") from None
-
-
 def _get_sync_commands_class(name: str) -> type[Commands]:
-    registration = _get_registration(name, "sync")
+    # every name-based public path (connect() via parsed_dsn.dbapi, and using(adapter=)) funnels
+    # through here, so resolution is the one place that consults the registry, the catalog,
+    # precedence, and the loader. The requested-mode check deliberately runs *after* resolution:
+    # a provider owns its exact adapter name even when it supplies only one mode, so a mode
+    # mismatch is a mode error, never a reason to look for a different same-name provider. It is
+    # also not a failed load — the registration stays, and a later call for the supported mode
+    # reuses it without invoking the provider again.
+    registration = _resolve_adapter_registration(name)
     if registration.commands is None:
         raise ValueError(f"Adapter {name!r} does not support sync mode")
     return registration.commands
 
 
 def _get_async_commands_class(name: str) -> type[CommandsAsync]:
-    registration = _get_registration(name, "async")
+    # same post-resolution mode ordering as the sync path
+    registration = _resolve_adapter_registration(name)
     if registration.async_commands is None:
         raise ValueError(f"Adapter {name!r} does not support async mode")
     return registration.async_commands

--- a/tests/test_adapter_loading.py
+++ b/tests/test_adapter_loading.py
@@ -903,7 +903,7 @@ class ClearRecordingDict(dict):
 
 
 def test_rollback_never_clears_the_live_registry_unless_existing_entries_were_tampered_with(monkeypatch):
-    # registry readers (_get_registration/_select_registration) run without the load lock, so a
+    # registry readers (_select_registration) run without the load lock, so a
     # clear()+update() restore would let a concurrent reader observe long-registered adapters as
     # transiently missing; untouched and append-only rollbacks must never empty the live dict
     registry = ClearRecordingDict(main._adapter_registry)

--- a/tests/test_adapter_name_resolution_integration.py
+++ b/tests/test_adapter_name_resolution_integration.py
@@ -1,0 +1,541 @@
+"""Integration coverage for name-based public adapter resolution.
+
+Exercises the real public entry points -- ``connect()``, ``connect_async()``,
+``using(adapter=)``, and ``using_async(adapter=)`` -- against the real discovery
+catalog, the real ``_resolve_adapter_registration()``, and the real
+``_load_adapter_provider()`` composition. The resolver is never monkeypatched
+here; only installed entry-point metadata is faked, so these tests fail if any
+part of that composition stops being wired into a public path.
+
+Private precedence, enumeration order, transactional rollback, hostile
+callbacks, and loader-cache corruption already have dedicated coverage in
+tests/test_adapter_resolution.py and tests/test_adapter_loading.py and are not
+duplicated here.
+"""
+
+import importlib.metadata
+import inspect
+import logging
+
+import pytest
+
+import pydapper
+import pydapper.main as main
+from pydapper import _adapter_discovery
+from pydapper._context import _AwaitableAsyncContextManager
+from tests.mocks import MockAsyncCommands
+from tests.mocks import MockAsyncConnection
+from tests.mocks import MockCommands
+from tests.mocks import MockConnection
+
+pytestmark = pytest.mark.core
+
+GROUP = "pydapper.adapters"
+
+
+def dsn_for(adapter_name):
+    return f"somedb+{adapter_name}://localhost/database"
+
+
+class FakeDistribution:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeEntryPoint:
+    """Passes real discovery *and* really loads a callback.
+
+    Discovery reads ``name``/``value``/``group``/``dist``; the loader calls
+    ``load()``. One fake for both halves keeps these tests on the real catalog +
+    loader path instead of a hand-built stand-in.
+    """
+
+    def __init__(self, name, *, loaded=None, distribution="acme-adapter", group=GROUP, load_error=None):
+        self.name = name
+        self.loaded = loaded
+        self.value = f"pydapper_should_not_import_{distribution}:register"
+        self.group = group
+        self.dist = FakeDistribution(distribution)
+        self.load_error = load_error
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        if self.load_error is not None:
+            raise self.load_error
+        return self.loaded
+
+
+def never_matches(connection):
+    return False
+
+
+def always_matches(connection):
+    return True
+
+
+def provider(
+    name,
+    *,
+    distribution="acme-adapter",
+    commands=MockCommands,
+    async_commands=None,
+    predicate=never_matches,
+):
+    """Build an entry point whose callback registers ``name``, plus its call log."""
+    calls = []
+
+    def register():
+        calls.append("called")
+        pydapper.register_adapter(
+            name,
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=predicate,
+        )
+
+    return FakeEntryPoint(name, loaded=register, distribution=distribution), calls
+
+
+def broken_provider(name, *, distribution="broken-adapter"):
+    return FakeEntryPoint(name, distribution=distribution, load_error=ImportError(f"{name} provider is broken"))
+
+
+def recording_sync_commands():
+    """A fresh sync command class that records what the DSN path handed it."""
+
+    class RecordingCommands(MockCommands):
+        connect_calls = []
+
+        @classmethod
+        def connect(cls, parsed_dsn, **connect_kwargs):
+            cls.connect_calls.append((parsed_dsn, connect_kwargs))
+            return cls(MockConnection())
+
+    return RecordingCommands
+
+
+def recording_async_commands():
+    """A fresh async command class that records what the DSN path handed it."""
+
+    class RecordingCommandsAsync(MockAsyncCommands):
+        connect_calls = []
+
+        @classmethod
+        async def connect_async(cls, parsed_dsn, **connect_kwargs):
+            cls.connect_calls.append((parsed_dsn, connect_kwargs))
+            return cls(MockAsyncConnection())
+
+    return RecordingCommandsAsync
+
+
+def assert_nothing_loaded(entry_points):
+    for entry_point in entry_points:
+        assert entry_point.load_calls == 0
+
+
+def error_chain_text(error):
+    """Join every message in an exception chain so leaks anywhere in it are visible."""
+    messages = []
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        messages.append(str(error))
+        error = error.__cause__ or error.__context__
+    return " ".join(messages)
+
+
+def assert_no_key_error(error):
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        assert not isinstance(error, KeyError), f"raw KeyError leaked through name resolution: {error!r}"
+        error = error.__cause__ or error.__context__
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(monkeypatch):
+    """Snapshot/restore the registry, provider catalog, and loader success state.
+
+    First-party adapters are still eagerly registered at import time in this
+    slice, so the registry is copied rather than emptied; catalog and loader
+    state are reset on both sides so no test here depends on execution order or
+    leaks a fake catalog into another module.
+    """
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    main._reset_provider_load_state_for_tests()
+    _adapter_discovery._reset_provider_catalog_for_tests()
+    yield registry
+    main._reset_provider_load_state_for_tests()
+    _adapter_discovery._reset_provider_catalog_for_tests()
+
+
+@pytest.fixture
+def install_entry_points(monkeypatch):
+    """Install fake installed distributions and force a fresh catalog build."""
+
+    def install(entries):
+        entries = list(entries)
+        monkeypatch.setattr(
+            importlib.metadata,
+            "entry_points",
+            lambda *, group: [ep for ep in entries if ep.group == group],
+        )
+        _adapter_discovery._reset_provider_catalog_for_tests()
+        return entries
+
+    return install
+
+
+@pytest.fixture
+def forbid_discovery(monkeypatch):
+    def fail_enumeration(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("this path must not enumerate entry points")
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fail_enumeration)
+    _adapter_discovery._reset_provider_catalog_for_tests()
+
+
+# ---------------------------------------------------------------------------- DSN paths
+
+
+def test_connect_lazily_loads_a_sync_provider_named_by_the_dsn(install_entry_points):
+    commands_class = recording_sync_commands()
+    entry_point, calls = provider("acmedb", commands=commands_class)
+    install_entry_points([entry_point])
+    assert "acmedb" not in main._adapter_registry
+
+    commands = pydapper.connect(dsn_for("acmedb"), timeout=5, application_name="pydapper")
+
+    assert isinstance(commands, commands_class)
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+    # the parsed DSN object and every connect kwarg reach the selected command class untouched
+    ((parsed_dsn, connect_kwargs),) = commands_class.connect_calls
+    assert parsed_dsn.dbapi == "acmedb"
+    assert parsed_dsn.hostname == "localhost"
+    assert connect_kwargs == {"timeout": 5, "application_name": "pydapper"}
+
+
+@pytest.mark.asyncio
+async def test_connect_async_lazily_loads_an_async_provider_named_by_the_dsn(install_entry_points):
+    commands_class = recording_async_commands()
+    entry_point, calls = provider("acmedb", commands=None, async_commands=commands_class)
+    install_entry_points([entry_point])
+    assert "acmedb" not in main._adapter_registry
+
+    awaitable = pydapper.connect_async(dsn_for("acmedb"), timeout=5)
+    # the awaitable-context-manager return type is unchanged by lazy resolution
+    assert isinstance(awaitable, _AwaitableAsyncContextManager)
+    commands = await awaitable
+
+    assert isinstance(commands, commands_class)
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+    ((parsed_dsn, connect_kwargs),) = commands_class.connect_calls
+    assert parsed_dsn.dbapi == "acmedb"
+    assert connect_kwargs == {"timeout": 5}
+
+    # context-manager semantics still work, and the now-registered name needs no second load
+    async with pydapper.connect_async(dsn_for("acmedb")) as context_commands:
+        assert isinstance(context_commands, commands_class)
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_connect_parses_the_dsn_once_and_resolves_only_that_exact_name(install_entry_points, monkeypatch):
+    commands_class = recording_sync_commands()
+    entry_point, calls = provider("acmedb", commands=commands_class)
+    other_entry, other_calls = provider("otherdb", distribution="other-adapter")
+    install_entry_points([entry_point, other_entry])
+
+    parse_calls = []
+    real_parse_dsn = main.parse_dsn
+
+    def counting_parse_dsn(dsn=None):
+        parse_calls.append(dsn)
+        return real_parse_dsn(dsn)
+
+    monkeypatch.setattr(main, "parse_dsn", counting_parse_dsn)
+    pydapper.connect(dsn_for("acmedb"))
+
+    assert parse_calls == [dsn_for("acmedb")]
+    assert calls == ["called"]
+    assert other_calls == []
+    assert_nothing_loaded([other_entry])
+
+
+# ---------------------------------------------------------------------------- explicit adapter= paths
+
+
+def test_using_with_explicit_adapter_lazily_loads_and_keeps_the_original_connection(install_entry_points):
+    entry_point, calls = provider("acmedb", commands=MockCommands)
+    install_entry_points([entry_point])
+    connection = MockConnection()
+
+    commands = pydapper.using(connection, adapter="acmedb")
+
+    assert isinstance(commands, MockCommands)
+    assert commands.connection is connection
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_using_async_with_explicit_adapter_lazily_loads_and_keeps_the_original_connection(install_entry_points):
+    entry_point, calls = provider("acmedb", commands=None, async_commands=MockAsyncCommands)
+    install_entry_points([entry_point])
+    connection = MockAsyncConnection()
+
+    commands = pydapper.using_async(connection, adapter="acmedb")
+
+    assert isinstance(commands, MockAsyncCommands)
+    assert commands.connection is connection
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_explicit_selection_never_evaluates_a_loaded_providers_predicate(install_entry_points):
+    def exploding_predicate(connection):  # pragma: no cover - must never run
+        raise AssertionError("explicit adapter= selection must not evaluate connection predicates")
+
+    sync_entry, sync_calls = provider("syncdb", commands=MockCommands, predicate=exploding_predicate)
+    async_entry, async_calls = provider(
+        "asyncdb",
+        distribution="async-adapter",
+        commands=None,
+        async_commands=MockAsyncCommands,
+        predicate=exploding_predicate,
+    )
+    install_entry_points([sync_entry, async_entry])
+
+    # loading a provider registers its predicate but must never call it on a name-based path
+    assert isinstance(pydapper.using(MockConnection(), adapter="syncdb"), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection(), adapter="asyncdb"), MockAsyncCommands)
+    assert isinstance(pydapper.connect(dsn_for("syncdb")), MockCommands)
+
+    assert sync_calls == ["called"]
+    assert async_calls == ["called"]
+
+
+def test_name_based_paths_load_only_the_requested_provider(install_entry_points):
+    good_entry, good_calls = provider("acmedb", commands=MockCommands, async_commands=MockAsyncCommands)
+    broken_entry = broken_provider("brokendb")
+    unrelated_entry, unrelated_calls = provider("otherdb", distribution="other-adapter")
+    install_entry_points([good_entry, broken_entry, unrelated_entry])
+
+    assert isinstance(pydapper.connect(dsn_for("acmedb")), MockCommands)
+    assert isinstance(pydapper.using(MockConnection(), adapter="acmedb"), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection(), adapter="acmedb"), MockAsyncCommands)
+
+    assert good_calls == ["called"]
+    assert good_entry.load_calls == 1
+    # a broken and an unrelated healthy provider are both left completely untouched
+    assert_nothing_loaded([broken_entry, unrelated_entry])
+    assert unrelated_calls == []
+    assert "brokendb" not in main._adapter_registry
+    assert "otherdb" not in main._adapter_registry
+
+
+# ---------------------------------------------------------------------------- existing registrations still win
+
+
+@pytest.mark.asyncio
+async def test_direct_registration_serves_every_public_path_without_discovery(forbid_discovery):
+    pydapper.register_adapter(
+        "acmedb",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=never_matches,
+    )
+    connection = MockConnection()
+    async_connection = MockAsyncConnection()
+
+    assert isinstance(pydapper.connect(dsn_for("acmedb")), MockCommands)
+    assert isinstance(await pydapper.connect_async(dsn_for("acmedb")), MockAsyncCommands)
+    assert pydapper.using(connection, adapter="acmedb").connection is connection
+    assert pydapper.using_async(async_connection, adapter="acmedb").connection is async_connection
+
+    # the enumeration guard proves no discovery ran; the unbuilt catalog and empty loader cache
+    # prove nothing was discovered or loaded behind it
+    assert _adapter_discovery._catalog is None
+    assert main._loaded_provider_registrations == {}
+
+
+# ---------------------------------------------------------------------------- unknown names
+
+
+@pytest.mark.parametrize(
+    ("label", "call"),
+    [
+        ("connect", lambda: pydapper.connect(dsn_for("unknown-adapter"))),
+        # connect_async resolves the name before it builds a coroutine, so this raises eagerly
+        ("connect_async", lambda: pydapper.connect_async(dsn_for("unknown-adapter"))),
+        ("using", lambda: pydapper.using(MockConnection(), adapter="unknown-adapter")),
+        ("using_async", lambda: pydapper.using_async(MockAsyncConnection(), adapter="unknown-adapter")),
+    ],
+)
+def test_unknown_exact_names_fail_clearly_without_leaking_key_error(install_entry_points, label, call):
+    entry_point, calls = provider("acmedb")
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError) as excinfo:
+        call()
+
+    message = str(excinfo.value)
+    assert "No registered or installed adapter" in message
+    assert "unknown-adapter" in message
+    assert_no_key_error(excinfo.value)
+    # an unrelated installed provider is not consulted for a name it does not declare
+    assert calls == []
+    assert_nothing_loaded([entry_point])
+
+
+# ---------------------------------------------------------------------------- mode checks happen after resolution
+
+
+@pytest.mark.asyncio
+async def test_async_only_provider_loads_then_raises_the_sync_mode_error(install_entry_points):
+    entry_point, calls = provider("asyncdb", commands=None, async_commands=MockAsyncCommands)
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError, match="does not support sync mode") as excinfo:
+        pydapper.connect(dsn_for("asyncdb"))
+    assert "asyncdb" in str(excinfo.value)
+
+    # provider selection does not depend on the requested mode: the provider owns the name, loads
+    # successfully, and the mode mismatch is reported afterwards without rolling the load back
+    registration = main._adapter_registry["asyncdb"]
+    assert registration.async_commands is MockAsyncCommands
+    assert registration.commands is None
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+    # the supported mode reuses the surviving registration and never invokes the provider again
+    assert isinstance(await pydapper.connect_async(dsn_for("asyncdb")), MockAsyncCommands)
+    assert main._adapter_registry["asyncdb"] is registration
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_sync_only_provider_loads_then_raises_the_async_mode_error(install_entry_points):
+    entry_point, calls = provider("syncdb", commands=MockCommands)
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError, match="does not support async mode") as excinfo:
+        pydapper.using_async(MockAsyncConnection(), adapter="syncdb")
+    assert "syncdb" in str(excinfo.value)
+
+    registration = main._adapter_registry["syncdb"]
+    assert registration.commands is MockCommands
+    assert registration.async_commands is None
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+    connection = MockConnection()
+    assert pydapper.using(connection, adapter="syncdb").connection is connection
+    assert main._adapter_registry["syncdb"] is registration
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_mode_mismatch_does_not_fall_back_to_another_same_name_provider(install_entry_points):
+    # one provider owns the name; a mode mismatch must surface as a mode error rather than send
+    # resolution looking for some other provider that happens to declare the same name
+    owner_entry, owner_calls = provider("acmedb", commands=None, async_commands=MockAsyncCommands)
+    other_entry, other_calls = provider("acmedb", distribution="other-adapter", commands=MockCommands)
+    install_entry_points([owner_entry])
+
+    with pytest.raises(ValueError, match="does not support sync mode"):
+        pydapper.connect(dsn_for("acmedb"))
+
+    assert owner_calls == ["called"]
+    assert other_calls == []
+    assert_nothing_loaded([other_entry])
+    assert main._adapter_registry["acmedb"].commands is None
+
+
+@pytest.mark.asyncio
+async def test_a_dual_mode_provider_is_invoked_once_across_all_public_name_paths(install_entry_points):
+    entry_point, calls = provider("acmedb", commands=MockCommands, async_commands=MockAsyncCommands)
+    install_entry_points([entry_point])
+
+    assert isinstance(pydapper.connect(dsn_for("acmedb")), MockCommands)
+    assert isinstance(await pydapper.connect_async(dsn_for("acmedb")), MockAsyncCommands)
+    assert isinstance(pydapper.using(MockConnection(), adapter="acmedb"), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection(), adapter="acmedb"), MockAsyncCommands)
+
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+# ---------------------------------------------------------------------------- credentials never leak
+
+
+@pytest.mark.parametrize("adapter_name", ["unknown-adapter", "brokendb"])
+@pytest.mark.parametrize("factory", [pydapper.connect, pydapper.connect_async])
+def test_dsn_resolution_errors_never_leak_credentials(install_entry_points, caplog, factory, adapter_name):
+    install_entry_points([broken_provider("brokendb")])
+    dsn = f"somedb+{adapter_name}://dsnuser:dsnsecret@localhost/database"
+
+    with caplog.at_level(logging.DEBUG, logger="pydapper.main"):
+        with pytest.raises(ValueError) as excinfo:
+            factory(dsn)
+
+    leaked = error_chain_text(excinfo.value) + " " + " ".join(record.getMessage() for record in caplog.records)
+    assert "dsnuser" not in leaked
+    assert "dsnsecret" not in leaked
+    assert dsn not in leaked
+    assert "localhost/database" not in leaked
+
+
+# ---------------------------------------------------------------------------- automatic selection is unchanged
+
+
+def test_automatic_selection_still_uses_the_registry_only(install_entry_points):
+    # this provider's predicate would match if automatic selection loaded installed providers;
+    # loading every provider for predicate evaluation is the next #468 slice, not this one
+    entry_point, calls = provider(
+        "acmedb", commands=MockCommands, async_commands=MockAsyncCommands, predicate=always_matches
+    )
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError):
+        pydapper.using(MockConnection())
+    with pytest.raises(ValueError):
+        pydapper.using_async(MockAsyncConnection())
+
+    assert calls == []
+    assert_nothing_loaded([entry_point])
+    # nothing on the automatic path even built the catalog
+    assert _adapter_discovery._catalog is None
+
+
+def test_automatic_selection_still_resolves_a_directly_registered_match(forbid_discovery):
+    class AutomaticCommands(MockCommands): ...
+
+    class AutomaticCommandsAsync(MockAsyncCommands): ...
+
+    pydapper.register_adapter(
+        "automatic",
+        commands=AutomaticCommands,
+        async_commands=AutomaticCommandsAsync,
+        using_connection_predicate=lambda connection: isinstance(connection, (MockConnection, MockAsyncConnection)),
+    )
+
+    assert isinstance(pydapper.using(MockConnection()), AutomaticCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection()), AutomaticCommandsAsync)
+    assert _adapter_discovery._catalog is None
+
+
+# ---------------------------------------------------------------------------- public surface
+
+
+def test_public_name_based_signatures_are_unchanged():
+    assert list(inspect.signature(pydapper.connect).parameters) == ["dsn", "connect_kwargs"]
+    assert list(inspect.signature(pydapper.connect_async).parameters) == ["dsn", "connect_kwargs"]
+    assert list(inspect.signature(pydapper.using).parameters) == ["connection", "adapter"]
+    assert list(inspect.signature(pydapper.using_async).parameters) == ["connection", "adapter"]
+    for function in (pydapper.using, pydapper.using_async):
+        assert inspect.signature(function).parameters["adapter"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert inspect.signature(function).parameters["adapter"].default is None

--- a/tests/test_adapter_name_resolution_integration.py
+++ b/tests/test_adapter_name_resolution_integration.py
@@ -16,6 +16,7 @@ duplicated here.
 import importlib.metadata
 import inspect
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -23,6 +24,7 @@ import pydapper
 import pydapper.main as main
 from pydapper import _adapter_discovery
 from pydapper._context import _AwaitableAsyncContextManager
+from pydapper.dsn_parser import PydapperParseResult
 from tests.mocks import MockAsyncCommands
 from tests.mocks import MockAsyncConnection
 from tests.mocks import MockCommands
@@ -31,6 +33,7 @@ from tests.mocks import MockConnection
 pytestmark = pytest.mark.core
 
 GROUP = "pydapper.adapters"
+FIRST_PARTY = "pydapper"
 
 
 def dsn_for(adapter_name):
@@ -155,20 +158,21 @@ def assert_no_key_error(error):
 
 @pytest.fixture(autouse=True)
 def isolated_state(monkeypatch):
-    """Snapshot/restore the registry, provider catalog, and loader success state.
+    """Give each test a private registry, provider catalog, and loader cache.
 
-    First-party adapters are still eagerly registered at import time in this
-    slice, so the registry is copied rather than emptied; catalog and loader
-    state are reset on both sides so no test here depends on execution order or
-    leaks a fake catalog into another module.
+    Every piece of process state these tests touch is swapped through
+    monkeypatch, so this is a real snapshot/restore rather than a reset: a
+    catalog or loader cache the process had already built is put back verbatim
+    at teardown instead of being emptied, and nothing here can decide whether a
+    name resolves in another module. First-party adapters are still eagerly
+    registered at import time in this slice, so the registry is copied rather
+    than emptied.
     """
     registry = main._adapter_registry.copy()
     monkeypatch.setattr(main, "_adapter_registry", registry)
-    main._reset_provider_load_state_for_tests()
-    _adapter_discovery._reset_provider_catalog_for_tests()
+    monkeypatch.setattr(_adapter_discovery, "_catalog", None)
+    monkeypatch.setattr(main, "_loaded_provider_registrations", {})
     yield registry
-    main._reset_provider_load_state_for_tests()
-    _adapter_discovery._reset_provider_catalog_for_tests()
 
 
 @pytest.fixture
@@ -189,6 +193,36 @@ def install_entry_points(monkeypatch):
 
 
 @pytest.fixture
+def dsn_parse_log(monkeypatch):
+    """Record what the DSN path parsed, and every real parser construction.
+
+    ``parsed`` holds the objects ``parse_dsn()`` handed back to CommandFactory,
+    so a test can assert that the *same object* reached the command class.
+    ``constructions`` counts ``PydapperParseResult.__init__`` calls, so a
+    downstream reparse is still visible even when it bypasses ``parse_dsn()``
+    entirely -- checking only the fields of whatever object arrives would let a
+    silently reparsed DSN pass.
+    """
+    parsed = []
+    constructions = []
+    real_parse_dsn = main.parse_dsn
+    real_init = PydapperParseResult.__init__
+
+    def counting_init(self, dsn):
+        constructions.append(dsn)
+        real_init(self, dsn)
+
+    def recording_parse_dsn(dsn=None):
+        result = real_parse_dsn(dsn)
+        parsed.append(result)
+        return result
+
+    monkeypatch.setattr(PydapperParseResult, "__init__", counting_init)
+    monkeypatch.setattr(main, "parse_dsn", recording_parse_dsn)
+    return SimpleNamespace(parsed=parsed, constructions=constructions)
+
+
+@pytest.fixture
 def forbid_discovery(monkeypatch):
     def fail_enumeration(*args, **kwargs):  # pragma: no cover - must never run
         raise AssertionError("this path must not enumerate entry points")
@@ -200,7 +234,7 @@ def forbid_discovery(monkeypatch):
 # ---------------------------------------------------------------------------- DSN paths
 
 
-def test_connect_lazily_loads_a_sync_provider_named_by_the_dsn(install_entry_points):
+def test_connect_lazily_loads_a_sync_provider_named_by_the_dsn(install_entry_points, dsn_parse_log):
     commands_class = recording_sync_commands()
     entry_point, calls = provider("acmedb", commands=commands_class)
     install_entry_points([entry_point])
@@ -211,15 +245,18 @@ def test_connect_lazily_loads_a_sync_provider_named_by_the_dsn(install_entry_poi
     assert isinstance(commands, commands_class)
     assert calls == ["called"]
     assert entry_point.load_calls == 1
-    # the parsed DSN object and every connect kwarg reach the selected command class untouched
+    # the DSN is parsed exactly once, and that very object -- not an equal copy -- is what reaches
+    # the selected command class, along with every connect kwarg untouched
     ((parsed_dsn, connect_kwargs),) = commands_class.connect_calls
+    assert dsn_parse_log.constructions == [dsn_for("acmedb")]
+    assert parsed_dsn is dsn_parse_log.parsed[0]
     assert parsed_dsn.dbapi == "acmedb"
     assert parsed_dsn.hostname == "localhost"
     assert connect_kwargs == {"timeout": 5, "application_name": "pydapper"}
 
 
 @pytest.mark.asyncio
-async def test_connect_async_lazily_loads_an_async_provider_named_by_the_dsn(install_entry_points):
+async def test_connect_async_lazily_loads_an_async_provider_named_by_the_dsn(install_entry_points, dsn_parse_log):
     commands_class = recording_async_commands()
     entry_point, calls = provider("acmedb", commands=None, async_commands=commands_class)
     install_entry_points([entry_point])
@@ -233,7 +270,10 @@ async def test_connect_async_lazily_loads_an_async_provider_named_by_the_dsn(ins
     assert isinstance(commands, commands_class)
     assert calls == ["called"]
     assert entry_point.load_calls == 1
+    # same parse-once and object-identity guarantee as the sync path
     ((parsed_dsn, connect_kwargs),) = commands_class.connect_calls
+    assert dsn_parse_log.constructions == [dsn_for("acmedb")]
+    assert parsed_dsn is dsn_parse_log.parsed[0]
     assert parsed_dsn.dbapi == "acmedb"
     assert connect_kwargs == {"timeout": 5}
 
@@ -244,23 +284,18 @@ async def test_connect_async_lazily_loads_an_async_provider_named_by_the_dsn(ins
     assert entry_point.load_calls == 1
 
 
-def test_connect_parses_the_dsn_once_and_resolves_only_that_exact_name(install_entry_points, monkeypatch):
+def test_connect_resolves_only_the_exact_dsn_name_without_reparsing(install_entry_points, dsn_parse_log):
     commands_class = recording_sync_commands()
     entry_point, calls = provider("acmedb", commands=commands_class)
     other_entry, other_calls = provider("otherdb", distribution="other-adapter")
     install_entry_points([entry_point, other_entry])
 
-    parse_calls = []
-    real_parse_dsn = main.parse_dsn
-
-    def counting_parse_dsn(dsn=None):
-        parse_calls.append(dsn)
-        return real_parse_dsn(dsn)
-
-    monkeypatch.setattr(main, "parse_dsn", counting_parse_dsn)
     pydapper.connect(dsn_for("acmedb"))
 
-    assert parse_calls == [dsn_for("acmedb")]
+    # lazily loading a provider must not cost an extra parse: one parse_dsn() call, one parser
+    # construction, and the resolver only ever sees the bare dbapi name from it
+    assert len(dsn_parse_log.parsed) == 1
+    assert dsn_parse_log.constructions == [dsn_for("acmedb")]
     assert calls == ["called"]
     assert other_calls == []
     assert_nothing_loaded([other_entry])
@@ -440,18 +475,28 @@ def test_sync_only_provider_loads_then_raises_the_async_mode_error(install_entry
 
 
 def test_mode_mismatch_does_not_fall_back_to_another_same_name_provider(install_entry_points):
-    # one provider owns the name; a mode mismatch must surface as a mode error rather than send
-    # resolution looking for some other provider that happens to declare the same name
-    owner_entry, owner_calls = provider("acmedb", commands=None, async_commands=MockAsyncCommands)
-    other_entry, other_calls = provider("acmedb", distribution="other-adapter", commands=MockCommands)
-    install_entry_points([owner_entry])
+    # both providers declare the same name and are genuinely installed. #559 precedence gives the
+    # name to the first-party pydapper distribution, and that owner supplies async only -- so a
+    # sync request must raise the mode error rather than fall through to the same-name external
+    # provider that *would* have satisfied sync mode. Selection must not be mode-aware.
+    owner_entry, owner_calls = provider(
+        "acmedb",
+        distribution=FIRST_PARTY,
+        commands=None,
+        async_commands=MockAsyncCommands,
+    )
+    external_entry, external_calls = provider("acmedb", distribution="other-adapter", commands=MockCommands)
+    install_entry_points([owner_entry, external_entry])
+    # the losing candidate really is in the catalog and really does support the requested mode
+    assert len(_adapter_discovery._get_provider_catalog()["acmedb"]) == 2
 
     with pytest.raises(ValueError, match="does not support sync mode"):
         pydapper.connect(dsn_for("acmedb"))
 
     assert owner_calls == ["called"]
-    assert other_calls == []
-    assert_nothing_loaded([other_entry])
+    assert owner_entry.load_calls == 1
+    assert external_calls == []
+    assert_nothing_loaded([external_entry])
     assert main._adapter_registry["acmedb"].commands is None
 
 

--- a/tests/test_adapter_resolution.py
+++ b/tests/test_adapter_resolution.py
@@ -917,20 +917,3 @@ def test_resolution_adds_no_public_api():
         "using",
         "using_async",
     }
-
-
-def test_public_connection_paths_are_untouched_by_this_slice(install_entry_points):
-    # integration is a later slice: an installed-but-unloaded provider must still be invisible to
-    # the public name-based lookups
-    entry_point, calls = provider("acmedb")
-    install_entry_points([entry_point])
-
-    with pytest.raises(ValueError) as excinfo:
-        main._get_sync_commands_class("acmedb")
-    assert "is registered" in str(excinfo.value)
-
-    with pytest.raises(ValueError):
-        main._get_async_commands_class("acmedb")
-
-    assert calls == []
-    assert_nothing_loaded([entry_point])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,12 +30,11 @@ def adapter_registry(monkeypatch):
     monkeypatch.setattr(main, "_adapter_registry", registry)
     # name-based public paths resolve through the provider catalog and loader now, so this fixture
     # also isolates that state: a fake catalog or cached load leaked by another module must never
-    # decide whether a name resolves here, in either direction
-    main._reset_provider_load_state_for_tests()
-    _adapter_discovery._reset_provider_catalog_for_tests()
-    yield registry
-    main._reset_provider_load_state_for_tests()
-    _adapter_discovery._reset_provider_catalog_for_tests()
+    # decide whether a name resolves here, in either direction. monkeypatch restores the real
+    # catalog and loader cache at teardown rather than leaving them emptied.
+    monkeypatch.setattr(_adapter_discovery, "_catalog", None)
+    monkeypatch.setattr(main, "_loaded_provider_registrations", {})
+    return registry
 
 
 def never_matches(connection):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import pytest
 
 import pydapper
 import pydapper.main as main
+from pydapper import _adapter_discovery
 from pydapper.bigquery import GoogleBigqueryClientCommands
 from pydapper.mssql import PymssqlCommands
 from pydapper.mysql import MySqlConnectorPythonCommands
@@ -27,7 +28,14 @@ pytestmark = pytest.mark.core
 def adapter_registry(monkeypatch):
     registry = main._adapter_registry.copy()
     monkeypatch.setattr(main, "_adapter_registry", registry)
-    return registry
+    # name-based public paths resolve through the provider catalog and loader now, so this fixture
+    # also isolates that state: a fake catalog or cached load leaked by another module must never
+    # decide whether a name resolves here, in either direction
+    main._reset_provider_load_state_for_tests()
+    _adapter_discovery._reset_provider_catalog_for_tests()
+    yield registry
+    main._reset_provider_load_state_for_tests()
+    _adapter_discovery._reset_provider_catalog_for_tests()
 
 
 def never_matches(connection):
@@ -262,17 +270,19 @@ def test_explicit_selection_bypasses_predicates_for_sync_and_async(adapter_regis
 
 
 @pytest.mark.parametrize(
-    ("factory", "connection", "mode"),
+    ("factory", "connection"),
     [
-        (pydapper.using, MockConnection, "sync"),
-        (pydapper.using_async, MockAsyncConnection, "async"),
+        (pydapper.using, MockConnection),
+        (pydapper.using_async, MockAsyncConnection),
     ],
 )
-def test_explicit_selection_rejects_unknown_adapter(adapter_registry, factory, connection, mode):
+def test_explicit_selection_rejects_unknown_adapter(adapter_registry, factory, connection):
+    # name resolution owns unknown names now, so both modes fail identically: a name that is
+    # neither registered nor installed is rejected before any mode is considered
     with pytest.raises(ValueError, match="unknown") as exc_info:
         factory(connection(), adapter="unknown")
 
-    assert mode in str(exc_info.value)
+    assert "No registered or installed adapter" in str(exc_info.value)
 
 
 def test_explicit_selection_rejects_adapter_without_requested_mode(adapter_registry):
@@ -626,14 +636,14 @@ def test_connect_rejects_an_unknown_dsn_adapter(adapter_registry):
     with pytest.raises(ValueError, match="unknown") as exc_info:
         pydapper.connect("somedb+unknown://localhost")
 
-    assert "sync" in str(exc_info.value)
+    assert "No registered or installed adapter" in str(exc_info.value)
 
 
 def test_connect_async_rejects_an_unknown_dsn_adapter(adapter_registry):
     with pytest.raises(ValueError, match="unknown") as exc_info:
         pydapper.connect_async("somedb+unknown://localhost")
 
-    assert "async" in str(exc_info.value)
+    assert "No registered or installed adapter" in str(exc_info.value)
 
 
 def test_connect_async_rejects_an_adapter_without_async_support(adapter_registry):


### PR DESCRIPTION
Name-based public integration slice of #468.

## What changed

`connect()`, `connect_async()`, `using(connection, adapter=name)`, and `using_async(connection, adapter=name)` now resolve installed adapter providers lazily. All four already converged on two private command-class helpers, so this wires the resolver in at that single chokepoint rather than in four places.

`_get_sync_commands_class()` / `_get_async_commands_class()` now delegate to `_resolve_adapter_registration()` from #559, which already owns catalog lookup, precedence, locking, and transactional provider loading. No second resolver and no second lock were added.

The obsolete `_get_registration(name, mode)` registry-only helper is removed. Its `mode` argument existed only to build the old error string, so once resolution owns unknown names the whole helper is dead weight.

### Before / after

```python
# an installed third-party distribution declaring:
#   [project.entry-points."pydapper.adapters"]
#   acmedb = "pydapper_acmedb.plugin:register"

pydapper.connect("acme+acmedb://localhost/db")
# before: ValueError: No adapter named 'acmedb' is registered for sync mode
# after:  loads the acmedb provider and returns AcmeCommands

pydapper.connect("acme+nosuchdb://localhost/db")
# after:  ValueError: No registered or installed adapter has the exact name
#         'nosuchdb'; adapter names are case-sensitive and are never normalized
```

## Behavior notes

**Mode validation happens after resolution.** Provider selection never depends on the requested mode: a provider owns its exact adapter name even if it supplies only one mode. An async-only provider first requested through `connect()` loads successfully and *then* raises `Adapter 'x' does not support sync mode`; the registration survives, and a later `connect_async()` reuses it without invoking the provider again. A mode mismatch is never treated as a failed load, and never sends resolution looking for a different same-name provider.

**Explicit selection bypasses predicates and loads only the requested provider.** `using(..., adapter=name)` resolves the exact name lazily and instantiates the command class with the original connection object; a loaded provider's `using_connection_predicate` is never evaluated on a name-based path. DSN selection resolves only `parsed_dsn.dbapi`. An unrelated broken provider is left completely untouched on both paths.

**DSN handling is unchanged.** The DSN is still parsed exactly once by the existing parser; the parsed object and all `connect_kwargs` reach the selected command class untouched; async return and context-manager semantics are unchanged. Only the bare `parsed_dsn.dbapi` name reaches resolution, so no DSN, username, or password can appear in a discovery/resolution error or log.

**Automatic selection is unchanged.** `using(connection)` / `using_async(connection)` without `adapter=` remain registry-only predicate selection and do not discover or load catalog providers in this PR.

## Still to come in later #468 slices

Automatic all-provider loading for `using()` without `adapter=`, first-party provider callback modules, first-party `pyproject.toml` entry points, removal of the `_builtin_adapters` eager bootstrap, and documentation/release notes.

## Tests

New `tests/test_adapter_name_resolution_integration.py` (23 tests) exercises the public root-level functions against the **real** catalog, real `_resolve_adapter_registration()`, and real `_load_adapter_provider()` — only installed entry-point metadata is faked, following the existing `tests/test_adapter_resolution.py` fake-provider pattern. The resolver itself is never monkeypatched. Reverting the two-line `main.py` change fails 19 of the 23.

Covered: lazy loading on all four paths; original connection identity; parsed DSN and `connect_kwargs` preservation; predicates never evaluated on explicit selection; only the requested provider loaded when an unrelated one is broken; direct registrations still served with no discovery at all; unknown names failing clearly with no `KeyError` anywhere in the cause chain; both mode errors after a successful load; registration surviving a mode mismatch and not being re-invoked; a dual-mode provider invoked once across all four paths; no credential leakage into errors or `DEBUG` logs; and automatic selection still registry-only.

Existing test updates: three `tests/test_main.py` unknown-name tests asserted the mode word from the removed registry-only error and now assert the resolver's failure (unknown names are mode-independent by design). `tests/test_main.py`'s `adapter_registry` fixture now also snapshots catalog and loader state, since its paths reach that state now. `test_public_connection_paths_are_untouched_by_this_slice` in `tests/test_adapter_resolution.py` pinned the pre-integration behavior this PR replaces and is removed.

Isolation was verified both as a suite and per-test, and in both module orderings.

## Verification

| Command | Result |
| --- | --- |
| `poetry run pytest tests/test_adapter_name_resolution_integration.py` | 23 passed |
| `poetry run pytest tests/test_adapter_resolution.py tests/test_adapter_discovery.py tests/test_adapter_loading.py tests/test_main.py` | 250 passed |
| `poetry run pytest -m "core"` | 1131 passed, 208 deselected |
| `poetry run pytest -m "sqlite"` | 29 passed, 1310 deselected |
| `poetry run mypy pydapper` | Success: no issues found in 28 source files |
| `poetry run mypy tests/type_tests.py` | Success: no issues found in 1 source file |
| `poetry run black --check pydapper tests` | 68 files would be left unchanged |
| `poetry run isort --check pydapper tests` | clean |
| `git diff --check` | clean |

Ordering checks (both passed, 273 tests each): the adapter suites plus the new module run with the new module first, and again in reverse order. Five representative new tests also pass individually.

**Not run:** the `postgresql`, `mysql`, `mssql`, `oracle`, and `bigquery` marker suites. They need optional extras and database services that are not installed here, and this change touches no backend, command, or parser behavior. `mkdocs build --strict` was not run — this PR makes no docs changes (docs are a later slice).

## Compatibility

No public API, signature, or return-type changes; `_get_registration` was private. `tests/type_tests.py` is unchanged and `mypy` is clean on both targets. One deliberate consequence of reusing #559's resolver: name-based paths now take the resolver's reentrant lock even on the already-registered fast path, which is what keeps a concurrent same-name resolution from invoking a provider twice.

Refs #468
