### PR TITLE
feat: extract first-party adapter provider callbacks

### DIFF
--- a/pydapper/_adapter_providers.py
+++ b/pydapper/_adapter_providers.py
@@ -1,0 +1,149 @@
+"""Private per-adapter registration callbacks for the first-party adapters.
+
+Each stable first-party adapter name owns exactly one zero-argument callback
+that registers exactly that name through the public ``register_adapter()`` and
+returns ``None``. These are the shape a later #468 slice will target from
+``[project.entry-points."pydapper.adapters"]`` metadata, so they satisfy the
+third-party provider-callback contract already: synchronous, zero-argument,
+``-> None``, one registration each, and no connection, network, credential, or
+discovery work.
+
+Command-class imports live *inside* the callbacks on purpose. Importing this
+module must not drag in every backend command module, because the next slice
+replaces the eager bootstrap with entry-point loading and only the requested
+adapter's provider should import anything. Registering an adapter still imports
+no optional database driver: the command classes defer that to connection
+creation via ``import_dbapi_module()``.
+
+Nothing here registers at import time -- ``_builtin_adapters`` invokes these
+callbacks -- and nothing here is exported from the package root.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .main import register_adapter
+
+
+def _connection_module_matches(connection: object, *module_prefixes: str) -> bool:
+    """Report whether a connection's type comes from one of the driver modules.
+
+    Walks ``type(connection).__mro__`` so a subclass of a driver connection is
+    claimed by the adapter that owns its base class, and matches a module only
+    when it equals a prefix or is a child module of it (``psycopg2`` matches
+    ``psycopg2`` and ``psycopg2.extensions`` but never ``psycopg2evil``).
+
+    Deliberately structural and cheap: it imports no driver module to answer,
+    and reads no ``repr()``, credential, DSN, attribute, or live network state
+    from the connection. A class with a non-string ``__module__`` is skipped
+    rather than raising.
+    """
+    for connection_class in type(connection).__mro__:
+        module = getattr(connection_class, "__module__", "")
+        if not isinstance(module, str):
+            continue
+        if any(module == prefix or module.startswith(f"{prefix}.") for prefix in module_prefixes):
+            return True
+    return False
+
+
+def _register_sqlite3_provider() -> None:
+    from .sqlite import Sqlite3Commands
+
+    register_adapter(
+        "sqlite3",
+        commands=Sqlite3Commands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "sqlite3"),
+    )
+
+
+def _register_psycopg2_provider() -> None:
+    from .postgresql import Psycopg2Commands
+
+    register_adapter(
+        "psycopg2",
+        commands=Psycopg2Commands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg2"),
+    )
+
+
+def _register_psycopg_provider() -> None:
+    # one adapter name owns both modes: psycopg3 sync and async register together through this
+    # single callback, never as two registrations
+    from .postgresql import Psycopg3Commands
+    from .postgresql import Psycopg3CommandsAsync
+
+    register_adapter(
+        "psycopg",
+        commands=Psycopg3Commands,
+        async_commands=Psycopg3CommandsAsync,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg"),
+    )
+
+
+def _register_aiopg_provider() -> None:
+    from .postgresql import AiopgCommands
+
+    register_adapter(
+        "aiopg",
+        async_commands=AiopgCommands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "aiopg"),
+    )
+
+
+def _register_mysql_provider() -> None:
+    from .mysql import MySqlConnectorPythonCommands
+
+    register_adapter(
+        "mysql",
+        commands=MySqlConnectorPythonCommands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "mysql.connector"),
+    )
+
+
+def _register_pymssql_provider() -> None:
+    from .mssql import PymssqlCommands
+
+    register_adapter(
+        "pymssql",
+        commands=PymssqlCommands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "pymssql"),
+    )
+
+
+def _register_oracledb_provider() -> None:
+    from .oracle import OracledbCommands
+
+    register_adapter(
+        "oracledb",
+        commands=OracledbCommands,
+        using_connection_predicate=lambda connection: _connection_module_matches(connection, "oracledb"),
+    )
+
+
+def _register_google_provider() -> None:
+    from .bigquery import GoogleBigqueryClientCommands
+
+    register_adapter(
+        "google",
+        commands=GoogleBigqueryClientCommands,
+        using_connection_predicate=lambda connection: _connection_module_matches(
+            connection, "google.cloud.bigquery.dbapi"
+        ),
+    )
+
+
+# the eager bootstrap's single delegation mechanism, in the original registration order. Entry-point
+# metadata in a later slice targets the callbacks individually, so this tuple stays an ordering
+# detail of the current bootstrap rather than a registry of its own.
+_FIRST_PARTY_ADAPTER_PROVIDERS: tuple[Callable[[], None], ...] = (
+    _register_sqlite3_provider,
+    _register_psycopg2_provider,
+    _register_psycopg_provider,
+    _register_aiopg_provider,
+    _register_mysql_provider,
+    _register_pymssql_provider,
+    _register_oracledb_provider,
+    _register_google_provider,
+)

--- a/pydapper/_builtin_adapters.py
+++ b/pydapper/_builtin_adapters.py
@@ -1,69 +1,24 @@
-from .bigquery import GoogleBigqueryClientCommands
-from .main import register_adapter
-from .mssql import PymssqlCommands
-from .mysql import MySqlConnectorPythonCommands
-from .oracle import OracledbCommands
-from .postgresql import AiopgCommands
-from .postgresql import Psycopg2Commands
-from .postgresql import Psycopg3Commands
-from .postgresql import Psycopg3CommandsAsync
-from .sqlite import Sqlite3Commands
+"""Eager bootstrap of the first-party adapters at package import.
 
