### PR TITLE
feat: load installed adapter providers before automatic selection

### DIFF
--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -459,11 +459,12 @@ def _resolve_adapter_registration(
 def _load_all_adapter_providers(*, _lock: threading.RLock = _provider_load_lock) -> None:
     """Load every installed provider that does not already own a registered name.
 
-    Private infrastructure for a later automatic-selection slice, which cannot
-    know which unloaded provider's ``using_connection_predicate`` would match a
-    connection until every provider has been loaded. Nothing calls this yet: the
-    name-based public paths deliberately keep loading only the one provider they
-    were asked for, so an unrelated broken provider still cannot break them.
+    Private infrastructure for automatic connection selection, which cannot know
+    which unloaded provider's ``using_connection_predicate`` would match a
+    connection until every provider has been loaded. _select_registration() is
+    its only caller: the name-based public paths deliberately keep loading only
+    the one provider they were asked for, so an unrelated broken provider still
+    cannot break them.
 
     The pass is deterministic and mode-independent. Catalog names are walked in
     explicitly sorted exact-name order rather than trusting metadata enumeration
@@ -537,6 +538,36 @@ def _get_async_commands_class(name: str) -> type[CommandsAsync]:
 
 
 def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
+    """Choose the one adapter whose connection predicate claims a connection.
+
+    Automatic selection is the only path that cannot name the adapter it wants,
+    so it is also the only one that must load every installed provider first: an
+    unloaded provider's ``using_connection_predicate`` is unreachable, and
+    treating it as absent would silently return a registry-only match where the
+    complete picture is an ambiguity. The pass therefore runs to completion
+    before a single registry entry is read — there is deliberately no
+    registry-only fast path, however unambiguous the already-registered adapters
+    look — and both the sync and async wrappers reach it through this one shared
+    call site.
+
+    Loading stays mode-independent: sync-only, async-only, and dual-mode
+    providers all load for either mode, because the pass cannot know which
+    registration a predicate will claim before the predicate exists. A provider
+    that cannot load therefore fails automatic selection even when the requested
+    mode would never have used it. This is the intentional counterpart to the
+    name-based paths — connect(), connect_async(), and explicit ``adapter=``
+    load only the provider they were asked for, so an unrelated broken provider
+    cannot break them.
+
+    A load failure is fail-fast: the resolver's ValueError propagates with its
+    original cause intact, no predicate runs, and it is never re-wrapped with
+    ``connection`` so a credential-bearing connection repr cannot reach a
+    provider error. Only once the pass succeeds does the existing behavior
+    resume unchanged: filter by requested mode, evaluate the eligible predicates
+    in deterministic adapter-name order, and apply the zero/one/multiple rule.
+    """
+    _load_all_adapter_providers()
+
     matches: list[_AdapterRegistration] = []
 
     for registration in sorted(_adapter_registry.values(), key=lambda item: item.name):

--- a/tests/test_adapter_automatic_selection_integration.py
+++ b/tests/test_adapter_automatic_selection_integration.py
@@ -1,0 +1,678 @@
+"""Integration coverage for automatic (predicate-based) adapter selection.
+
+Exercises the real public entry points -- ``using(connection)`` and
+``using_async(connection)`` without ``adapter=`` -- against the real discovery
+catalog, the real ``_load_all_adapter_providers()``, the real
+``_resolve_adapter_registration()``, the real ``_load_adapter_provider()``, and
+the real predicate-selection logic. Nothing in that composition is ever stubbed;
+only installed entry-point metadata is faked, so these tests fail if automatic
+selection stops loading installed providers before it evaluates predicates.
+
+Exhaustive discovery, precedence, rollback, hostile-callback, and private
+load-all coverage already lives in tests/test_adapter_discovery.py,
+tests/test_adapter_loading.py, tests/test_adapter_resolution.py, and
+tests/test_adapter_load_all.py and is not duplicated here.
+"""
+
+import importlib.metadata
+import inspect
+import threading
+import types
+
+import pytest
+
+import pydapper
+import pydapper.main as main
+from pydapper import _adapter_discovery
+from tests.mocks import MockAsyncCommands
+from tests.mocks import MockAsyncConnection
+from tests.mocks import MockCommands
+from tests.mocks import MockConnection
+
+pytestmark = pytest.mark.core
+
+GROUP = "pydapper.adapters"
+
+
+class FakeDistribution:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeEntryPoint:
+    """Passes real discovery *and* really loads a callback.
+
+    Discovery reads ``name``/``value``/``group``/``dist``; the loader calls
+    ``load()``. One fake for both halves keeps these tests on the real catalog +
+    loader path instead of a hand-built stand-in.
+    """
+
+    def __init__(self, name, *, loaded=None, distribution="acme-adapter", group=GROUP, load_error=None):
+        self.name = name
+        self.loaded = loaded
+        self.value = f"pydapper_should_not_import_{distribution}:register"
+        self.group = group
+        self.dist = FakeDistribution(distribution)
+        self.load_error = load_error
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        if self.load_error is not None:
+            raise self.load_error
+        return self.loaded
+
+
+def never_matches(connection):
+    return False
+
+
+def provider(
+    name,
+    *,
+    distribution="acme-adapter",
+    commands=MockCommands,
+    async_commands=None,
+    predicate=never_matches,
+    event_log=None,
+):
+    """Build an entry point whose callback really registers ``name``, plus its call log.
+
+    When ``event_log`` is supplied the callback and the registered predicate both
+    append to it, so a test can assert the observable order of provider loading
+    against predicate evaluation rather than merely their totals.
+    """
+    calls = []
+    recorded_predicate = predicate
+
+    if event_log is not None:
+
+        def recorded_predicate(connection, _name=name, _predicate=predicate):
+            event_log.append(f"predicate:{_name}")
+            return _predicate(connection)
+
+    def register():
+        calls.append("called")
+        if event_log is not None:
+            event_log.append(f"load:{name}")
+        pydapper.register_adapter(
+            name,
+            commands=commands,
+            async_commands=async_commands,
+            using_connection_predicate=recorded_predicate,
+        )
+
+    return FakeEntryPoint(name, loaded=register, distribution=distribution), calls
+
+
+def broken_provider(name, *, distribution="broken-adapter", error=None):
+    error = error if error is not None else ImportError(f"{name} provider is broken")
+    return FakeEntryPoint(name, distribution=distribution, load_error=error), error
+
+
+def matches_connection(target):
+    def predicate(connection):
+        return connection is target
+
+    return predicate
+
+
+def exploding_predicate(connection):  # pragma: no cover - must never run
+    raise AssertionError("a mode-ineligible or unreached predicate was evaluated")
+
+
+def assert_nothing_loaded(entry_points):
+    for entry_point in entry_points:
+        assert entry_point.load_calls == 0
+
+
+def error_chain_text(error):
+    """Join every message in an exception chain so leaks anywhere in it are visible."""
+    messages = []
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        messages.append(str(error))
+        error = error.__cause__ or error.__context__
+    return " ".join(messages)
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(monkeypatch):
+    """Give each test a private registry, provider catalog, and loader cache.
+
+    Every piece of process state these tests touch is swapped through
+    monkeypatch, so this is a real snapshot/restore rather than a reset: a
+    catalog or loader cache the process had already built is put back verbatim
+    at teardown instead of being emptied, and nothing here can decide whether a
+    name resolves in another module. First-party adapters are still eagerly
+    registered at import time in this slice, so the registry is copied rather
+    than emptied; their predicates run during automatic selection here and match
+    none of the mock connections below.
+    """
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    monkeypatch.setattr(_adapter_discovery, "_catalog", None)
+    monkeypatch.setattr(main, "_loaded_provider_registrations", {})
+    yield registry
+
+
+@pytest.fixture
+def install_entry_points(monkeypatch):
+    """Install fake installed distributions and force a fresh catalog build."""
+
+    def install(entries):
+        entries = list(entries)
+        monkeypatch.setattr(
+            importlib.metadata,
+            "entry_points",
+            lambda *, group: [ep for ep in entries if ep.group == group],
+        )
+        _adapter_discovery._reset_provider_catalog_for_tests()
+        return entries
+
+    return install
+
+
+# ---------------------------------------------------------------------------- installed providers participate
+
+
+def test_using_loads_an_unregistered_sync_provider_and_uses_its_predicate(install_entry_points):
+    connection = MockConnection()
+    seen = []
+
+    def predicate(candidate):
+        seen.append(candidate)
+        return candidate is connection
+
+    class AcmeCommands(MockCommands): ...
+
+    entry_point, calls = provider("acmedb", commands=AcmeCommands, predicate=predicate)
+    install_entry_points([entry_point])
+    assert "acmedb" not in main._adapter_registry
+
+    commands = pydapper.using(connection)
+
+    assert isinstance(commands, AcmeCommands)
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+    # the original connection object -- not a copy or a wrapper -- reaches both the predicate that
+    # selected the adapter and the command class that was constructed from it
+    assert seen == [connection]
+    assert commands.connection is connection
+
+
+def test_using_async_loads_an_unregistered_async_provider_and_uses_its_predicate(install_entry_points):
+    connection = MockAsyncConnection()
+    seen = []
+
+    def predicate(candidate):
+        seen.append(candidate)
+        return candidate is connection
+
+    class AcmeCommandsAsync(MockAsyncCommands): ...
+
+    entry_point, calls = provider("acmedb", commands=None, async_commands=AcmeCommandsAsync, predicate=predicate)
+    install_entry_points([entry_point])
+    assert "acmedb" not in main._adapter_registry
+
+    commands = pydapper.using_async(connection)
+
+    assert isinstance(commands, AcmeCommandsAsync)
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+    assert seen == [connection]
+    assert commands.connection is connection
+
+
+def test_every_provider_loads_before_the_first_predicate_runs(install_entry_points):
+    # the directly registered name sorts ahead of every provider name *and* ahead of every eagerly
+    # bootstrapped built-in, so a registry-only fast path or any interleaving of loading with
+    # predicate evaluation would put its predicate before at least one load: entry
+    connection = MockConnection()
+    events = []
+
+    def direct_predicate(candidate):
+        events.append("predicate:aaa-direct")
+        return False
+
+    pydapper.register_adapter(
+        "aaa-direct",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=direct_predicate,
+    )
+    middle, _ = provider("mmm", distribution="mmm-dist", event_log=events)
+    last, _ = provider(
+        "zzz",
+        distribution="zzz-dist",
+        predicate=matches_connection(connection),
+        event_log=events,
+    )
+    install_entry_points([last, middle])
+
+    assert isinstance(pydapper.using(connection), MockCommands)
+
+    loads = [event for event in events if event.startswith("load:")]
+    predicates = [event for event in events if event.startswith("predicate:")]
+    assert loads == ["load:mmm", "load:zzz"]
+    assert predicates == ["predicate:aaa-direct", "predicate:mmm", "predicate:zzz"]
+    # every load precedes every predicate, and the first predicate belongs to the adapter that was
+    # already registered before the call
+    assert events.index("load:zzz") < events.index("predicate:aaa-direct")
+
+
+# ---------------------------------------------------------------------------- loading ignores the requested mode
+
+
+def test_sync_selection_loads_async_only_providers_without_evaluating_them(install_entry_points):
+    connection = MockConnection()
+    async_entry, async_calls = provider(
+        "asyncdb",
+        distribution="async-dist",
+        commands=None,
+        async_commands=MockAsyncCommands,
+        predicate=exploding_predicate,
+    )
+    sync_entry, sync_calls = provider(
+        "syncdb", distribution="sync-dist", commands=MockCommands, predicate=matches_connection(connection)
+    )
+    install_entry_points([async_entry, sync_entry])
+
+    assert isinstance(pydapper.using(connection), MockCommands)
+
+    # the async-only provider really was loaded, and its predicate really was skipped
+    assert async_calls == sync_calls == ["called"]
+    assert async_entry.load_calls == 1
+    assert main._adapter_registry["asyncdb"].async_commands is MockAsyncCommands
+
+
+def test_async_selection_loads_sync_only_providers_without_evaluating_them(install_entry_points):
+    connection = MockAsyncConnection()
+    sync_entry, sync_calls = provider(
+        "syncdb", distribution="sync-dist", commands=MockCommands, predicate=exploding_predicate
+    )
+    async_entry, async_calls = provider(
+        "asyncdb",
+        distribution="async-dist",
+        commands=None,
+        async_commands=MockAsyncCommands,
+        predicate=matches_connection(connection),
+    )
+    install_entry_points([sync_entry, async_entry])
+
+    assert isinstance(pydapper.using_async(connection), MockAsyncCommands)
+
+    assert sync_calls == async_calls == ["called"]
+    assert sync_entry.load_calls == 1
+    assert main._adapter_registry["syncdb"].commands is MockCommands
+
+
+# ---------------------------------------------------------------------------- zero / one / multiple is unchanged
+
+
+@pytest.mark.parametrize(
+    ("factory", "connection_class", "mode"),
+    [
+        (pydapper.using, MockConnection, "sync"),
+        (pydapper.using_async, MockAsyncConnection, "async"),
+    ],
+)
+def test_zero_matches_still_raises_the_no_match_error_after_loading(
+    install_entry_points, factory, connection_class, mode
+):
+    entry_point, calls = provider(
+        "acmedb", commands=MockCommands, async_commands=MockAsyncCommands, predicate=never_matches
+    )
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError, match="adapter=") as excinfo:
+        factory(connection_class())
+
+    message = str(excinfo.value)
+    assert f"No registered {mode} adapter" in message
+    assert "register an adapter" in message
+    # the provider was still loaded; it simply did not claim the connection
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_multiple_matches_across_registry_and_providers_stay_deterministically_ambiguous(install_entry_points):
+    connection = MockConnection()
+    pydapper.register_adapter(
+        "aaa-direct",
+        commands=MockCommands,
+        using_connection_predicate=matches_connection(connection),
+    )
+    entry_point, calls = provider(
+        "zzz-provider",
+        distribution="zzz-dist",
+        commands=MockCommands,
+        predicate=matches_connection(connection),
+    )
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError, match="adapter=") as excinfo:
+        pydapper.using(connection)
+
+    message = str(excinfo.value)
+    # a directly registered adapter and a freshly loaded provider are both candidates, named in
+    # adapter-name order rather than load order
+    assert "aaa-direct" in message
+    assert "zzz-provider" in message
+    assert message.index("aaa-direct") < message.index("zzz-provider")
+    assert calls == ["called"]
+
+
+def test_a_directly_registered_name_suppresses_its_provider_but_still_matches(install_entry_points):
+    connection = MockConnection()
+
+    class DirectCommands(MockCommands): ...
+
+    pydapper.register_adapter(
+        "acmedb",
+        commands=DirectCommands,
+        using_connection_predicate=matches_connection(connection),
+    )
+    direct_record = main._adapter_registry["acmedb"]
+    same_name, same_name_calls = provider(
+        "acmedb", distribution="external-dist", commands=MockCommands, predicate=exploding_predicate
+    )
+    install_entry_points([same_name])
+
+    commands = pydapper.using(connection)
+
+    # the suppressed provider never loaded, so only the directly registered predicate could have
+    # produced this match
+    assert isinstance(commands, DirectCommands)
+    assert commands.connection is connection
+    assert main._adapter_registry["acmedb"] is direct_record
+    assert same_name_calls == []
+    assert_nothing_loaded([same_name])
+
+
+def test_predicate_errors_still_wrap_the_original_cause_after_loading(install_entry_points):
+    cause = RuntimeError("predicate failed")
+
+    def raises(connection):
+        raise cause
+
+    entry_point, calls = provider("acmedb", commands=MockCommands, predicate=raises)
+    install_entry_points([entry_point])
+
+    with pytest.raises(ValueError, match="acmedb") as excinfo:
+        pydapper.using(MockConnection())
+
+    assert "sync" in str(excinfo.value)
+    assert excinfo.value.__cause__ is cause
+    assert calls == ["called"]
+
+
+# ---------------------------------------------------------------------------- provider failures come first
+
+
+@pytest.mark.parametrize(
+    ("factory", "connection_class"),
+    [
+        (pydapper.using, MockConnection),
+        (pydapper.using_async, MockAsyncConnection),
+    ],
+)
+def test_a_broken_provider_fails_before_any_predicate_runs(install_entry_points, factory, connection_class):
+    connection = connection_class()
+    # this adapter would match, and sorts ahead of the broken provider: automatic selection must
+    # still fail rather than settle for the match it could already see
+    pydapper.register_adapter(
+        "aaa-direct",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=exploding_predicate,
+    )
+    broken, boom = broken_provider("brokendb")
+    install_entry_points([broken])
+
+    with pytest.raises(ValueError) as excinfo:
+        factory(connection)
+
+    assert "brokendb" in str(excinfo.value)
+    # the original provider failure survives in the cause chain, and the failure is reported as a
+    # provider problem rather than re-wrapped with the connection under inspection
+    assert excinfo.value.__cause__ is boom
+    assert repr(connection) not in error_chain_text(excinfo.value)
+
+
+def test_a_broken_provider_lacking_the_requested_mode_still_fails_selection(install_entry_points):
+    # the broken provider is not even a sync candidate -- it is the async-only provider's name that
+    # is installed -- but loading is deliberately mode-independent, so sync selection fails too
+    pydapper.register_adapter(
+        "sync-match",
+        commands=MockCommands,
+        using_connection_predicate=exploding_predicate,
+    )
+    async_only, async_calls = provider(
+        "asyncdb",
+        distribution="async-dist",
+        commands=None,
+        async_commands=MockAsyncCommands,
+        predicate=exploding_predicate,
+    )
+    broken, boom = broken_provider("brokenasyncdb")
+    install_entry_points([async_only, broken])
+
+    with pytest.raises(ValueError) as excinfo:
+        pydapper.using(MockConnection())
+
+    assert "brokenasyncdb" in str(excinfo.value)
+    assert excinfo.value.__cause__ is boom
+    # the healthy async-only provider sorts first and really did load before the failure
+    assert async_calls == ["called"]
+
+
+def test_duplicate_unregistered_providers_fail_before_predicates(install_entry_points):
+    pydapper.register_adapter(
+        "aaa-direct",
+        commands=MockCommands,
+        using_connection_predicate=exploding_predicate,
+    )
+    first, first_calls = provider("dupedb", distribution="one-dist")
+    second, second_calls = provider("dupedb", distribution="two-dist")
+    install_entry_points([first, second])
+
+    with pytest.raises(ValueError) as excinfo:
+        pydapper.using(MockConnection())
+
+    message = str(excinfo.value)
+    assert "'dupedb'" in message
+    assert "'one-dist'" in message
+    assert "'two-dist'" in message
+    assert first_calls == second_calls == []
+    assert_nothing_loaded([first, second])
+
+
+def test_repairing_a_provider_and_retrying_loads_the_rest_before_predicates(install_entry_points):
+    connection = MockConnection()
+    events = []
+    earlier, earlier_calls = provider("aaa", distribution="earlier-dist", event_log=events)
+    broken, _ = broken_provider("mmm")
+    later, later_calls = provider(
+        "zzz",
+        distribution="later-dist",
+        predicate=matches_connection(connection),
+        event_log=events,
+    )
+    install_entry_points([earlier, broken, later])
+
+    with pytest.raises(ValueError, match="mmm"):
+        pydapper.using(connection)
+    # fail-fast: the earlier provider loaded, the later one was never reached, no predicate ran
+    assert earlier_calls == ["called"]
+    assert later_calls == []
+    assert events == ["load:aaa"]
+
+    repaired, repaired_calls = provider("mmm", distribution="broken-adapter", event_log=events)
+    install_entry_points([earlier, repaired, later])
+
+    commands = pydapper.using(connection)
+
+    assert isinstance(commands, MockCommands)
+    assert commands.connection is connection
+    # the earlier success is reused rather than reloaded, the repaired and remaining providers load,
+    # and only then do predicates run
+    assert earlier_calls == repaired_calls == later_calls == ["called"]
+    assert earlier.load_calls == 1
+    assert events[:3] == ["load:aaa", "load:mmm", "load:zzz"]
+    assert all(event.startswith("predicate:") for event in events[3:])
+
+
+# ---------------------------------------------------------------------------- callbacks run at most once
+
+
+def test_repeated_sync_and_async_selection_never_reinvokes_a_provider(install_entry_points):
+    connection = MockConnection()
+    async_connection = MockAsyncConnection()
+    entry_point, calls = provider(
+        "acmedb",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        predicate=lambda candidate: candidate in (connection, async_connection),
+    )
+    install_entry_points([entry_point])
+
+    for _ in range(3):
+        assert isinstance(pydapper.using(connection), MockCommands)
+        assert isinstance(pydapper.using_async(async_connection), MockAsyncCommands)
+
+    assert calls == ["called"]
+    assert entry_point.load_calls == 1
+
+
+def test_concurrent_sync_and_async_selection_invokes_each_provider_once(install_entry_points, monkeypatch):
+    # the winning thread blocks inside the first provider's callback until every other worker is
+    # provably parked on the shared lock, so an unserialized pass would invoke a callback twice or
+    # trip an incidental duplicate-registration error rather than merely running fast. The lock is
+    # injected into the real helper's default rather than replacing the helper, so the whole
+    # composition under test stays real.
+    thread_count = 4
+    # the winner acquires three times before it blocks (the pass, the nested resolution, the
+    # nested load); every other worker is then parked at the pass's own acquire
+    expected_attempts = 3 + (thread_count - 1)
+    start_barrier = threading.Barrier(thread_count + 1)
+    first_entered = threading.Event()
+    all_workers_at_lock = threading.Event()
+    release = threading.Event()
+    alpha_calls = []
+
+    class CountingRLock:
+        def __init__(self):
+            self._inner = threading.RLock()
+            self._count_guard = threading.Lock()
+            self._acquire_attempts = 0
+
+        def __enter__(self):
+            with self._count_guard:
+                self._acquire_attempts += 1
+                if self._acquire_attempts >= expected_attempts:
+                    all_workers_at_lock.set()
+            self._inner.acquire()
+            return self
+
+        def __exit__(self, *exc_info):
+            self._inner.release()
+
+    def register_alpha():
+        alpha_calls.append("called")
+        first_entered.set()
+        assert release.wait(timeout=30)
+        pydapper.register_adapter("alpha", commands=MockCommands, using_connection_predicate=never_matches)
+
+    connection = MockConnection()
+    async_connection = MockAsyncConnection()
+    pydapper.register_adapter(
+        "matchdb",
+        commands=MockCommands,
+        async_commands=MockAsyncCommands,
+        using_connection_predicate=lambda candidate: candidate in (connection, async_connection),
+    )
+    alpha = FakeEntryPoint("alpha", loaded=register_alpha, distribution="one-dist")
+    bravo, bravo_calls = provider("bravo", distribution="two-dist")
+    install_entry_points([alpha, bravo])
+    shared_lock = CountingRLock()
+    monkeypatch.setitem(main._load_all_adapter_providers.__kwdefaults__, "_lock", shared_lock)
+
+    results = []
+    errors = []
+
+    def worker(index):
+        try:
+            start_barrier.wait(timeout=30)
+            if index % 2:
+                results.append(pydapper.using_async(async_connection))
+            else:
+                results.append(pydapper.using(connection))
+        except Exception as exc:  # pragma: no cover - failure reporting only
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    start_barrier.wait(timeout=30)
+    assert first_entered.wait(timeout=30)
+    assert all_workers_at_lock.wait(timeout=30)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert not any(thread.is_alive() for thread in threads)
+
+    assert not errors
+    assert alpha_calls == bravo_calls == ["called"]
+    assert alpha.load_calls == bravo.load_calls == 1
+    assert len(results) == thread_count
+    assert {type(result) for result in results} == {MockCommands, MockAsyncCommands}
+
+
+# ---------------------------------------------------------------------------- name-based paths stay isolated
+
+
+def test_name_based_paths_still_ignore_an_unrelated_broken_provider(install_entry_points):
+    good, good_calls = provider("acmedb", commands=MockCommands, async_commands=MockAsyncCommands)
+    broken, _ = broken_provider("brokendb")
+    install_entry_points([good, broken])
+
+    assert isinstance(pydapper.connect("somedb+acmedb://localhost/database"), MockCommands)
+    assert isinstance(pydapper.using(MockConnection(), adapter="acmedb"), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection(), adapter="acmedb"), MockAsyncCommands)
+
+    # only automatic selection loads everything; the name-based paths still load exactly one
+    # provider and leave the broken one untouched
+    assert good_calls == ["called"]
+    assert good.load_calls == 1
+    assert_nothing_loaded([broken])
+    assert "brokendb" not in main._adapter_registry
+
+
+# ---------------------------------------------------------------------------- public surface
+
+
+def test_automatic_selection_integration_adds_no_public_api():
+    public_names = {
+        name
+        for name, value in vars(pydapper).items()
+        if not name.startswith("_") and not isinstance(value, types.ModuleType)
+    }
+    assert public_names == {
+        "AdapterCapability",
+        "CommandKind",
+        "CommandOptions",
+        "Mapper",
+        "RawRow",
+        "connect",
+        "connect_async",
+        "register_adapter",
+        "using",
+        "using_async",
+    }
+    assert list(inspect.signature(pydapper.using).parameters) == ["connection", "adapter"]
+    assert list(inspect.signature(pydapper.using_async).parameters) == ["connection", "adapter"]
+    for function in (pydapper.using, pydapper.using_async):
+        assert inspect.signature(function).parameters["adapter"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert inspect.signature(function).parameters["adapter"].default is None

--- a/tests/test_adapter_load_all.py
+++ b/tests/test_adapter_load_all.py
@@ -6,8 +6,10 @@ catalog, the real ``_resolve_adapter_registration()``, and the real
 entry-point metadata is faked, so these tests fail if the pass stops delegating
 selection, precedence, or the transactional load.
 
-The helper is private infrastructure for a later automatic-selection slice and
-is deliberately not wired into any public path yet.
+The helper is private infrastructure for automatic connection selection, which
+is its only caller. This module covers the pass itself and the scope of that
+wiring; the public automatic-selection behavior built on it lives in
+tests/test_adapter_automatic_selection_integration.py.
 
 Callback validation, hostile mutation, rollback internals, exact-name public
 integration, and resolver mutation coverage already live in
@@ -674,34 +676,38 @@ def test_direct_registration_winning_the_lock_suppresses_its_same_name_provider(
 # ---------------------------------------------------------------------------- scope
 
 
-def test_automatic_using_paths_do_not_call_the_load_all_helper(install_entry_points, monkeypatch):
-    def must_not_run(*args, **kwargs):  # pragma: no cover - must never run
-        raise AssertionError("automatic selection must not load all providers in this slice")
+def test_only_automatic_selection_calls_the_pass(install_entry_points, monkeypatch):
+    # a spy, not a stub: the real pass still runs underneath, so this pins *where* it is wired in
+    # rather than replacing the behavior the rest of the suite exercises
+    pass_calls = []
+    real_pass = main._load_all_adapter_providers
 
-    monkeypatch.setattr(main, "_load_all_adapter_providers", must_not_run)
-    entry, calls = provider("acmedb", predicate=lambda connection: True)
+    def counting_pass(*args, **kwargs):
+        pass_calls.append("called")
+        return real_pass(*args, **kwargs)
+
+    monkeypatch.setattr(main, "_load_all_adapter_providers", counting_pass)
+    entry, calls = provider("acmedb", commands=MockCommands, async_commands=MockAsyncCommands)
     install_entry_points([entry])
     connection = object()
 
-    # automatic selection stays registry-only: the installed provider is never loaded, so its
-    # would-be matching predicate is never consulted
-    with pytest.raises(ValueError) as sync_excinfo:
+    # every name-based path resolves one exact name and never runs the pass
+    assert isinstance(pydapper.connect("somedb+acmedb://localhost/database"), MockCommands)
+    assert isinstance(pydapper.using(connection, adapter="acmedb"), MockCommands)
+    assert isinstance(pydapper.using_async(connection, adapter="acmedb"), MockAsyncCommands)
+    assert pass_calls == []
+    assert calls == ["called"]
+
+    # automatic selection runs it exactly once per call, through one shared call site for both modes
+    with pytest.raises(ValueError, match="No registered sync adapter"):
         pydapper.using(connection)
-    with pytest.raises(ValueError) as async_excinfo:
+    assert pass_calls == ["called"]
+    with pytest.raises(ValueError, match="No registered async adapter"):
         pydapper.using_async(connection)
-
-    assert "No registered sync adapter" in str(sync_excinfo.value)
-    assert "No registered async adapter" in str(async_excinfo.value)
-    assert calls == []
-    assert_nothing_loaded([entry])
-    assert "acmedb" not in main._adapter_registry
+    assert pass_calls == ["called", "called"]
 
 
-def test_automatic_selection_still_uses_a_directly_registered_adapter(install_entry_points, monkeypatch):
-    def must_not_run(*args, **kwargs):  # pragma: no cover - must never run
-        raise AssertionError("automatic selection must not load all providers in this slice")
-
-    monkeypatch.setattr(main, "_load_all_adapter_providers", must_not_run)
+def test_automatic_selection_runs_the_pass_even_when_a_registered_adapter_matches(install_entry_points):
     entry, calls = provider("acmedb")
     install_entry_points([entry])
     connection = object()
@@ -714,8 +720,11 @@ def test_automatic_selection_still_uses_a_directly_registered_adapter(install_en
 
     assert isinstance(pydapper.using(connection), MockCommands)
     assert isinstance(pydapper.using_async(connection), MockAsyncCommands)
-    assert calls == []
-    assert_nothing_loaded([entry])
+
+    # no registry-only shortcut: the unrelated provider is loaded anyway, because an unloaded
+    # provider could have matched too and made this an ambiguity rather than a selection
+    assert calls == ["called"]
+    assert entry.load_calls == 1
 
 
 def test_load_all_adds_no_public_api():

--- a/tests/test_adapter_name_resolution_integration.py
+++ b/tests/test_adapter_name_resolution_integration.py
@@ -534,29 +534,34 @@ def test_dsn_resolution_errors_never_leak_credentials(install_entry_points, capl
     assert "localhost/database" not in leaked
 
 
-# ---------------------------------------------------------------------------- automatic selection is unchanged
+# ---------------------------------------------------------------------------- automatic selection deliberately differs
 
 
-def test_automatic_selection_still_uses_the_registry_only(install_entry_points):
-    # this provider's predicate would match if automatic selection loaded installed providers;
-    # loading every provider for predicate evaluation is the next #468 slice, not this one
+def test_only_automatic_selection_loads_unrelated_installed_providers(install_entry_points):
+    # the intentional #468 contrast, shown on one catalog: a name-based path loads only the
+    # provider it was asked for, while automatic selection loads every installed provider so their
+    # predicates exist to be evaluated at all
     entry_point, calls = provider(
         "acmedb", commands=MockCommands, async_commands=MockAsyncCommands, predicate=always_matches
     )
-    install_entry_points([entry_point])
+    unrelated, unrelated_calls = provider("otherdb", distribution="other-adapter")
+    install_entry_points([entry_point, unrelated])
 
-    with pytest.raises(ValueError):
-        pydapper.using(MockConnection())
-    with pytest.raises(ValueError):
-        pydapper.using_async(MockAsyncConnection())
+    assert isinstance(pydapper.using(MockConnection(), adapter="acmedb"), MockCommands)
+    assert calls == ["called"]
+    assert unrelated_calls == []
+    assert_nothing_loaded([unrelated])
 
-    assert calls == []
-    assert_nothing_loaded([entry_point])
-    # nothing on the automatic path even built the catalog
-    assert _adapter_discovery._catalog is None
+    # the same unrelated provider is loaded once automatic selection needs the whole picture
+    assert isinstance(pydapper.using(MockConnection()), MockCommands)
+    assert isinstance(pydapper.using_async(MockAsyncConnection()), MockAsyncCommands)
+    assert unrelated_calls == ["called"]
+    assert unrelated.load_calls == 1
 
 
-def test_automatic_selection_still_resolves_a_directly_registered_match(forbid_discovery):
+def test_automatic_selection_still_resolves_a_directly_registered_match(install_entry_points):
+    install_entry_points([])
+
     class AutomaticCommands(MockCommands): ...
 
     class AutomaticCommandsAsync(MockAsyncCommands): ...
@@ -570,7 +575,9 @@ def test_automatic_selection_still_resolves_a_directly_registered_match(forbid_d
 
     assert isinstance(pydapper.using(MockConnection()), AutomaticCommands)
     assert isinstance(pydapper.using_async(MockAsyncConnection()), AutomaticCommandsAsync)
-    assert _adapter_discovery._catalog is None
+    # automatic selection discovers the catalog now, but an empty one is a successful no-op that
+    # loads nothing
+    assert main._loaded_provider_registrations == {}
 
 
 # ---------------------------------------------------------------------------- public surface


### PR DESCRIPTION
The automatic-selection integration slice of #468.

## What changed

`_load_all_adapter_providers()` (merged in #561) had no caller: it was private
infrastructure waiting for this slice. Automatic connection selection was still
registry-only, so an installed-but-unloaded provider's
`using_connection_predicate` was unreachable and `using(connection)` behaved as
though that adapter did not exist.

This wires the pass in at the single shared chokepoint both automatic paths
already converge on — `_select_registration(connection, mode)` — as the first
statement, before any registry entry is inspected. The production change is one
call plus documentation; `_load_all_adapter_providers()`, the resolver, the
transactional loader, the discovery catalog, and the predicate-selection logic
are all reused exactly as designed.

**Before**

```python
# acmedb is installed and declares pydapper.adapters, but nothing imported it
pydapper.using(acme_connection)
# ValueError: No registered sync adapter can handle <acmedb.Connection ...>;
#             register an adapter or pass adapter= explicitly
```

**After**

```python
pydapper.using(acme_connection)   # loads every installed provider, then matches
# <pydapper_acmedb.commands.AcmeCommands object at ...>
```

## The intentional contrast

| path | loads |
| --- | --- |
| `connect()` / `connect_async()` (DSN) | only the provider named by `parsed_dsn.dbapi` |
| `using(conn, adapter=name)` / `using_async(conn, adapter=name)` | only the provider named by `name` |
| `using(conn)` / `using_async(conn)` (automatic) | **every** installed provider |

Automatic selection has no name to resolve, so it cannot know which unloaded
provider would claim the connection until every predicate exists. The name-based
paths keep their request-only behavior, so an unrelated broken provider still
cannot break them. This slice does not move the pass into
`_resolve_adapter_registration()`, the command-class getters, or the
`CommandFactory` methods shared with explicit/DSN selection.

There is deliberately **no registry-only fast path**. Even when exactly one
already-registered adapter appears to match, an unloaded installed provider
might match too — reporting a selection instead of the ambiguity would be wrong.

## Mode filtering

Loading is mode-independent and mode filtering happens strictly after it:

1. discover the provider catalog;
2. load every resolvable provider — sync-only, async-only, and dual-mode alike;
3. filter registrations by requested mode (`commands` for sync, `async_commands`
   for async), skipping a mode-ineligible registration without evaluating its
   predicate;
4. evaluate eligible predicates in deterministic adapter-name order;
5. apply the existing zero / one / multiple rule.

No mode or connection is passed into `_load_all_adapter_providers()`, and the
helper was not changed to filter. A consequence is intentional: a broken
**async-only** provider still fails a **sync** automatic-selection request, and
vice versa, because automatic selection loads everything before it filters.

## Failure ordering and predicate behavior

Failure is fail-fast and ordered ahead of all predicate evaluation. If
discovery, duplicate resolution, provider import, callback execution, or
callback validation fails, the existing load-all/resolver/loader `ValueError`
propagates with its cause chain intact, no predicate runs — including a
predicate belonging to an adapter registered before the call — and the error is
never re-wrapped with the connection representation, so a credential-bearing
connection repr cannot reach a provider error. Providers loaded earlier in the
pass keep their registrations per #561's retry behavior; there is no global
rollback, so repairing a provider and retrying resumes without reinvoking a
successful callback.

Everything after a successful pass is unchanged: original connection object
passed to each predicate and to the selected command class, the no-match
`ValueError`, the deterministic ambiguity `ValueError` naming the matching
adapters, and predicate exceptions wrapped with the original exception as
`__cause__`.

#561's precedence and locking are reused as-is: a directly registered name
suppresses its same-name installed provider (whose predicate never runs) while
that registration's own predicate still participates in matching; duplicate
unregistered providers fail before any predicate; no second lock is introduced;
and no lock is held around user predicate execution.

## Tests

New: `tests/test_adapter_automatic_selection_integration.py` (19 tests). It
drives the real public `pydapper.using()` / `pydapper.using_async()` against the
real catalog, the real `_load_all_adapter_providers()`, the real resolver, the
real transactional loader, and the real predicate-selection logic. Only
installed entry-point metadata is faked — nothing in that composition is stubbed,
and no package is installed from the network. Coverage: provider-backed sync and
async selection; connection identity through predicate and command class;
load-before-first-predicate ordering; mode-independent loading with
mode-filtered evaluation; zero / one / multiple matches; registry + provider
ambiguity; direct-registration suppression; broken-provider failure ordering and
cause preservation; repair-and-retry; duplicate providers; predicate-error
causes; repeated and concurrent (barrier/event, no sleeps) callback-once
behavior; name-path isolation; and no new public surface.

Obsolete assertions that pinned the pre-integration behavior were updated in
place, not weakened:

* `tests/test_adapter_load_all.py` — `test_automatic_using_paths_do_not_call_the_load_all_helper`
  became `test_only_automatic_selection_calls_the_pass`, now a **spy** (the real
  pass still runs) proving the pass is reached from automatic selection and from
  no name-based path; `test_automatic_selection_still_uses_a_directly_registered_adapter`
  became `test_automatic_selection_runs_the_pass_even_when_a_registered_adapter_matches`,
  pinning the absence of a registry-only shortcut.
* `tests/test_adapter_name_resolution_integration.py` —
  `test_automatic_selection_still_uses_the_registry_only` became
  `test_only_automatic_selection_loads_unrelated_installed_providers`, pinning
  the contrast on one catalog; the directly-registered-match test no longer
  forbids discovery, since automatic selection legitimately discovers now.

Unrelated exact-name isolation tests are untouched, and the `forbid_discovery`
guard still protects the pure-registry name-based test. Each new test also
passes in isolation, and the adapter modules pass in three different orderings.

## Later work

First-party `pydapper.adapters` entry-point packaging, removal of the
`_builtin_adapters` eager bootstrap, and documentation/release notes for
discovery and loading all remain outstanding under #468.

## Verification

| command | result |
| --- | --- |
| `poetry run pytest tests/test_adapter_automatic_selection_integration.py` | 19 passed |
| `poetry run pytest tests/test_adapter_load_all.py tests/test_adapter_name_resolution_integration.py tests/test_adapter_resolution.py tests/test_adapter_loading.py tests/test_adapter_discovery.py tests/test_main.py` | 297 passed |
| `poetry run pytest -m "core"` | 1174 passed, 208 deselected |
| `poetry run pytest -m "sqlite"` | 29 passed, 1353 deselected |
| `poetry run mypy pydapper` | Success: no issues found in 28 source files |
| `poetry run mypy tests/type_tests.py` | Success: no issues found in 1 source file |
| `poetry run black --check pydapper tests` | 70 files unchanged |
| `poetry run isort --check pydapper tests` | clean |
| `git diff --check` | clean |

Skipped: the `postgresql`, `mysql`, `mssql`, `oracle`, and `bigquery` marker
suites. They need optional extras plus Docker/testcontainers or cloud services
that are not installed or running here, and this slice touches no backend
adapter, command, transaction, or DSN behavior. `mkdocs build --strict` was not
run — docs are explicitly out of scope for this slice and no docs file changed.

Refs #468