+Temporary and intentionally unchanged in behavior: ``pydapper/__init__.py``
+still imports this module, and importing it still registers the same eight
+stable adapter names in the same order it always has.
 
-def _connection_module_matches(connection: object, *module_prefixes: str) -> bool:
-    for connection_class in type(connection).__mro__:
-        module = getattr(connection_class, "__module__", "")
-        if not isinstance(module, str):
-            continue
-        if any(module == prefix or module.startswith(f"{prefix}.") for prefix in module_prefixes):
-            return True
-    return False
+The registration definitions themselves now live in ``_adapter_providers`` as
+one callback per adapter name, so this module is only the ordering and the
+invocation. There is deliberately no ``register_adapter()`` call and no
+command-class import left here -- duplicating either would give first-party
+registration two sources of truth right before the next #468 slice moves the
+same callbacks behind ``pydapper.adapters`` entry points and deletes this eager
+bootstrap.
+"""
+
+from ._adapter_providers import _FIRST_PARTY_ADAPTER_PROVIDERS
 
 
 def _register_builtin_adapters() -> None:
-    register_adapter(
-        "sqlite3",
-        commands=Sqlite3Commands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "sqlite3"),
-    )
-    register_adapter(
-        "psycopg2",
-        commands=Psycopg2Commands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg2"),
-    )
-    register_adapter(
-        "psycopg",
-        commands=Psycopg3Commands,
-        async_commands=Psycopg3CommandsAsync,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "psycopg"),
-    )
-    register_adapter(
-        "aiopg",
-        async_commands=AiopgCommands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "aiopg"),
-    )
-    register_adapter(
-        "mysql",
-        commands=MySqlConnectorPythonCommands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "mysql.connector"),
-    )
-    register_adapter(
-        "pymssql",
-        commands=PymssqlCommands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "pymssql"),
-    )
-    register_adapter(
-        "oracledb",
-        commands=OracledbCommands,
-        using_connection_predicate=lambda connection: _connection_module_matches(connection, "oracledb"),
-    )
-    register_adapter(
-        "google",
-        commands=GoogleBigqueryClientCommands,
-        using_connection_predicate=lambda connection: _connection_module_matches(
-            connection, "google.cloud.bigquery.dbapi"
-        ),
-    )
+    for register_provider in _FIRST_PARTY_ADAPTER_PROVIDERS:
+        register_provider()
 
 
 _register_builtin_adapters()

--- a/tests/test_first_party_adapter_providers.py
+++ b/tests/test_first_party_adapter_providers.py
@@ -1,0 +1,606 @@
+"""Focused coverage for the first-party adapter provider callbacks.
+
+Exercises ``pydapper._adapter_providers`` -- the eight zero-argument callbacks a
+later #468 slice will target from ``pydapper.adapters`` entry-point metadata --
+and the eager ``_builtin_adapters`` bootstrap that currently delegates to them.
+
+These tests own the *callback contract* and the *registration table*: the exact
+name each callback registers, its sync/async shape, its command classes, its
+connection-predicate semantics, and the fact that neither invoking a callback
+nor evaluating a predicate imports an optional database driver. The generic
+provider loader's callback validation, hostile-callback defenses, and
+transactional rollback already have dedicated coverage in
+tests/test_adapter_loading.py, tests/test_adapter_resolution.py, and
+tests/test_adapter_load_all.py and are not duplicated here.
+
+Process-level facts -- driver import laziness and fresh-interpreter bootstrap
+order -- are asserted in clean subprocesses rather than by deleting entries from
+this process's ``sys.modules``.
+"""
+
+import inspect
+import json
+import subprocess
+import sys
+import textwrap
+import typing
+
+import pytest
+
+import pydapper
+import pydapper.main as main
+from pydapper import _adapter_providers
+from pydapper import _builtin_adapters
+from pydapper.bigquery import GoogleBigqueryClientCommands
+from pydapper.mssql import PymssqlCommands
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.oracle import OracledbCommands
+from pydapper.postgresql import AiopgCommands
+from pydapper.postgresql import Psycopg2Commands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.sqlite import Sqlite3Commands
+
+pytestmark = pytest.mark.core
+
+
+# the registration table this slice must preserve exactly, in the original bootstrap order:
+# (callback attribute name, adapter name, sync commands, async commands, connection module prefix)
+PROVIDER_TABLE = (
+    ("_register_sqlite3_provider", "sqlite3", Sqlite3Commands, None, "sqlite3"),
+    ("_register_psycopg2_provider", "psycopg2", Psycopg2Commands, None, "psycopg2"),
+    ("_register_psycopg_provider", "psycopg", Psycopg3Commands, Psycopg3CommandsAsync, "psycopg"),
+    ("_register_aiopg_provider", "aiopg", None, AiopgCommands, "aiopg"),
+    ("_register_mysql_provider", "mysql", MySqlConnectorPythonCommands, None, "mysql.connector"),
+    ("_register_pymssql_provider", "pymssql", PymssqlCommands, None, "pymssql"),
+    ("_register_oracledb_provider", "oracledb", OracledbCommands, None, "oracledb"),
+    ("_register_google_provider", "google", GoogleBigqueryClientCommands, None, "google.cloud.bigquery.dbapi"),
+)
+
+EXPECTED_NAMES = tuple(row[1] for row in PROVIDER_TABLE)
+
+# every optional driver a provider callback or a connection predicate must never pull in. The
+# standard-library ``sqlite3`` module is deliberately absent: importing it through the SQLite
+# command implementation is acceptable.
+OPTIONAL_DRIVERS = (
+    "psycopg2",
+    "psycopg",
+    "aiopg",
+    "mysql.connector",
+    "pymssql",
+    "oracledb",
+    "google.cloud.bigquery.dbapi",
+)
+
+
+def table_row(callback_attr):
+    for row in PROVIDER_TABLE:
+        if row[0] == callback_attr:
+            return row
+    raise AssertionError(f"{callback_attr} is not in the expected provider table")  # pragma: no cover
+
+
+def callback(callback_attr):
+    return getattr(_adapter_providers, callback_attr)
+
+
+def ids(rows):
+    return [row[1] for row in rows]
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch):
+    """Give each test a private registry, provider catalog, and loader cache.
+
+    Every piece of process state these tests touch is swapped through
+    monkeypatch, so this is a real snapshot/restore rather than a reset: state
+    the process had already built is put back verbatim at teardown and nothing
+    here can decide whether a name resolves in another module. First-party
+    adapters are still eagerly registered at import time in this slice, so the
+    registry is copied rather than emptied.
+    """
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    monkeypatch.setattr(main, "_loaded_provider_registrations", {})
+    yield registry
+
+
+@pytest.fixture
+def register_fresh(isolated_registry):
+    """Invoke one provider callback with its own name not yet registered.
+
+    Returns ``(result, registration, before)`` so a test can assert the callback's
+    return value, the registration it produced, and that it disturbed nothing else.
+    """
+
+    def invoke(callback_attr):
+        name = table_row(callback_attr)[1]
+        isolated_registry.pop(name, None)
+        before = dict(isolated_registry)
+        result = callback(callback_attr)()
+        return result, isolated_registry[name], before
+
+    return invoke
+
+
+def connection_from_module(module, *, bases=()):
+    """Build a connection object whose type reports ``module`` as its ``__module__``."""
+    return type("FakeConnection", bases or (object,), {"__module__": module})()
+
+
+def run_in_subprocess(body):
+    """Run a script in a clean interpreter and return its stdout.
+
+    Every script ends by printing a sentinel, and the caller asserts on it, so a
+    script that silently fails to reach its assertions cannot pass as a success.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, f"subprocess failed:\n{completed.stdout}\n{completed.stderr}"
+    return completed.stdout
+
+
+# a meta-path finder makes the driver-import assertions independent of which optional extras happen
+# to be installed: a forbidden import fails loudly even when the driver is absent, where a
+# sys.modules check would silently pass
+DRIVER_IMPORT_GUARD = """
+import sys
+
+FORBIDDEN = {forbidden!r}
+
+
+class ForbiddenDriverImport(AssertionError):
+    pass
+
+
+class DriverImportGuard:
+    def find_spec(self, fullname, path=None, target=None):
+        for prefix in FORBIDDEN:
+            if fullname == prefix or fullname.startswith(prefix + "."):
+                raise ForbiddenDriverImport(fullname)
+        return None
+
+
+def install_guard():
+    for prefix in FORBIDDEN:
+        assert prefix not in sys.modules, prefix
+    sys.meta_path.insert(0, DriverImportGuard())
+
+
+def assert_guard_is_armed():
+    # proves the guard would really fire, so a passing driver-laziness test can never be a
+    # silently inert import hook
+    try:
+        __import__(FORBIDDEN[0])
+    except ForbiddenDriverImport:
+        return
+    raise AssertionError("driver import guard did not fire")
+"""
+
+# a bootstrap stub lets a subprocess import the provider module *without* the eager
+# `_builtin_adapters` bootstrap having populated the registry first, which is how the next slice
+# will import it. Seeding sys.modules is the only way to observe that today, since importing any
+# pydapper submodule runs the package __init__.
+BOOTSTRAP_STUB = """
+import sys
+import types
+
+sys.modules["pydapper._builtin_adapters"] = types.ModuleType("pydapper._builtin_adapters")
+"""
+
+
+def driver_guard_script(body):
+    return DRIVER_IMPORT_GUARD.format(forbidden=list(OPTIONAL_DRIVERS)) + textwrap.dedent(body)
+
+
+def bootstrap_stub_script(body):
+    return BOOTSTRAP_STUB + textwrap.dedent(body)
+
+
+# ---------------------------------------------------------------------------- callback surface
+
+
+def test_module_exposes_exactly_the_eight_intended_callbacks():
+    discovered = sorted(
+        name
+        for name, value in vars(_adapter_providers).items()
+        if name.startswith("_register_") and name.endswith("_provider") and inspect.isfunction(value)
+    )
+
+    assert discovered == sorted(row[0] for row in PROVIDER_TABLE)
+
+
+def test_provider_tuple_holds_the_eight_callbacks_in_registration_order():
+    assert _adapter_providers._FIRST_PARTY_ADAPTER_PROVIDERS == tuple(callback(row[0]) for row in PROVIDER_TABLE)
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_is_synchronous_zero_argument_and_annotated_none(row):
+    fn = callback(row[0])
+
+    assert inspect.isfunction(fn)
+    assert not inspect.iscoroutinefunction(fn)
+    assert not inspect.isasyncgenfunction(fn)
+    assert not inspect.isgeneratorfunction(fn)
+    assert list(inspect.signature(fn).parameters) == []
+    assert typing.get_type_hints(fn)["return"] is type(None)
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_returns_none(row, register_fresh):
+    result, _, _ = register_fresh(row[0])
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------- registration effect
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_adds_exactly_one_registration_with_its_assigned_name(row, register_fresh, isolated_registry):
+    _, registration, before = register_fresh(row[0])
+
+    assert list(isolated_registry) == list(before) + [row[1]]
+    assert registration.name == row[1]
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_leaves_unrelated_registrations_unchanged(row, register_fresh, isolated_registry):
+    _, _, before = register_fresh(row[0])
+
+    assert list(isolated_registry)[: len(before)] == list(before)
+    for name, registration in before.items():
+        assert isolated_registry[name] is registration
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_registers_the_expected_command_classes(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+
+    assert registration.commands is row[2]
+    assert registration.async_commands is row[3]
+
+
+def test_psycopg_registers_both_modes_through_one_callback(register_fresh, isolated_registry):
+    _, registration, before = register_fresh("_register_psycopg_provider")
+
+    assert list(isolated_registry) == list(before) + ["psycopg"]
+    assert registration.commands is Psycopg3Commands
+    assert registration.async_commands is Psycopg3CommandsAsync
+
+
+def test_aiopg_remains_async_only(register_fresh):
+    _, registration, _ = register_fresh("_register_aiopg_provider")
+
+    assert registration.commands is None
+    assert registration.async_commands is AiopgCommands
+
+
+@pytest.mark.parametrize(
+    "row", [row for row in PROVIDER_TABLE if row[1] not in {"psycopg", "aiopg"}], ids=lambda row: row[1]
+)
+def test_non_psycopg_adapters_remain_sync_only(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+
+    assert registration.commands is row[2]
+    assert registration.async_commands is None
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_callback_on_an_already_registered_name_raises_and_preserves_the_registration(row, isolated_registry):
+    name = row[1]
+    existing = isolated_registry[name]
+    before = dict(isolated_registry)
+
+    with pytest.raises(ValueError, match=f"Adapter {name!r} is already registered"):
+        callback(row[0])()
+
+    assert list(isolated_registry) == list(before)
+    assert isolated_registry[name] is existing
+    for other, registration in before.items():
+        assert isolated_registry[other] is registration
+
+
+# ---------------------------------------------------------------------------- connection predicates
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_predicate_accepts_the_exact_driver_module_prefix(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+
+    assert registration.using_connection_predicate(connection_from_module(row[4])) is True
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_predicate_accepts_a_subclass_of_a_driver_connection(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+    driver_connection_class = type("DriverConnection", (object,), {"__module__": row[4]})
+    subclass = type("UserSubclass", (driver_connection_class,), {"__module__": "application.pool"})
+
+    assert registration.using_connection_predicate(subclass()) is True
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_predicate_accepts_driver_child_modules(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+
+    assert registration.using_connection_predicate(connection_from_module(f"{row[4]}.connection")) is True
+
+
+@pytest.mark.parametrize("row", PROVIDER_TABLE, ids=ids(PROVIDER_TABLE))
+def test_predicate_rejects_case_differences_near_prefixes_and_unrelated_modules(row, register_fresh):
+    _, registration, _ = register_fresh(row[0])
+    predicate = registration.using_connection_predicate
+
+    assert predicate(connection_from_module(row[4].upper())) is False
+    assert predicate(connection_from_module(row[4].capitalize())) is False
+    assert predicate(connection_from_module(f"{row[4]}evil")) is False
+    assert predicate(connection_from_module(f"{row[4]}evil.connection")) is False
+    assert predicate(connection_from_module(f"not_{row[4]}")) is False
+    assert predicate(connection_from_module("totally.unrelated.driver")) is False
+
+
+def test_psycopg_predicate_does_not_claim_psycopg2_connections(register_fresh):
+    _, psycopg, _ = register_fresh("_register_psycopg_provider")
+    _, psycopg2, _ = register_fresh("_register_psycopg2_provider")
+
+    assert psycopg.using_connection_predicate(connection_from_module("psycopg2")) is False
+    assert psycopg2.using_connection_predicate(connection_from_module("psycopg")) is False
+    assert psycopg.using_connection_predicate(connection_from_module("psycopg.connection")) is True
+
+
+def test_predicate_ignores_a_non_string_module(register_fresh):
+    _, registration, _ = register_fresh("_register_sqlite3_provider")
+    hostile = type("Hostile", (object,), {"__module__": 42})()
+
+    assert registration.using_connection_predicate(hostile) is False
+
+
+def test_predicate_matches_through_a_non_string_module_in_the_mro(register_fresh):
+    _, registration, _ = register_fresh("_register_sqlite3_provider")
+    driver_base = type("DriverConnection", (object,), {"__module__": "sqlite3"})
+    hostile = type("Hostile", (driver_base,), {"__module__": 42})()
+
+    assert registration.using_connection_predicate(hostile) is True
+
+
+# ---------------------------------------------------------------------------- import laziness
+
+
+def test_callback_invocation_imports_no_optional_driver():
+    output = run_in_subprocess(driver_guard_script("""
+            install_guard()
+            assert_guard_is_armed()
+
+            import pydapper.main as main
+            from pydapper import _adapter_providers
+
+            # the eager bootstrap already invoked all eight callbacks during ``import pydapper``
+            # above; invoke them again against an empty registry so the guard covers explicit
+            # invocation the way the next slice's entry-point loader will do it
+            main._adapter_registry = {}
+            for provider in _adapter_providers._FIRST_PARTY_ADAPTER_PROVIDERS:
+                assert provider() is None
+
+            assert list(main._adapter_registry) == {names!r}
+            print("INVOKED_WITHOUT_DRIVERS")
+            """.replace("{names!r}", repr(list(EXPECTED_NAMES)))))
+
+    assert "INVOKED_WITHOUT_DRIVERS" in output
+
+
+def test_predicate_evaluation_imports_no_optional_driver():
+    output = run_in_subprocess(driver_guard_script("""
+            install_guard()
+            assert_guard_is_armed()
+
+            import pydapper.main as main
+
+            evaluated = 0
+            for registration in main._adapter_registry.values():
+                for module in ("sqlite3", "psycopg2", "psycopg", "aiopg", "mysql.connector",
+                               "pymssql", "oracledb", "google.cloud.bigquery.dbapi", "unrelated"):
+                    connection = type("FakeConnection", (object,), {"__module__": module})()
+                    assert registration.using_connection_predicate(connection) in (True, False)
+                    evaluated += 1
+
+            assert evaluated == 72, evaluated
+            print("PREDICATES_WITHOUT_DRIVERS")
+            """))
+
+    assert "PREDICATES_WITHOUT_DRIVERS" in output
+
+
+def test_importing_the_provider_module_alone_imports_no_command_module():
+    output = run_in_subprocess(bootstrap_stub_script("""
+        import pydapper._adapter_providers  # noqa: F401
+
+        # importing the callbacks must not drag in every backend command module; the next slice
+        # loads only the requested adapter's provider
+        for command_module in ("pydapper.sqlite", "pydapper.postgresql", "pydapper.mysql",
+                               "pydapper.mssql", "pydapper.oracle", "pydapper.bigquery"):
+            assert command_module not in sys.modules, command_module
+        print("PROVIDER_MODULE_IS_LAZY")
+        """))
+
+    assert "PROVIDER_MODULE_IS_LAZY" in output
+
+
+def test_each_callback_imports_only_its_own_command_module():
+    output = run_in_subprocess(bootstrap_stub_script("""
+        import json
+
+        from pydapper import _adapter_providers
+
+        imported = {}
+        for provider in _adapter_providers._FIRST_PARTY_ADAPTER_PROVIDERS:
+            before = set(sys.modules)
+            provider()
+            imported[provider.__name__] = sorted(
+                name for name in set(sys.modules) - before if name.startswith("pydapper.")
+            )
+        print(json.dumps(imported))
+        """))
+    imported = json.loads(output.strip().splitlines()[-1])
+
+    # each callback pulls in its own backend package the first time that package is needed;
+    # psycopg/aiopg share the already-imported pydapper.postgresql package
+    assert imported["_register_sqlite3_provider"] == ["pydapper.sqlite", "pydapper.sqlite.sqlite3"]
+    assert "pydapper.postgresql" in imported["_register_psycopg2_provider"]
+    assert imported["_register_psycopg_provider"] == []
+    assert imported["_register_aiopg_provider"] == []
+    assert "pydapper.mysql" in imported["_register_mysql_provider"]
+    assert "pydapper.mssql" in imported["_register_pymssql_provider"]
+    assert "pydapper.oracle" in imported["_register_oracledb_provider"]
+    assert "pydapper.bigquery" in imported["_register_google_provider"]
+    # no callback reaches into another adapter's backend package
+    assert not any(name.startswith("pydapper.bigquery") for name in imported["_register_sqlite3_provider"])
+
+
+# ---------------------------------------------------------------------------- eager bootstrap
+
+
+def test_fresh_import_still_registers_the_eight_names_in_order():
+    output = run_in_subprocess("""
+        import json
+
+        import pydapper
+        import pydapper.main as main
+
+        print(json.dumps(list(main._adapter_registry)))
+        """)
+
+    assert json.loads(output.strip().splitlines()[-1]) == list(EXPECTED_NAMES)
+
+
+def test_fresh_import_registers_the_expected_shapes():
+    output = run_in_subprocess("""
+        import json
+
+        import pydapper
+        import pydapper.main as main
+
+        shapes = {
+            name: [
+                registration.commands.__name__ if registration.commands is not None else None,
+                registration.async_commands.__name__ if registration.async_commands is not None else None,
+            ]
+            for name, registration in main._adapter_registry.items()
+        }
+        print(json.dumps(shapes))
+        """)
+    shapes = json.loads(output.strip().splitlines()[-1])
+
+    assert shapes == {
+        row[1]: [row[2].__name__ if row[2] is not None else None, row[3].__name__ if row[3] is not None else None]
+        for row in PROVIDER_TABLE
+    }
+
+
+def test_eager_bootstrap_delegates_to_the_provider_callbacks(monkeypatch, isolated_registry):
+    """The bootstrap is only ordering + invocation; the callbacks are the registration source."""
+    calls = []
+
+    def recorder(name):
+        def record() -> None:
+            calls.append(name)
+
+        return record
+
+    monkeypatch.setattr(
+        _builtin_adapters,
+        "_FIRST_PARTY_ADAPTER_PROVIDERS",
+        tuple(recorder(row[1]) for row in PROVIDER_TABLE),
+    )
+    before = dict(isolated_registry)
+
+    assert _builtin_adapters._register_builtin_adapters() is None
+
+    assert calls == list(EXPECTED_NAMES)
+    # with every callback stubbed out, the bootstrap registered nothing on its own
+    assert list(isolated_registry) == list(before)
+
+
+def test_bootstrap_uses_the_provider_tuple_as_its_single_registration_source():
+    assert _builtin_adapters._FIRST_PARTY_ADAPTER_PROVIDERS is _adapter_providers._FIRST_PARTY_ADAPTER_PROVIDERS
+    # no direct registration path or command-class import survives in the bootstrap module
+    assert not hasattr(_builtin_adapters, "register_adapter")
+    assert not hasattr(_builtin_adapters, "_connection_module_matches")
+    for _, _, commands, async_commands, _ in PROVIDER_TABLE:
+        for command_class in (commands, async_commands):
+            if command_class is not None:
+                assert not hasattr(_builtin_adapters, command_class.__name__)
+
+
+# ---------------------------------------------------------------------------- public surface
+
+
+def test_no_provider_callback_or_record_becomes_a_public_package_symbol():
+    for callback_attr, *_ in PROVIDER_TABLE:
+        assert not hasattr(pydapper, callback_attr)
+    assert not hasattr(pydapper, "_FIRST_PARTY_ADAPTER_PROVIDERS")
+    assert not hasattr(pydapper, "_connection_module_matches")
+
+    # nothing this slice added is reachable by identity through a public package-root symbol
+    private_objects = [callback(row[0]) for row in PROVIDER_TABLE]
+    private_objects.append(_adapter_providers._FIRST_PARTY_ADAPTER_PROVIDERS)
+    private_objects.append(_adapter_providers._connection_module_matches)
+    for name in dir(pydapper):
+        if not name.startswith("_"):
+            attribute = getattr(pydapper, name)
+            assert not any(attribute is private for private in private_objects), name
+
+    # the provider module itself stays a private submodule and is not re-exported
+    assert _adapter_providers.__name__ == "pydapper._adapter_providers"
+    assert "adapter_providers" not in dir(pydapper)
+
+
+def test_provider_module_registers_nothing_at_import_time():
+    output = run_in_subprocess(bootstrap_stub_script("""
+        # the provider module is imported here without the eager bootstrap having run, so any
+        # import-time registration side effect in it would show up in the registry
+        import pydapper.main as main
+
+        assert list(main._adapter_registry) == [], list(main._adapter_registry)
+        import pydapper._adapter_providers  # noqa: F401
+        assert list(main._adapter_registry) == [], list(main._adapter_registry)
+        print("NO_IMPORT_TIME_REGISTRATION")
+        """))
+
+    assert "NO_IMPORT_TIME_REGISTRATION" in output
+
+
+# ---------------------------------------------------------------------------- unchanged behavior
+
+
+def test_connect_still_resolves_a_first_party_adapter(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pydapper.connect("sqlite+sqlite3://pydapper.db") as commands:
+        assert isinstance(commands, Sqlite3Commands)
+        assert commands.execute("create table t (id integer)") == -1
+
+
+def test_explicit_selection_still_resolves_a_first_party_adapter():
+    import sqlite3
+
+    connection = sqlite3.connect(":memory:")
+    try:
+        commands = pydapper.using(connection, adapter="sqlite3")
+        assert isinstance(commands, Sqlite3Commands)
+    finally:
+        connection.close()
+
+
+def test_automatic_selection_still_resolves_a_first_party_adapter():
+    import sqlite3
+
+    connection = sqlite3.connect(":memory:")
+    try:
+        commands = pydapper.using(connection)
+        assert isinstance(commands, Sqlite3Commands)
+    finally:
+        connection.close()


### PR DESCRIPTION
First-party provider-callback extraction slice of #468. Depends on #562 (merged), which made automatic `using()`/`using_async()` selection load all installed providers before evaluating predicates.

## What changed and why

#468 will eventually declare the eight first-party adapters through `[project.entry-points."pydapper.adapters"]`, where each entry point must target a synchronous, zero-argument callback that registers exactly one adapter name and returns `None`.

Today `pydapper/_builtin_adapters.py` calls `register_adapter()` eight times inline. This PR extracts those eight definitions into callbacks shaped for that contract, in a new private `pydapper/_adapter_providers.py`, and makes the existing eager bootstrap delegate to them. **No behavior changes.**

## The eight callbacks

| Callback | Name | Sync commands | Async commands | Connection module prefix |
| --- | --- | --- | --- | --- |
| `_register_sqlite3_provider` | `sqlite3` | `Sqlite3Commands` | — | `sqlite3` |
| `_register_psycopg2_provider` | `psycopg2` | `Psycopg2Commands` | — | `psycopg2` |
| `_register_psycopg_provider` | `psycopg` | `Psycopg3Commands` | `Psycopg3CommandsAsync` | `psycopg` |
| `_register_aiopg_provider` | `aiopg` | — | `AiopgCommands` | `aiopg` |
| `_register_mysql_provider` | `mysql` | `MySqlConnectorPythonCommands` | — | `mysql.connector` |
| `_register_pymssql_provider` | `pymssql` | `PymssqlCommands` | — | `pymssql` |
| `_register_oracledb_provider` | `oracledb` | `OracledbCommands` | — | `oracledb` |
| `_register_google_provider` | `google` | `GoogleBigqueryClientCommands` | — | `google.cloud.bigquery.dbapi` |

`psycopg` registers both modes together through one callback and one adapter name. Each callback is an explicit function (no generated closures), calls the public `register_adapter()` exactly once, returns `None`, opens no connection, and relies on existing `register_adapter()` validation and duplicate-name behavior. Nothing registers at provider-module import time.

## Single source of registration truth

`_builtin_adapters` no longer contains any `register_adapter()` call or command-class import. It holds only the ordering and the invocation:

```python
from ._adapter_providers import _FIRST_PARTY_ADAPTER_PROVIDERS


def _register_builtin_adapters() -> None:
    for register_provider in _FIRST_PARTY_ADAPTER_PROVIDERS:
        register_provider()


_register_builtin_adapters()
```

The eight definitions are not duplicated across the two modules.

## Deferred imports

Command-class imports live inside the individual callbacks, so importing `_adapter_providers` does not pull in every backend command module — which matters for the next slice, when entry-point loading replaces the eager bootstrap. Invoking a callback still imports no optional database driver (`psycopg2`, `psycopg`, `aiopg`, `mysql.connector`, `pymssql`, `oracledb`, `google.cloud.bigquery.dbapi`); the command classes keep deferring driver import to connection creation via `import_dbapi_module()`. Importing the standard-library `sqlite3` module through the SQLite command implementation is unchanged and acceptable.

## Predicates

`_connection_module_matches()` moved verbatim into `_adapter_providers` as the single predicate implementation, with its exact semantics preserved: walks `type(connection).__mro__`, matches a module equal to the prefix or beginning with `<prefix>.`, supports driver-connection subclasses, rejects near-prefix spoofing (`psycopg2evil` for prefix `psycopg2`), safely ignores a non-string `__module__`, imports no driver module to answer, and inspects no `repr()`, credential, DSN, attribute, or network state.

## Eager import behavior intentionally unchanged

`pydapper/__init__.py` still imports `_builtin_adapters`, the module-level bootstrap call remains, and a plain `import pydapper` still eagerly registers the same eight names in the same order. This is deliberate so the extraction is behavior-preserving. Entry-point metadata, eager-bootstrap removal, built-wheel metadata verification, and documentation are later slices — no `pyproject.toml`/`poetry.lock` change here.

## Tests

New `tests/test_first_party_adapter_providers.py` (106 tests) isolates the private registry and loader cache per test via monkeypatch snapshot/restore, following existing fixture conventions. It covers the callback surface (exactly eight functions, synchronous, zero-argument, `-> None`, returning `None`), the exact registration table and sync/async shapes, `psycopg` registering both modes together, `aiopg` staying async-only, duplicate-name `ValueError` preserving the existing registration, and predicate accept/reject semantics including case differences and near-prefix names.

Process-level facts run in clean subprocesses rather than by mutating this process's `sys.modules`: fresh-interpreter bootstrap order and shapes, provider-module import laziness, and driver-import laziness. The driver checks install a `sys.meta_path` guard that raises on any forbidden driver import, and the script asserts the guard actually fires before proceeding — so the assertion cannot pass vacuously when an optional extra is simply not installed.

The suite was mutation-checked: swapping the bootstrap order, renaming `oracledb` to `oracle`, dropping `Psycopg3CommandsAsync`, changing the `mysql.connector` prefix, weakening the predicate to a bare `startswith`, hoisting a command import to module level, and reintroducing a direct `register_adapter` in the bootstrap each produce failures.

Generic provider-loader callback validation and rollback are not re-tested here; they have dedicated coverage in `tests/test_adapter_loading.py`, `tests/test_adapter_resolution.py`, and `tests/test_adapter_load_all.py`.

## Verification

| Command | Result |
| --- | --- |
| `poetry run pytest tests/test_first_party_adapter_providers.py` | 106 passed |
| `poetry run pytest tests/test_main.py tests/test_adapter_loading.py tests/test_adapter_resolution.py tests/test_adapter_load_all.py tests/test_adapter_name_resolution_integration.py tests/test_adapter_automatic_selection_integration.py` | 292 passed |
| `poetry run pytest -m "core"` | 1280 passed, 208 deselected |
| `poetry run pytest -m "sqlite"` | 29 passed, 1459 deselected |
| `poetry run mypy pydapper` | Success: no issues found in 29 source files |
| `poetry run mypy tests/type_tests.py` | Success: no issues found in 1 source file |
| `poetry run black --check pydapper tests` | 72 files unchanged |
| `poetry run isort --check pydapper tests` | clean |
| `git diff --check` | clean |

Driver-specific suites (`postgresql`, `mysql`, `mssql`, `oracle`, `bigquery`) were **not** run: they require optional extras and Docker/testcontainers services that are not installed in this environment, and this refactor does not touch command behavior, DSN parsing, or driver code. No optional extras were installed and no database services were launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)