### PR TITLE
feat: add reusable adapter conformance suite and capability profiles

### DIFF
--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -82,6 +82,13 @@ including a SQL `NULL` note, a falsey `0` score, and an empty-string label — t
 seed. All query and DML statements are written in pydapper's portable `?name?` placeholder syntax, so they run
 unchanged on every adapter; the harness owns only DDL, seeding, and connection construction.
 
+Every value the framework itself binds as a parameter is non-`NULL`. Some drivers — BigQuery's DBAPI, for
+example — derive a parameter's type from its Python value and reject an untyped `None`, so binding `NULL` is
+not part of the mandatory core profiles. The canonical dataset still contains a real SQL `NULL` note and
+`scalar.null-returns-none` still asserts that a stored `NULL` reads back as `None`; producing that `NULL` is
+the harness's job, and a harness whose driver cannot bind `None` may seed it any way its dialect allows (the
+BigQuery harness binds a sentinel and then clears it with a literal `UPDATE ... SET note = NULL`).
+
 A harness that does not supply a field a case needs fails that case with a structured
 `HarnessDefinitionError` carrying the profile id, the case id, and the missing field name — a missing harness
 field never silently skips or weakens a core case. There is deliberately no "skip this core case" option;
@@ -163,7 +170,7 @@ service or emulator is available.
 | `mysql` | `MySqlConnectorPythonCommands` | sync | *(none)* | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes |
 | `pymssql` | `PymssqlCommands` | sync | *(none)* | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md) |
 | `oracledb` | `OracledbCommands` | sync | *(none)* | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`) |
-| `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`) |
+| `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`), and the DBAPI cannot bind an untyped `None`, so the harness seeds the canonical SQL `NULL` note through a sentinel and a literal `UPDATE` |
 
 ## Extending the suite in future capability work
 

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -1,0 +1,181 @@
+# Adapter conformance
+
+`pydapper.testing.adapter_conformance` is a reusable, typed conformance suite for adapter command classes. It
+ships inside the installed `pydapper` distribution, so first-party and third-party adapter authors run the same
+contract without copying tests out of the pydapper repository. The helper uses only the Python standard library
+and pydapper core: it does not require pytest or any other test framework, it never imports an optional database
+driver, and importing it starts no service, container, or emulator. It is not exported from the `pydapper`
+package root; import it explicitly:
+
+```python
+from pydapper.testing.adapter_conformance import run_core_sync
+```
+
+## Mandatory profiles: `core-sync` and `core-async`
+
+`core-sync` and `core-async` are the stable identifiers of the two mandatory profiles.
+
+* Every registration that provides a **sync** command class promises `core-sync`.
+* Every registration that provides an **async** command class promises `core-async`.
+
+The two profiles are independent. An adapter registered for both modes must pass both; passing sync conformance
+says nothing about async conformance, and a sync-only harness is never asked for async fields (or vice versa).
+Mode support is represented by which command classes a registration supplies — these mandatory profiles are
+**not** `AdapterCapability` flags.
+
+Each profile covers registration and selection, the #541 cursor lifecycle (cleanup on success and active
+failure, error precedence, truthy-exit non-suppression, plain and context-manager cursors, unbuffered
+exhaustion and explicit `close()`/`aclose()`), parameter handling and execution, row mapping and `RawRow`
+mappers, zero/one/many cardinality, scalar semantics (no row vs SQL `NULL` vs falsey values), command options,
+preparation-hook ordering, and capability honesty. Cases are either **live** (they run through your real
+database resources) or **instrumented** (they wrap your real concrete command class around framework-owned
+recording and fault-injection connections, so cursor counts, call order, exception precedence, and
+"fails before driver work" guarantees are observed directly rather than inferred from return values).
+
+## Optional capability profiles
+
+Optional behaviors are independent profiles keyed to `pydapper.AdapterCapability` members — there is no linear
+"better adapter" tier, and no adapter is required to support any optional capability. The production catalog is
+returned by `capability_profiles()` and is **currently empty**, because no optional capability is implemented
+yet. The framework enforces honesty in both directions:
+
+* A command class that declares a valid capability with no populated profile for its mode **fails** conformance
+  (`capabilities.declared-profile-populated`). An unimplemented capability can never appear covered; zero-case
+  profiles are rejected outright.
+* A declaration that is not a `frozenset` of `AdapterCapability` members **fails** conformance
+  (`capabilities.declaration-valid`).
+* `supports()` must exactly match the class declaration (`capabilities.supports-matches-declaration`), and
+  valid non-default `CommandOptions` for undeclared capabilities must raise `UnsupportedFeatureError` **before
+  cursor acquisition or driver work** (`options.unsupported-raises`, `options.unsupported-before-driver-work`).
+
+Native database support alone is never enough to declare a capability: a capability describes behavior the
+command class actually implements, tests through its conformance profile, and documents. Until then, the
+feature must fail loudly rather than silently execute as if supported.
+
+## The harness API
+
+A harness supplies factories, isolation, and narrow dialect knobs. It never owns assertions: every behavioral
+check belongs to the framework runner, and harness- or adapter-provided code has no API to declare a case
+passed.
+
+Sync adapters subclass `SyncAdapterHarness`; async adapters subclass `AsyncAdapterHarness`.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `adapter_name` | yes | The registered adapter name (exact, case-sensitive). |
+| `command_class` | yes | The declared concrete `Commands` / `CommandsAsync` subclass for the mode. |
+| `connect_dsn` | yes | A DSN that safely reaches an isolated test database through `connect()` / `connect_async()`. |
+| `create_commands()` | yes | Return a fresh command instance over a fresh connection with the canonical dataset freshly seeded. Called once per case. |
+| `teardown_commands(commands)` | yes | Release everything `create_commands()` built. Runs after success and failure. |
+| `connect_kwargs` | no | Extra kwargs for the `connect()` path (for example BigQuery's `client=`). |
+| `table_name` | no | Name (optionally schema/dataset qualified) of the conformance table. Default `pydapper_conformance`. |
+| `column_case` | no | `"lower"` (default) or `"upper"` for dialects that fold unquoted identifiers (Oracle). |
+| `supports_empty_strings` | no | `False` only when the database cannot store `''` distinctly from NULL (Oracle); the empty-string dataset value then seeds as the documented fallback `"blank"`. |
+| `strict_rowcounts` | no | `False` only when DML rowcounts are documented as unreliable (BigQuery emulator). Rowcount cases still run and must return an `int`; only exact equality is relaxed. |
+| `sql_overrides` | no | Statement-id → SQL overrides for the narrow cases where portable SQL is insufficient (still pydapper `?name?` placeholders). |
+| `recover_after_error(commands)` | no | Backend recovery needed after an intentionally failed command (default no-op). |
+| `cursor_factory_style` | async only | `"awaitable"` (default: `connection.cursor()` returns an awaitable, the `CommandsAsync` base contract) or `"synchronous"` (the psycopg3-async shape: `cursor()` returns the cursor directly and the command class normalizes it). Instrumented cases use this to exercise your real `cursor()` override. |
+
+The framework owns the canonical dataset and every query it runs. `CONFORMANCE_COLUMNS` is
+`("id", "label", "score", "note")` and `seed_rows(supports_empty_strings)` returns the three canonical rows —
+including a SQL `NULL` note, a falsey `0` score, and an empty-string label — that `create_commands()` must
+seed. All query and DML statements are written in pydapper's portable `?name?` placeholder syntax, so they run
+unchanged on every adapter; the harness owns only DDL, seeding, and connection construction.
+
+A harness that does not supply a field a case needs fails that case with a structured
+`HarnessDefinitionError` carrying the profile id, the case id, and the missing field name — a missing harness
+field never silently skips or weakens a core case. There is deliberately no "skip this core case" option;
+driver limitations are expressed only through the narrow, documented knobs above.
+
+## Case isolation and cleanup
+
+Every case gets a fresh command instance, connection, and dataset through `create_commands()`; case ordering
+and earlier failures cannot make later cases pass. `teardown_commands()` runs after every case, on success and
+on failure. If both a case and its teardown fail, the case failure is preserved and the teardown failure is
+retained as structured secondary information on the result (`CaseResult.cleanup_error`); a teardown failure
+after an otherwise passing case fails that case.
+
+## Deterministic, structured results
+
+`run_core_sync()` / `run_core_async()` return a `ConformanceReport` whose `results` follow the declared
+profile/case order exactly, run after run. Each `CaseResult` carries the profile id, case id, pass/fail, a
+human-readable message, the original `cause` exception when one exists, the `missing_field` for harness
+validation failures, and any `cleanup_error`. `report.raise_for_failures()` raises a
+`ConformanceFailureError` that exposes the same structured failures — nothing requires parsing exception
+prose.
+
+## Running one adapter
+
+```python
+from pydapper.testing.adapter_conformance import run_core_sync
+
+report = run_core_sync(MyAdapterHarness())
+for failure in report.failures:
+    print(failure.profile_id, failure.case_id, failure.message)
+report.raise_for_failures()
+```
+
+`run_core_async` is a plain awaitable and is awaited inside your own event loop — the framework never calls
+`asyncio.run()` itself:
+
+```python
+report = await run_core_async(MyAsyncAdapterHarness())
+```
+
+### Complete third-party sync example
+
+```python
+{!docs/../docs_src/adapter_conformance/sync_example.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+### Complete third-party async example
+
+```python
+{!docs/../docs_src/adapter_conformance/async_example.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+## Reporting service-backed runs you could not execute
+
+Service-free evidence (mock harnesses and instrumented concrete-class cases) and live service-backed evidence
+are different things, and reports must keep them distinct. A live suite that was skipped, or merely collected,
+is a test-run status — never a pass. When you cannot run a live suite, report:
+
+* whether the optional database driver was installed;
+* whether the service or emulator was reachable;
+* whether credentials were required and available; and
+* which service-free conformance cases cover the same shared behavior.
+
+## First-party driver conformance matrix
+
+One row per first-party command class. "Verification" describes what is actually executed where — service-free
+coverage runs everywhere, live suites run only under their backend marker when their Docker/testcontainers
+service or emulator is available.
+
+| Adapter name | Command class | Mode | Declared capabilities | Conformance entry | Verification | Driver limits |
+|---|---|---|---|---|---|---|
+| `sqlite3` | `Sqlite3Commands` | sync | *(none)* | `tests/test_sqlite/test_conformance.py` | live, service-free (runs in the core and sqlite suites) | [SQLite](database_support/sqlite.md) |
+| `psycopg2` | `Psycopg2Commands` | sync | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `psycopg` | `Psycopg3Commands` | sync | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `psycopg` | `Psycopg3CommandsAsync` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage (including its synchronous cursor-factory normalization); live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute` |
+| `mysql` | `MySqlConnectorPythonCommands` | sync | *(none)* | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes |
+| `pymssql` | `PymssqlCommands` | sync | *(none)* | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md) |
+| `oracledb` | `OracledbCommands` | sync | *(none)* | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`) |
+| `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`) |
+
+## Extending the suite in future capability work
+
+Every PR that adds or changes an optional capability must, in the same change:
+
+* update the `AdapterCapability` enum/declaration when necessary;
+* add a real, reusable capability profile to the production catalog (zero-case profiles are rejected, so an
+  empty placeholder cannot ship);
+* test at least one supported and one unsupported adapter against the new profile;
+* update the affected first-party capability declaration;
+* update driver limitations and documentation, including the matrix above; and
+* update the type tests when public typing changes.
+
+This keeps `supports()`, the declarations, the profiles, and the documentation honest together: a capability is
+declared only when its implementation, its profile, and its documentation all exist.

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -34,6 +34,15 @@ recording and fault-injection connections, so cursor counts, call order, excepti
 
 ## Optional capability profiles
 
+!!! warning "Provisional API — no capability profiles ship yet"
+    `capability_profiles()` returns an **empty** catalog, and `ConformanceProfile`, `SyncCase`, and `AsyncCase`
+    exist only so the first capability feature has somewhere to land. There is nothing for an adapter author to
+    write against yet: no `AdapterCapability` member has a profile, and no adapter can usefully declare one. This
+    part of the public API is **provisional and may change** when the first real capability profile is added; the
+    mandatory `core-sync` / `core-async` surface described above is not. See
+    [Extending the suite in future capability work](#extending-the-suite-in-future-capability-work) for what that
+    first change must carry.
+
 Optional behaviors are independent profiles keyed to `pydapper.AdapterCapability` members — there is no linear
 "better adapter" tier, and no adapter is required to support any optional capability. The production catalog is
 returned by `capability_profiles()` and is **currently empty**, because no optional capability is implemented
@@ -59,6 +68,23 @@ check belongs to the framework runner, and harness- or adapter-provided code has
 passed.
 
 Sync adapters subclass `SyncAdapterHarness`; async adapters subclass `AsyncAdapterHarness`.
+
+Every configuration field below may be **declared on the subclass or assigned per instance** — none of them is a
+`ClassVar`, so assigning to `self` in `__init__` type checks without a `type: ignore`. That matters for the
+common case of a value that does not exist until a fixture has run, such as a DSN that is only known once a test
+container has started:
+
+```python
+class MyHarness(SyncAdapterHarness):
+    adapter_name = "acmedb"
+    command_class = AcmeDbCommands
+
+    def __init__(self, container):
+        self.connect_dsn = f"acmedb://{container.host}:{container.port}/conformance"
+```
+
+A field that is genuinely static (`table_name`, `column_case`, `strict_rowcounts`, …) is still clearest as a
+class attribute; both forms are supported and mix freely on one harness.
 
 | Field | Required | Meaning |
 |---|---|---|
@@ -94,6 +120,52 @@ A harness that does not supply a field a case needs fails that case with a struc
 field never silently skips or weakens a core case. There is deliberately no "skip this core case" option;
 driver limitations are expressed only through the narrow, documented knobs above.
 
+### Where to seed: under the adapter or through it
+
+`create_commands()` must return a freshly seeded dataset, and there are two reasonable ways to produce it. Both
+are used in this repository, so it is worth choosing deliberately:
+
+* **Driver-level (recommended default).** Insert the rows with the raw driver, underneath the adapter — the
+  `connection.executemany(...)` in both examples below, and what pydapper's own sqlite3 harness does. Setup then
+  shares no code path with the thing under test, so a broken seed cannot be confused with broken adapter
+  behavior, and reading the harness tells you exactly what is in the table.
+* **Through the adapter.** Insert the rows with `commands.execute(...)` and pydapper's portable `?name?`
+  placeholders, as pydapper's service-backed harnesses do through the shared
+  `tests/conformance_support.py::seed_through_adapter` helper. One seeding statement then works unchanged across
+  every dialect, which is why harnesses for many backends share it; the cost is that setup runs through the
+  adapter it is about to judge.
+
+Prefer driver-level seeding unless you are maintaining harnesses for several dialects at once and want a single
+portable seeding path. This is a readability and blast-radius preference, not a correctness one: failures inside
+`create_commands()` are attributed to the harness either way (see below), so seeding through the adapter no
+longer risks a broken seed being reported as adapter misbehavior.
+
+## Harness setup failures are attributed to the harness
+
+If the harness's own `create_commands()` raises — a connection factory that cannot connect, a `CREATE TABLE`
+against the wrong dataset, a seeding statement the driver rejects — the resulting `CaseResult` is failed with
+`harness_setup_failed=True` and a message that names `create_commands()` as the culprit, while `cause` remains
+the original exception object. `ConformanceReport.harness_setup_failed` is `True` if any case in the run has it,
+and `ConformanceFailureError`'s summary gains a `[HARNESS SETUP FAILED: n of m failure(s) …]` segment, so the
+traceback CI prints already says the harness never got off the ground.
+
+This exists because one broken setup call fails every case that needs a fixture: without attribution, a single
+bad seeding statement reads as dozens of identical behavioral failures against a perfectly good adapter. A run
+with `harness_setup_failed` set is not a verdict on the adapter — fix the harness and run again.
+
+The boundaries are narrow and deliberate:
+
+* Only the harness's own `create_commands()` call is wrapped, never the framework's validation or bookkeeping
+  around it, and never the adapter behavior a case exercises afterwards. Genuine behavioral failures keep their
+  existing shape and report `harness_setup_failed=False`.
+* `KeyboardInterrupt`, `SystemExit`, and `asyncio.CancelledError` still propagate unconverted; cancellation and
+  shutdown are never turned into case results.
+* A harness that omits a required field or override is still a `HarnessDefinitionError` with its `missing_field`
+  — a missing override is a definition error, not a setup failure, and reporting for it is unchanged.
+* The internal exception type used to carry this across the runner boundary is private. Branch on the two
+  structured attributes (`CaseResult.harness_setup_failed`, `ConformanceReport.harness_setup_failed`), not on an
+  exception class and not on message text.
+
 ## Case isolation and cleanup
 
 Every case gets a fresh command instance, connection, and dataset through `create_commands()`; case ordering
@@ -107,9 +179,28 @@ after an otherwise passing case fails that case.
 `run_core_sync()` / `run_core_async()` return a `ConformanceReport` whose `results` follow the declared
 profile/case order exactly, run after run. Each `CaseResult` carries the profile id, case id, pass/fail, a
 human-readable message, the original `cause` exception when one exists, the `missing_field` for harness
-validation failures, and any `cleanup_error`. `report.raise_for_failures()` raises a
+validation failures, any `cleanup_error`, and `harness_setup_failed`. `report.raise_for_failures()` raises a
 `ConformanceFailureError` that exposes the same structured failures — nothing requires parsing exception
 prose.
+
+### Two flags that make a run mean less than it looks
+
+`report.passed` answers "did every case that ran pass?" and nothing more. Two separate booleans say whether the
+run was a conformance run at all, and both are structured attributes so no caller has to read messages:
+
+| Flag | `True` means | What it invalidates |
+|---|---|---|
+| `report.covers_full_inventory` | every planned case ran (the default; `False` only after a `case_ids` filter) | a passing run that covered a subset is not conformance |
+| `report.harness_setup_failed` | at least one case failed inside the harness's own `create_commands()` | the failures describe your harness, not the adapter |
+
+Anything that **claims conformance** — a CI gate, a published matrix row, a release note — must therefore assert
+`report.passed and report.covers_full_inventory`. `raise_for_failures()` deliberately ignores completeness: it
+is about failures only, so a filtered run that passes everything it ran raises nothing.
+
+```python
+report = run_core_sync(MyAdapterHarness())
+assert report.passed and report.covers_full_inventory
+```
 
 ## Running one adapter
 
@@ -129,7 +220,35 @@ report.raise_for_failures()
 report = await run_core_async(MyAsyncAdapterHarness())
 ```
 
+### Debugging one case with `case_ids`
+
+Both runners accept an optional `case_ids` collection that narrows the run to the named cases. It exists purely
+to shorten the debug loop: against a container-backed backend, a full profile costs minutes per iteration —
+mostly the client's connection retry backoff — which is a miserable way to chase one failing case.
+
+```python
+report = run_core_sync(MyAdapterHarness(), case_ids=["rows.query-buffered", "scalar.null-returns-none"])
+assert report.covers_full_inventory is False  # by construction: this is a debug run, not a conformance run
+```
+
+The rules are chosen so a filtered run can never be mistaken for a real one:
+
+* **A filtered run is never a conformance result.** `covers_full_inventory` is `False` whenever a filter narrowed
+  the run, and `ConformanceFailureError`'s summary gains a `[PARTIAL RUN: …]` segment. Naming every planned case
+  is still full coverage, and `case_ids=None` (the default) runs the full inventory exactly as before.
+* **Unknown ids fail loudly, before anything runs.** A typo raises `CaseSelectionError` — carrying `profile_id`,
+  `requested_case_ids`, and `unknown_case_ids` — rather than quietly running fewer cases. An empty selection
+  raises the same error with an empty `unknown_case_ids`, because "no cases ran and none failed" is not a pass.
+* **A bare string is a `TypeError`.** `case_ids="rows.query-buffered"` would otherwise be a collection of
+  characters; pass a list.
+* Ids come from `core_sync_profile().sync_cases` / `core_async_profile().async_cases` (plus any
+  declared-capability profile cases, which are planned before filtering and so can also be selected).
+  Duplicates are de-duplicated, and results still follow declared case order, not the order you requested.
+
 ### Complete third-party sync example
+
+This one computes `connect_dsn` per instance in `__init__` — the shape a harness needs when the DSN only exists
+after a fixture has run — and seeds at the driver level.
 
 ```python
 {!docs/../docs_src/adapter_conformance/sync_example.py!}
@@ -137,6 +256,9 @@ report = await run_core_async(MyAsyncAdapterHarness())
 (*This script is complete, it should run "as is"*)
 
 ### Complete third-party async example
+
+This one declares `connect_dsn` on the class instead, which is the simpler form when the value is known up
+front. Both forms are supported.
 
 ```python
 {!docs/../docs_src/adapter_conformance/async_example.py!}

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -294,6 +294,9 @@ registrations.
 Empty sets are honest: they mean no optional capability is implemented yet, not that the underlying database lacks
 the feature.
 
+Adapters prove these contracts — the mandatory per-mode core behavior and, once implemented, each declared
+capability — with the reusable conformance suite; see [Adapter conformance](adapter_conformance.md).
+
 ## Preparation hooks
 
 Command classes may override four protected, documented adapter-author hooks. They are extension points for

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,11 +8,19 @@
   deterministic (profile id, case id, original cause, and missing harness field), and framework-owned
   recording/fault-injection connections prove lifecycle behavior — cursor cleanup on success and failure,
   active-error precedence over cleanup failures, truthy-exit non-suppression, bounded single-row fetches, and
-  fail-before-driver-work validation — through the real adapter classes rather than mocks of them. Optional
-  behaviors remain independent `AdapterCapability` profiles: the catalog starts empty, zero-case profiles are
-  rejected, and a declared capability without a populated profile fails conformance, so an unimplemented
-  capability can never appear covered. All eight first-party adapters (nine command classes) adopt the suite in
-  the repository's backend test suites. See [Adapter conformance](adapter_conformance.md).
+  fail-before-driver-work validation — through the real adapter classes rather than mocks of them. Harness
+  configuration fields may be declared on the subclass or assigned per instance, so a DSN that only exists once a
+  test container has started needs no `type: ignore`. A failure inside the harness's own `create_commands()` is
+  attributed to the harness through `CaseResult.harness_setup_failed` / `ConformanceReport.harness_setup_failed`
+  and never reported as adapter behavior, so one broken seeding call cannot masquerade as dozens of behavioral
+  failures. Both runners take an optional `case_ids` filter for shortening the debug loop against a slow backend:
+  unknown ids and empty selections raise `CaseSelectionError` before anything runs, and a filtered report carries
+  `covers_full_inventory=False`, so only `report.passed and report.covers_full_inventory` is a conformance result.
+  Optional behaviors remain independent `AdapterCapability` profiles: the catalog starts empty, zero-case profiles
+  are rejected, and a declared capability without a populated profile fails conformance, so an unimplemented
+  capability can never appear covered — that capability surface is provisional until the first profile ships. All
+  eight first-party adapters (nine command classes) adopt the suite in the repository's backend test suites. See
+  [Adapter conformance](adapter_conformance.md).
 * feat: declare first-party adapters as installed entry points and remove eager bootstrap. PR [#564](https://github.com/zschumacher/pydapper/pull/564) by [@zschumacher](https://github.com/zschumacher).
 * v1: adapters are now discovered through the standard `pydapper.adapters` entry-point group and load lazily.
   First-party and third-party adapters use one provider contract: an installed distribution declares an entry point

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,18 @@
 ## Latest Changes
 
+* v1: a reusable adapter conformance suite now ships in the installed distribution at
+  `pydapper.testing.adapter_conformance`. Adapter authors implement a typed `SyncAdapterHarness` /
+  `AsyncAdapterHarness` and run the mandatory `core-sync` and `core-async` profiles against their real concrete
+  command classes — no pytest, no optional database drivers, and no copied repository tests required. The two
+  mode profiles are independent (a dual-mode adapter must pass both), results and failures are structured and
+  deterministic (profile id, case id, original cause, and missing harness field), and framework-owned
+  recording/fault-injection connections prove lifecycle behavior — cursor cleanup on success and failure,
+  active-error precedence over cleanup failures, truthy-exit non-suppression, bounded single-row fetches, and
+  fail-before-driver-work validation — through the real adapter classes rather than mocks of them. Optional
+  behaviors remain independent `AdapterCapability` profiles: the catalog starts empty, zero-case profiles are
+  rejected, and a declared capability without a populated profile fails conformance, so an unimplemented
+  capability can never appear covered. All eight first-party adapters (nine command classes) adopt the suite in
+  the repository's backend test suites. See [Adapter conformance](adapter_conformance.md).
 * feat: declare first-party adapters as installed entry points and remove eager bootstrap. PR [#564](https://github.com/zschumacher/pydapper/pull/564) by [@zschumacher](https://github.com/zschumacher).
 * v1: adapters are now discovered through the standard `pydapper.adapters` entry-point group and load lazily.
   First-party and third-party adapters use one provider contract: an installed distribution declares an entry point

--- a/docs_src/adapter_conformance/async_example.py
+++ b/docs_src/adapter_conformance/async_example.py
@@ -1,0 +1,123 @@
+"""A complete third-party async-only adapter running the reusable conformance suite.
+
+The "acmeaio" driver below is a tiny async facade over stdlib sqlite3, standing in
+for a real async driver. The conformance API itself never calls ``asyncio.run()`` —
+``run_core_async`` is awaited inside whatever event loop the caller owns, which here
+is the one this script starts at the bottom.
+"""
+
+import asyncio
+import sqlite3
+import tempfile
+
+import pydapper
+from pydapper.commands import BaseSqlParamHandler
+from pydapper.commands import CommandsAsync
+from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_async
+from pydapper.testing.adapter_conformance import seed_rows
+
+WORKDIR = tempfile.mkdtemp()
+
+
+class AcmeAioCursor:
+    """An async cursor facade over a sqlite3 cursor."""
+
+    def __init__(self, cursor: sqlite3.Cursor) -> None:
+        self._cursor = cursor
+
+    @property
+    def description(self):
+        return self._cursor.description
+
+    @property
+    def rowcount(self) -> int:
+        return self._cursor.rowcount
+
+    async def execute(self, sql, parameters=None) -> None:
+        if parameters is None:
+            self._cursor.execute(sql)
+        else:
+            self._cursor.execute(sql, parameters)
+
+    async def executemany(self, sql, seq_of_parameters=None) -> None:
+        self._cursor.executemany(sql, seq_of_parameters or [])
+
+    async def fetchone(self):
+        return self._cursor.fetchone()
+
+    async def fetchall(self):
+        return self._cursor.fetchall()
+
+    async def fetchmany(self, size=1):
+        return self._cursor.fetchmany(size)
+
+    async def close(self) -> None:
+        self._cursor.close()
+
+
+class AcmeAioConnection:
+    """An async connection facade whose cursor() returns an awaitable."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    async def cursor(self, *args, **kwargs) -> AcmeAioCursor:
+        return AcmeAioCursor(self._connection.cursor())
+
+    def close(self) -> None:
+        self._connection.close()
+
+
+class AcmeAioCommands(CommandsAsync):
+    class SqlParamHandler(BaseSqlParamHandler):
+        def get_param_placeholder(self, param_name: str) -> str:
+            return "?"
+
+    @classmethod
+    async def connect_async(cls, parsed_dsn, **connect_kwargs) -> "AcmeAioCommands":
+        return cls(AcmeAioConnection(sqlite3.connect(parsed_dsn.database, **connect_kwargs)))
+
+
+pydapper.register_adapter(
+    "acmeaio",
+    async_commands=AcmeAioCommands,
+    using_connection_predicate=lambda connection: isinstance(connection, AcmeAioConnection),
+)
+
+
+class AcmeAioConformanceHarness(AsyncAdapterHarness):
+    adapter_name = "acmeaio"
+    command_class = AcmeAioCommands
+    # four slashes make the sqlite path absolute; the +acmeaio suffix selects this adapter
+    connect_dsn = f"sqlite+acmeaio:///{WORKDIR}/example.db"
+    # our cursor() returns an awaitable, the CommandsAsync base contract; a driver whose
+    # cursor() returns the cursor synchronously (like psycopg3 async) declares "synchronous"
+    cursor_factory_style = "awaitable"
+
+    async def create_commands(self) -> CommandsAsync:
+        connection = sqlite3.connect(":memory:")
+        connection.execute(
+            "CREATE TABLE pydapper_conformance (id INTEGER PRIMARY KEY, label TEXT, score INTEGER, note TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO pydapper_conformance (id, label, score, note) VALUES (?, ?, ?, ?)",
+            seed_rows(self.supports_empty_strings),
+        )
+        connection.commit()
+        return AcmeAioCommands(AcmeAioConnection(connection))
+
+    async def teardown_commands(self, commands: CommandsAsync) -> None:
+        commands.connection.close()
+
+
+async def main() -> None:
+    report = await run_core_async(AcmeAioConformanceHarness())
+    for failure in report.failures:
+        print(f"{failure.profile_id}/{failure.case_id}: {failure.message}")
+    print(f"{report.profile_id} for {report.adapter_name!r}: {len(report.results)} cases, passed={report.passed}")
+    report.raise_for_failures()
+
+
+asyncio.run(main())
+# core-async for 'acmeaio': 54 cases, passed=True

--- a/docs_src/adapter_conformance/sync_example.py
+++ b/docs_src/adapter_conformance/sync_example.py
@@ -14,8 +14,6 @@ from pydapper.testing.adapter_conformance import SyncAdapterHarness
 from pydapper.testing.adapter_conformance import run_core_sync
 from pydapper.testing.adapter_conformance import seed_rows
 
-WORKDIR = tempfile.mkdtemp()
-
 
 class AcmeDbCommands(Commands):
     class SqlParamHandler(BaseSqlParamHandler):
@@ -37,8 +35,13 @@ pydapper.register_adapter(
 class AcmeDbConformanceHarness(SyncAdapterHarness):
     adapter_name = "acmedb"
     command_class = AcmeDbCommands
-    # four slashes make the sqlite path absolute; the +acmedb suffix selects this adapter
-    connect_dsn = f"sqlite+acmedb:///{WORKDIR}/example.db"
+
+    def __init__(self) -> None:
+        # no harness field is a ClassVar, so configuration a real harness only learns at
+        # runtime -- a container's host and port, a temp directory -- is assigned on self
+        workdir = tempfile.mkdtemp()
+        # four slashes make the sqlite path absolute; the +acmedb suffix selects this adapter
+        self.connect_dsn = f"sqlite+acmedb:///{workdir}/example.db"
 
     def create_commands(self) -> Commands:
         # a fresh, isolated database and dataset for every conformance case
@@ -62,4 +65,6 @@ for failure in report.failures:
     print(f"{failure.profile_id}/{failure.case_id}: {failure.message}")
 print(f"{report.profile_id} for {report.adapter_name!r}: {len(report.results)} cases, passed={report.passed}")
 report.raise_for_failures()
+# claiming conformance takes both: every case passed *and* every planned case ran
+assert report.passed and report.covers_full_inventory
 # core-sync for 'acmedb': 54 cases, passed=True

--- a/docs_src/adapter_conformance/sync_example.py
+++ b/docs_src/adapter_conformance/sync_example.py
@@ -1,0 +1,65 @@
+"""A complete third-party sync-only adapter running the reusable conformance suite.
+
+The "acmedb" driver below is stdlib sqlite3 wearing a third-party hat: the point is
+the shape of the harness, not the database. No pytest is required.
+"""
+
+import sqlite3
+import tempfile
+
+import pydapper
+from pydapper.commands import BaseSqlParamHandler
+from pydapper.commands import Commands
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_sync
+from pydapper.testing.adapter_conformance import seed_rows
+
+WORKDIR = tempfile.mkdtemp()
+
+
+class AcmeDbCommands(Commands):
+    class SqlParamHandler(BaseSqlParamHandler):
+        def get_param_placeholder(self, param_name: str) -> str:
+            return "?"
+
+    @classmethod
+    def connect(cls, parsed_dsn, **connect_kwargs) -> "AcmeDbCommands":
+        return cls(sqlite3.connect(parsed_dsn.database, **connect_kwargs))
+
+
+pydapper.register_adapter(
+    "acmedb",
+    commands=AcmeDbCommands,
+    using_connection_predicate=lambda connection: isinstance(connection, sqlite3.Connection),
+)
+
+
+class AcmeDbConformanceHarness(SyncAdapterHarness):
+    adapter_name = "acmedb"
+    command_class = AcmeDbCommands
+    # four slashes make the sqlite path absolute; the +acmedb suffix selects this adapter
+    connect_dsn = f"sqlite+acmedb:///{WORKDIR}/example.db"
+
+    def create_commands(self) -> Commands:
+        # a fresh, isolated database and dataset for every conformance case
+        connection = sqlite3.connect(":memory:")
+        connection.execute(
+            "CREATE TABLE pydapper_conformance (id INTEGER PRIMARY KEY, label TEXT, score INTEGER, note TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO pydapper_conformance (id, label, score, note) VALUES (?, ?, ?, ?)",
+            seed_rows(self.supports_empty_strings),
+        )
+        connection.commit()
+        return AcmeDbCommands(connection)
+
+    def teardown_commands(self, commands: Commands) -> None:
+        commands.connection.close()
+
+
+report = run_core_sync(AcmeDbConformanceHarness())
+for failure in report.failures:
+    print(f"{failure.profile_id}/{failure.case_id}: {failure.message}")
+print(f"{report.profile_id} for {report.adapter_name!r}: {len(report.results)} cases, passed={report.passed}")
+report.raise_for_failures()
+# core-sync for 'acmedb': 54 cases, passed=True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Compatibility Policy: compatibility.md
   - Command options: command_options.md
   - Adapter registration: adapter_registration.md
+  - Adapter conformance: adapter_conformance.md
   - Database Support:
       - Intro - Database Support: database_support/intro.md
       - Google BigQuery: database_support/bigquery.md

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -10,6 +10,7 @@ from ..utils import import_dbapi_module
 
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
+    from ..types import AsyncCursorType
 
 
 class Psycopg3Commands(Commands):
@@ -45,7 +46,7 @@ class Psycopg3CommandsAsync(CommandsAsync):
         )
         return cls(conn)
 
-    def cursor(self, *args, **kwargs):
+    def cursor(self, *args, **kwargs) -> "_AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType]":
         async def cursor_proxy():
             return self.connection.cursor(*args, **kwargs)
 

--- a/pydapper/testing/__init__.py
+++ b/pydapper/testing/__init__.py
@@ -1,0 +1,11 @@
+"""Reusable, framework-neutral testing helpers shipped with the pydapper distribution.
+
+Nothing in this package is exported from the ``pydapper`` package root. Import the
+documented helpers explicitly, for example::
+
+    from pydapper.testing.adapter_conformance import run_core_sync
+
+Everything importable under ``pydapper.testing`` uses only the standard library and
+pydapper core: no pytest, no optional database drivers, and no repository test
+utilities.
+"""

--- a/pydapper/testing/adapter_conformance/__init__.py
+++ b/pydapper/testing/adapter_conformance/__init__.py
@@ -13,6 +13,13 @@ mandatory per-mode core profiles::
 adapter must pass both. Optional capabilities are covered by independent capability
 profiles keyed to :class:`pydapper.AdapterCapability`; see :func:`capability_profiles`.
 
+The capability surface — :class:`ConformanceProfile`, :class:`SyncCase`,
+:class:`AsyncCase`, and :func:`capability_profiles` — is **provisional**: no capability
+profile ships yet, so there is nothing for an adapter author to write against, and this
+part of the API may change when the first one lands. The mandatory core surface is not
+provisional. See the "Extending the suite in future capability work" section of the
+adapter conformance documentation.
+
 This package uses only the standard library and pydapper core: it never imports
 pytest, optional database drivers, or any test-service tooling, and importing it
 starts nothing.
@@ -29,6 +36,7 @@ from ._profiles import capability_profiles
 from ._profiles import core_async_profile
 from ._profiles import core_sync_profile
 from ._results import CaseResult
+from ._results import CaseSelectionError
 from ._results import ConformanceError
 from ._results import ConformanceFailureError
 from ._results import ConformanceReport
@@ -48,6 +56,7 @@ __all__ = [
     "AsyncAdapterHarness",
     "AsyncCase",
     "CaseResult",
+    "CaseSelectionError",
     "ConformanceError",
     "ConformanceFailureError",
     "ConformanceProfile",

--- a/pydapper/testing/adapter_conformance/__init__.py
+++ b/pydapper/testing/adapter_conformance/__init__.py
@@ -1,0 +1,65 @@
+"""Reusable adapter conformance suite for pydapper command classes.
+
+Adapter authors implement a :class:`SyncAdapterHarness` and/or
+:class:`AsyncAdapterHarness` for their concrete command classes and run the
+mandatory per-mode core profiles::
+
+    from pydapper.testing.adapter_conformance import run_core_sync
+
+    report = run_core_sync(MyAdapterHarness())
+    report.raise_for_failures()
+
+``core-sync`` and ``core-async`` are independent mandatory profiles; a dual-mode
+adapter must pass both. Optional capabilities are covered by independent capability
+profiles keyed to :class:`pydapper.AdapterCapability`; see :func:`capability_profiles`.
+
+This package uses only the standard library and pydapper core: it never imports
+pytest, optional database drivers, or any test-service tooling, and importing it
+starts nothing.
+"""
+
+from ._harness import AsyncAdapterHarness
+from ._harness import SyncAdapterHarness
+from ._profiles import CORE_ASYNC
+from ._profiles import CORE_SYNC
+from ._profiles import AsyncCase
+from ._profiles import ConformanceProfile
+from ._profiles import SyncCase
+from ._profiles import capability_profiles
+from ._profiles import core_async_profile
+from ._profiles import core_sync_profile
+from ._results import CaseResult
+from ._results import ConformanceError
+from ._results import ConformanceFailureError
+from ._results import ConformanceReport
+from ._results import HarnessDefinitionError
+from ._results import ProfileDefinitionError
+from ._runner import run_core_async
+from ._runner import run_core_sync
+from ._sqlspec import CONFORMANCE_COLUMNS
+from ._sqlspec import CONFORMANCE_ROWS
+from ._sqlspec import seed_rows
+
+__all__ = [
+    "CORE_ASYNC",
+    "CORE_SYNC",
+    "CONFORMANCE_COLUMNS",
+    "CONFORMANCE_ROWS",
+    "AsyncAdapterHarness",
+    "AsyncCase",
+    "CaseResult",
+    "ConformanceError",
+    "ConformanceFailureError",
+    "ConformanceProfile",
+    "ConformanceReport",
+    "HarnessDefinitionError",
+    "ProfileDefinitionError",
+    "SyncAdapterHarness",
+    "SyncCase",
+    "capability_profiles",
+    "core_async_profile",
+    "core_sync_profile",
+    "run_core_async",
+    "run_core_sync",
+    "seed_rows",
+]

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -561,11 +561,13 @@ async def _execute_rowcount(ctx: AsyncCaseContext) -> None:
 )
 async def _execute_executemany(ctx: AsyncCaseContext) -> None:
     commands = await ctx.create_commands()
+    # every bound value is non-NULL: some drivers derive a parameter's type from its
+    # Python value and cannot bind an untyped None (see the docs' NULL parameter note).
     count = await commands.execute_async(
         ctx.sql("insert_row"),
         params=[
-            {"id": 10, "label": "ten", "score": 1, "note": None},
-            {"id": 11, "label": "eleven", "score": 2, "note": None},
+            {"id": 10, "label": "ten", "score": 1, "note": "tenth"},
+            {"id": 11, "label": "eleven", "score": 2, "note": "eleventh"},
         ],
     )
     ctx.check(isinstance(count, int), f"executemany must return an int row count, got {type(count).__name__}")
@@ -604,8 +606,8 @@ async def _execute_mixed_records(ctx: AsyncCaseContext) -> None:
     count = await commands.execute_async(
         ctx.sql("insert_row"),
         params=[
-            {"id": 20, "label": "twenty", "score": 1, "note": None},
-            Row(id=21, label="twentyone", score=2, note=None),
+            {"id": 20, "label": "twenty", "score": 1, "note": "twentieth"},
+            Row(id=21, label="twentyone", score=2, note="twentyfirst"),
         ],
     )
     ctx.check(isinstance(count, int), f"mixed executemany must return an int, got {type(count).__name__}")

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -30,6 +30,7 @@ from pydapper.rows import RawRow
 from ._checks import AsyncCaseContext
 from ._instrumentation import CursorScript
 from ._profiles import AsyncCase
+from ._profiles import capability_profiles
 
 _CASES: List[AsyncCase] = []
 
@@ -45,8 +46,8 @@ def _case(
 
 
 def async_core_cases() -> Tuple[AsyncCase, ...]:
-    """Return the full, ordered ``core-async`` case inventory."""
-    return tuple(_CASES)
+    """Return the full, ordered, immutable ``core-async`` case inventory."""
+    return _FROZEN_CASES
 
 
 class _InjectedExecuteFault(Exception):
@@ -74,8 +75,23 @@ _UNSUPPORTED_OPTION_PROBES: Tuple[Tuple[AdapterCapability, CommandOptions], ...]
     (AdapterCapability.COMMAND_TIMEOUT, CommandOptions(timeout=1.5)),
     (AdapterCapability.STORED_PROCEDURES, CommandOptions(command_kind=CommandKind.STORED_PROCEDURE)),
     (AdapterCapability.READONLY, CommandOptions(readonly=True)),
+    (AdapterCapability.READONLY, CommandOptions(readonly=False)),
     (AdapterCapability.MAX_ROWS, CommandOptions(max_rows=5)),
 )
+
+
+def _probe_is_implemented(ctx: "AsyncCaseContext", capability: AdapterCapability) -> bool:
+    """An option probe is waived only for a capability the adapter declares AND whose
+    reusable profile exists in the *production* catalog for this mode.
+
+    Until the owning feature ships a real production profile, a declaration alone
+    never waives the probe, so a falsely declared capability cannot silently accept
+    the option it pretends to implement.
+    """
+    if capability not in _declared_capabilities(ctx):
+        return False
+    profile = capability_profiles().get(capability)
+    return profile is not None and bool(profile.async_cases)
 
 
 def _declared_capabilities(ctx: AsyncCaseContext) -> frozenset:
@@ -878,14 +894,13 @@ async def _options_default_equivalence(ctx: AsyncCaseContext) -> None:
 
 @_case(
     "options.unsupported-raises",
-    "Valid non-default options for undeclared capabilities raise UnsupportedFeatureError",
+    "Valid non-default options for unimplemented capabilities raise UnsupportedFeatureError",
     "live",
 )
 async def _options_unsupported(ctx: AsyncCaseContext) -> None:
     commands = await ctx.create_commands()
-    declared = _declared_capabilities(ctx)
     for capability, options in _UNSUPPORTED_OPTION_PROBES:
-        if capability in declared:
+        if _probe_is_implemented(ctx, capability):
             continue
         with ctx.expect_raises(UnsupportedFeatureError):
             await commands.query_async(ctx.sql("select_all"), options=options)
@@ -897,9 +912,8 @@ async def _options_unsupported(ctx: AsyncCaseContext) -> None:
     "instrumented",
 )
 async def _options_unsupported_no_driver_work(ctx: AsyncCaseContext) -> None:
-    declared = _declared_capabilities(ctx)
     for capability, options in _UNSUPPORTED_OPTION_PROBES:
-        if capability in declared:
+        if _probe_is_implemented(ctx, capability):
             continue
         connection = ctx.recording_connection()
         commands = ctx.instrumented_commands(connection)
@@ -968,10 +982,12 @@ async def _capabilities_profiles_populated(ctx: AsyncCaseContext) -> None:
     for member in declared:
         if not isinstance(member, AdapterCapability):
             ctx.fail(f"cannot evaluate capability profiles: non-enum member {member!r}")
-        profile = ctx.capability_catalog.get(member)
+        # authoritative check against the production catalog: an injected catalog can
+        # add profiles to run, but it can never make a declaration look covered
+        profile = capability_profiles().get(member)
         if profile is None:
             ctx.fail(
-                f"declared capability {member.value!r} has no conformance profile; "
+                f"declared capability {member.value!r} has no production conformance profile; "
                 "a capability may only be declared once its reusable profile exists"
             )
         if not profile.async_cases:
@@ -979,3 +995,8 @@ async def _capabilities_profiles_populated(ctx: AsyncCaseContext) -> None:
                 f"declared capability {member.value!r} has no async conformance cases; "
                 "a declared capability must be covered in every declared mode"
             )
+
+
+#: The production inventory is frozen once at import; later mutation of the private
+#: registration list cannot alter what the runner executes.
+_FROZEN_CASES: Tuple[AsyncCase, ...] = tuple(_CASES)

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -404,7 +404,9 @@ async def _lifecycle_hook_order(ctx: AsyncCaseContext) -> None:
         f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
     )
     prepare_cursor_event = connection.log.first("prepare_cursor")
-    if prepare_cursor_event is None or prepare_cursor_event.detail is None:
+    if prepare_cursor_event is None or prepare_cursor_event.detail is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("the prepare-cursor hook was never observed")
     hook_cursor, hook_options = prepare_cursor_event.detail
     context_cursor = connection.cursors[0]
@@ -423,12 +425,16 @@ async def _lifecycle_hook_order(ctx: AsyncCaseContext) -> None:
         "UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1}, options=explicit
     )
     prepare_command_event = connection.log.first("prepare_command")
-    if prepare_command_event is None or prepare_command_event.detail is None:
+    if prepare_command_event is None or prepare_command_event.detail is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("the prepare-command hook was never observed")
     _, handler, hook_options = prepare_command_event.detail
     ctx.check(hook_options is explicit, "hooks must receive the caller's normalized CommandOptions instance")
     execute_event = connection.log.first("execute")
-    if execute_event is None:
+    if execute_event is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("no execute reached the driver after the preparation hooks")
     ctx.check(
         getattr(handler, "prepared_sql", None) == execute_event.sql,
@@ -694,7 +700,9 @@ async def _rows_duplicate_columns(ctx: AsyncCaseContext) -> None:
     with ctx.expect_raises(DuplicateColumnException) as caught:
         await commands.query_async(ctx.sql("select_duplicate_columns"), params={"id": 1})
     error = caught.exception
-    if not isinstance(error, DuplicateColumnException):
+    if not isinstance(error, DuplicateColumnException):  # pragma: no cover
+        # unreachable: expect_raises() captures only the expected type — any other exception
+        # propagates instead; the guard only narrows Optional for mypy
         ctx.fail(f"expected a DuplicateColumnException, captured {error!r}")
     duplicate = ctx.col("id")
     ctx.check(error.columns == (duplicate, duplicate), f"structured columns attribute wrong: {error.columns!r}")

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -398,11 +398,7 @@ async def _lifecycle_hook_order(ctx: AsyncCaseContext) -> None:
     commands = ctx.instrumented_commands(connection)
     ctx.install_hook_recorder(commands, connection.log)
     await commands.execute_async("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1})
-    kinds = connection.log.kinds()
-    ctx.check(
-        kinds == ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"),
-        f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
-    )
+    ctx.check_event_order(connection.log, ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"))
     prepare_cursor_event = connection.log.first("prepare_cursor")
     if prepare_cursor_event is None or prepare_cursor_event.detail is None:  # pragma: no cover
         # unreachable: the event-order assertion above already proves the hook fired, and the

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -1,0 +1,981 @@
+"""The complete ``core-async`` case inventory.
+
+Mirrors the ``core-sync`` inventory for every behavior the async mode supports,
+plus async-only lifecycle shapes: ``aclose()`` cleanup, awaitable versus synchronous
+plain-cursor ``close()``, and the harness-declared async cursor-factory style
+(awaitable-returning versus synchronous-returning ``connection.cursor()``).
+"""
+
+import inspect
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import List
+from typing import Tuple
+
+import pydapper
+from pydapper.capabilities import AdapterCapability
+from pydapper.command_options import CommandKind
+from pydapper.command_options import CommandOptions
+from pydapper.exceptions import DuplicateColumnException
+from pydapper.exceptions import InvalidParameterShapeException
+from pydapper.exceptions import MissingParameterException
+from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import NoResultException
+from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.rows import RawRow
+
+from ._checks import AsyncCaseContext
+from ._instrumentation import CursorScript
+from ._profiles import AsyncCase
+
+_CASES: List[AsyncCase] = []
+
+
+def _case(
+    case_id: str, description: str, kind: str
+) -> Callable[[Callable[[AsyncCaseContext], Awaitable[None]]], Callable]:
+    def register(fn: Callable[[AsyncCaseContext], Awaitable[None]]) -> Callable[[AsyncCaseContext], Awaitable[None]]:
+        _CASES.append(AsyncCase(case_id=case_id, description=description, kind=kind, run=fn))
+        return fn
+
+    return register
+
+
+def async_core_cases() -> Tuple[AsyncCase, ...]:
+    """Return the full, ordered ``core-async`` case inventory."""
+    return tuple(_CASES)
+
+
+class _InjectedExecuteFault(Exception):
+    """Framework-injected execution failure."""
+
+
+class _InjectedFetchFault(Exception):
+    """Framework-injected fetch failure."""
+
+
+class _InjectedCleanupFault(Exception):
+    """Framework-injected cursor cleanup failure."""
+
+
+class _InjectedMapperFault(Exception):
+    """Framework-injected row mapper failure."""
+
+
+@dataclass
+class _ParamRecord:
+    id: int
+
+
+_UNSUPPORTED_OPTION_PROBES: Tuple[Tuple[AdapterCapability, CommandOptions], ...] = (
+    (AdapterCapability.COMMAND_TIMEOUT, CommandOptions(timeout=1.5)),
+    (AdapterCapability.STORED_PROCEDURES, CommandOptions(command_kind=CommandKind.STORED_PROCEDURE)),
+    (AdapterCapability.READONLY, CommandOptions(readonly=True)),
+    (AdapterCapability.MAX_ROWS, CommandOptions(max_rows=5)),
+)
+
+
+def _declared_capabilities(ctx: AsyncCaseContext) -> frozenset:
+    declared: Any = getattr(ctx.command_class, "capabilities", frozenset())
+    if isinstance(declared, frozenset) and all(isinstance(member, AdapterCapability) for member in declared):
+        return declared
+    return frozenset()
+
+
+async def _close_connection(connection: Any) -> None:
+    close = getattr(connection, "close", None)
+    if callable(close):
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "registration.explicit-adapter-selection",
+    "Explicit adapter selection through using_async(adapter=...) returns the declared concrete class",
+    "live",
+)
+async def _registration_explicit(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    selected = pydapper.using_async(commands.connection, adapter=ctx.adapter_name)
+    ctx.check(
+        type(selected) is ctx.command_class,
+        f"using_async(adapter={ctx.adapter_name!r}) returned {type(selected).__name__}, "
+        f"expected {ctx.command_class.__name__}",
+    )
+
+
+@_case(
+    "registration.supplied-connection",
+    "A supplied connection works through the documented public selection path",
+    "live",
+)
+async def _registration_supplied_connection(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    selected = pydapper.using_async(commands.connection, adapter=ctx.adapter_name)
+    rows = await selected.query_async(ctx.sql("select_all"))
+    ctx.check(len(rows) == len(ctx.seeded_rows()), f"expected {len(ctx.seeded_rows())} rows, got {len(rows)}")
+
+
+@_case(
+    "registration.dsn-connect",
+    "The documented connect_async() path works with the harness-supplied DSN",
+    "live",
+)
+async def _registration_dsn_connect(ctx: AsyncCaseContext) -> None:
+    connected = await pydapper.connect_async(ctx.connect_dsn, **dict(ctx.harness.connect_kwargs))
+    try:
+        ctx.check(
+            type(connected) is ctx.command_class,
+            f"connect_async() returned {type(connected).__name__}, expected {ctx.command_class.__name__}",
+        )
+        value = await connected.execute_scalar_async(ctx.sql("select_literal"))
+        ctx.check(value == 1, f"connect_async()-built commands failed a trivial scalar query, got {value!r}")
+    finally:
+        await _close_connection(connected.connection)
+
+
+# --------------------------------------------------------------------------------------
+# lifecycle (instrumented)
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "lifecycle.context-cursor-success",
+    "An async context-manager cursor is acquired once, entered, used via the entered object, and exited once",
+    "instrumented",
+)
+async def _lifecycle_context_success(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    rows = await commands.query_async("SELECT id, label FROM t")
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_single_cursor_lifecycle(connection)
+    recorder = connection.recorders[0]
+    ctx.check(recorder.enter_calls == 1, "native cursor __aenter__ must run exactly once")
+    ctx.check(recorder.exit_calls == 1, "native cursor __aexit__ must run exactly once")
+    ctx.check(recorder.exit_args[-1] == (None, None, None), "successful exit must receive a clean exception triple")
+    for event in connection.log.of_kind("execute") + connection.log.of_kind("fetchall"):
+        ctx.check(event.on_entered is True, f"driver work must go through the entered cursor, saw {event!r}")
+
+
+@_case(
+    "lifecycle.plain-cursor-close",
+    "A plain async cursor is closed exactly once on success and failure, with sync and awaitable close()",
+    "instrumented",
+)
+async def _lifecycle_plain_cursor(ctx: AsyncCaseContext) -> None:
+    for close_style in ("sync", "awaitable"):
+        connection = ctx.recording_connection(cursor_style="plain", close_style=close_style)
+        commands = ctx.instrumented_commands(connection)
+        await commands.query_async("SELECT id, label FROM t")
+        ctx.check(
+            connection.recorders[0].close_calls == 1,
+            f"plain cursor with {close_style} close() must be closed exactly once after success",
+        )
+
+        fault = _InjectedExecuteFault("boom")
+        failing = ctx.recording_connection(
+            CursorScript(execute_error=fault), cursor_style="plain", close_style=close_style
+        )
+        commands = ctx.instrumented_commands(failing)
+        with ctx.expect_raises(_InjectedExecuteFault) as caught:
+            await commands.query_async("SELECT id, label FROM t")
+        ctx.check(caught.exception is fault, "the active command error must propagate as the same exception object")
+        ctx.check(
+            failing.recorders[0].close_calls == 1,
+            f"plain cursor with {close_style} close() must be closed exactly once after failure",
+        )
+
+
+@_case(
+    "lifecycle.cleanup-after-failure",
+    "Async cursor cleanup runs after an active command failure and receives the real exception triple",
+    "instrumented",
+)
+async def _lifecycle_cleanup_after_failure(ctx: AsyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        await commands.query_async("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must propagate as the same exception object")
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "cursor cleanup must run exactly once after failure")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the active error")
+    ctx.check(exit_event is not None and exit_event.tb_is_active is True, "native exit must receive the live traceback")
+
+
+@_case(
+    "lifecycle.active-error-precedence",
+    "An active command error is not replaced by an async cursor cleanup failure",
+    "instrumented",
+)
+async def _lifecycle_error_precedence(ctx: AsyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault, exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        await commands.query_async("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must win over an __aexit__ failure")
+
+    for close_style in ("sync", "awaitable"):
+        plain = ctx.recording_connection(
+            CursorScript(execute_error=fault, close_error=cleanup),
+            cursor_style="plain",
+            close_style=close_style,
+        )
+        commands = ctx.instrumented_commands(plain)
+        with ctx.expect_raises(_InjectedExecuteFault) as caught:
+            await commands.query_async("SELECT id, label FROM t")
+        ctx.check(
+            caught.exception is fault,
+            f"the active command error must win over a plain {close_style} close() failure",
+        )
+
+
+@_case(
+    "lifecycle.truthy-exit-not-suppressing",
+    "A truthy async cursor exit cannot suppress an active command error or fabricate a return value",
+    "instrumented",
+)
+async def _lifecycle_truthy_exit(ctx: AsyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault, exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        await commands.query_first_async("SELECT id, label FROM t")
+    ctx.check(
+        caught.exception is fault,
+        "a truthy cursor exit must not suppress the command error or produce a fabricated result",
+    )
+
+    fetch_fault = _InjectedFetchFault("fetch")
+    connection = ctx.recording_connection(CursorScript(fetchall_error=fetch_fault, exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedFetchFault) as caught_fetch:
+        await commands.query_async("SELECT id, label FROM t")
+    ctx.check(caught_fetch.exception is fetch_fault, "a truthy cursor exit must not suppress a fetch error")
+
+
+@_case(
+    "lifecycle.cleanup-error-after-success",
+    "An async cursor cleanup failure with no active command error propagates",
+    "instrumented",
+)
+async def _lifecycle_cleanup_error_after_success(ctx: AsyncCaseContext) -> None:
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedCleanupFault) as caught:
+        await commands.query_async("SELECT id, label FROM t")
+    ctx.check(caught.exception is cleanup, "with no active error the cleanup failure itself must propagate")
+
+
+@_case(
+    "lifecycle.fetch-error-precedence",
+    "An async fetch failure is the active error and wins over cursor cleanup failures",
+    "instrumented",
+)
+async def _lifecycle_fetch_error(ctx: AsyncCaseContext) -> None:
+    fault = _InjectedFetchFault("fetch")
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(fetchall_error=fault, exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedFetchFault) as caught:
+        await commands.query_async("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the fetch error must propagate unchanged")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the fetch error")
+
+
+@_case(
+    "lifecycle.mapper-error-cleanup",
+    "An async mapper failure propagates and the cursor is still cleaned up with the mapper error active",
+    "instrumented",
+)
+async def _lifecycle_mapper_error(ctx: AsyncCaseContext) -> None:
+    fault = _InjectedMapperFault("mapper")
+
+    def broken_mapper(row: RawRow) -> Any:
+        raise fault
+
+    connection = ctx.recording_connection(CursorScript(exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedMapperFault) as caught:
+        await commands.query_async("SELECT id, label FROM t", mapper=broken_mapper)
+    ctx.check(caught.exception is fault, "the mapper error must propagate as the same exception object")
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "cursor cleanup must still run after a mapper failure")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the mapper error")
+
+
+@_case(
+    "lifecycle.model-error-cleanup",
+    "An async model construction failure propagates and the cursor is still cleaned up",
+    "instrumented",
+)
+async def _lifecycle_model_error(ctx: AsyncCaseContext) -> None:
+    class ExplodingModel:
+        def __init__(self, **kwargs: Any) -> None:
+            raise _InjectedMapperFault("model")
+
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedMapperFault):
+        await commands.query_async("SELECT id, label FROM t", model=ExplodingModel)
+    ctx.check(connection.recorders[0].exit_calls == 1, "cursor cleanup must still run after a model failure")
+
+
+@_case(
+    "lifecycle.unbuffered-exhaustion-cleanup",
+    "Async unbuffered results acquire lazily and clean up the cursor on exhaustion",
+    "instrumented",
+)
+async def _lifecycle_unbuffered_exhaustion(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    generator = await commands.query_async("SELECT id, label FROM t", buffered=False)
+    ctx.check(connection.cursor_calls == 0, "an unconsumed unbuffered query must not acquire a cursor")
+    values = [row async for row in generator]
+    ctx.check(len(values) == 2, f"unbuffered query yielded {len(values)} rows, expected 2")
+    ctx.check(connection.recorders[0].exit_calls == 1, "exhaustion must clean up the cursor exactly once")
+
+
+@_case(
+    "lifecycle.unbuffered-explicit-aclose",
+    "Async unbuffered results clean up the cursor exactly once on explicit aclose()",
+    "instrumented",
+)
+async def _lifecycle_unbuffered_aclose(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"), (3, "gamma"))))
+    commands = ctx.instrumented_commands(connection)
+    generator = await commands.query_async("SELECT id, label FROM t", buffered=False)
+    first = await generator.__anext__()
+    ctx.check(first == {"id": 1, "label": "alpha"}, f"unexpected first unbuffered row {first!r}")
+    await generator.aclose()
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "explicit aclose() must clean up the cursor exactly once")
+
+
+@_case(
+    "lifecycle.hook-order",
+    "Async preparation hooks run once per cursor/handler, in order, on the entered cursor, with normalized options",
+    "instrumented",
+)
+async def _lifecycle_hook_order(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rowcount=1))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    await commands.execute_async("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1})
+    kinds = connection.log.kinds()
+    ctx.check(
+        kinds == ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"),
+        f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
+    )
+    prepare_cursor_event = connection.log.first("prepare_cursor")
+    if prepare_cursor_event is None or prepare_cursor_event.detail is None:
+        ctx.fail("the prepare-cursor hook was never observed")
+    hook_cursor, hook_options = prepare_cursor_event.detail
+    context_cursor = connection.cursors[0]
+    entered = getattr(context_cursor, "entered_cursor", None)
+    ctx.check(
+        hook_cursor is entered,
+        "the prepare-cursor hook must receive the entered cursor object",
+    )
+    ctx.check(hook_options == CommandOptions(), "hooks must receive normalized default CommandOptions")
+
+    explicit = CommandOptions()
+    connection = ctx.recording_connection(CursorScript(rowcount=1))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    await commands.execute_async(
+        "UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1}, options=explicit
+    )
+    prepare_command_event = connection.log.first("prepare_command")
+    if prepare_command_event is None or prepare_command_event.detail is None:
+        ctx.fail("the prepare-command hook was never observed")
+    _, handler, hook_options = prepare_command_event.detail
+    ctx.check(hook_options is explicit, "hooks must receive the caller's normalized CommandOptions instance")
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("no execute reached the driver after the preparation hooks")
+    ctx.check(
+        getattr(handler, "prepared_sql", None) == execute_event.sql,
+        "the prepare-command hook must observe the handler whose prepared SQL is executed",
+    )
+
+
+# --------------------------------------------------------------------------------------
+# parameters and execution
+# --------------------------------------------------------------------------------------
+
+
+@_case("params.params-keyword", "The preferred params= spelling binds values", "live")
+async def _params_keyword(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    row = await commands.query_first_async(ctx.sql("select_by_id"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"params= lookup returned the wrong row: {row!r}")
+
+
+@_case("params.param-alias", "The compatibility param= spelling binds values", "live")
+async def _params_alias(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    row = await commands.query_first_async(ctx.sql("select_by_id"), param={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"param= lookup returned the wrong row: {row!r}")
+
+
+@_case(
+    "params.both-rejected-before-driver-work",
+    "Supplying both params= and param= fails before cursor acquisition or driver work",
+    "instrumented",
+)
+async def _params_both_rejected(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(ValueError):
+        await commands.query_async("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1}, param={"id": 2})  # type: ignore[call-overload]
+    ctx.check(connection.cursor_calls == 0, "the params/param conflict must fail before any cursor is acquired")
+
+
+@_case(
+    "params.repeated-placeholders",
+    "Repeated placeholders preserve occurrence order and reuse the correct value",
+    "live",
+)
+async def _params_repeated(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    row = await commands.query_first_async(ctx.sql("select_repeated_placeholder"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"repeated placeholder query returned the wrong row: {row!r}")
+
+
+@_case(
+    "params.repeated-placeholders-binding",
+    "Repeated placeholders bind the same value once per occurrence, in order",
+    "instrumented",
+)
+async def _params_repeated_binding(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    await commands.query_async("SELECT id, label FROM t WHERE id = ?id? AND ?id? = id", params={"id": 7})
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("execute must reach the driver")
+    ctx.check(
+        tuple(execute_event.params or ()) == (7, 7),
+        f"repeated placeholders must bind (7, 7); driver saw {execute_event.params!r}",
+    )
+
+
+@_case(
+    "params.missing-raises",
+    "A missing parameter raises MissingParameterException before driver work",
+    "instrumented",
+)
+async def _params_missing(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(MissingParameterException):
+        await commands.query_async("SELECT id, label FROM t WHERE id = ?id?", params={"other": 1})
+    with ctx.expect_raises(MissingParameterException):
+        await commands.query_async("SELECT id, label FROM t WHERE id = ?id?")
+    ctx.check(connection.cursor_calls == 0, "missing parameters must fail before any cursor is acquired")
+
+
+@_case(
+    "params.invalid-shape-raises",
+    "Invalid parameter record and list shapes raise InvalidParameterShapeException before driver work",
+    "instrumented",
+)
+async def _params_invalid_shape(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(InvalidParameterShapeException):
+        await commands.execute_async("UPDATE t SET label = ?label? WHERE id = ?id?", params=42)
+    with ctx.expect_raises(InvalidParameterShapeException):
+        await commands.execute_async("UPDATE t SET label = ?label? WHERE id = ?id?", params=[42])
+    with ctx.expect_raises(InvalidParameterShapeException):
+        await commands.query_async("SELECT id, label FROM t WHERE id = ?id?", params=[{"id": 1}])
+    ctx.check(connection.cursor_calls == 0, "invalid parameter shapes must fail before any cursor is acquired")
+
+
+@_case(
+    "params.record-representations",
+    "Mappings, attribute objects, and dataclass instances all work as parameter records",
+    "live",
+)
+async def _params_representations(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    sql = ctx.sql("select_by_id")
+    for record in ({"id": 1}, SimpleNamespace(id=1), _ParamRecord(id=1)):
+        row = await commands.query_first_async(sql, params=record)
+        ctx.check(
+            row[ctx.col("id")] == 1,
+            f"parameter record {type(record).__name__} returned the wrong row: {row!r}",
+        )
+
+
+@_case("execute.rowcount", "execute_async() returns the affected row count", "live")
+async def _execute_rowcount(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    count = await commands.execute_async(ctx.sql("update_label"), params={"label": "delta", "id": 1})
+    ctx.check(isinstance(count, int), f"execute_async() must return an int row count, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 1, f"expected an affected row count of 1, got {count}")
+
+
+@_case(
+    "execute.executemany-rowcount",
+    "executemany through execute_async() returns the total affected row count",
+    "live",
+)
+async def _execute_executemany(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    count = await commands.execute_async(
+        ctx.sql("insert_row"),
+        params=[
+            {"id": 10, "label": "ten", "score": 1, "note": None},
+            {"id": 11, "label": "eleven", "score": 2, "note": None},
+        ],
+    )
+    ctx.check(isinstance(count, int), f"executemany must return an int row count, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 2, f"expected an affected row count of 2, got {count}")
+
+
+@_case(
+    "execute.executemany-empty-noop",
+    "An empty executemany list is a no-op returning 0 without cursor acquisition",
+    "instrumented",
+)
+async def _execute_empty_noop(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    result = await commands.execute_async("UPDATE t SET label = ?label? WHERE id = ?id?", params=[])
+    ctx.check(result == 0, f"empty executemany must return 0, got {result!r}")
+    ctx.check(connection.cursor_calls == 0, "empty executemany must not acquire a cursor")
+
+
+@_case(
+    "execute.executemany-mixed-records",
+    "Mixed supported executemany record representations work together",
+    "live",
+)
+async def _execute_mixed_records(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+
+    @dataclass
+    class Row:
+        id: int
+        label: str
+        score: int
+        note: Any
+
+    count = await commands.execute_async(
+        ctx.sql("insert_row"),
+        params=[
+            {"id": 20, "label": "twenty", "score": 1, "note": None},
+            Row(id=21, label="twentyone", score=2, note=None),
+        ],
+    )
+    ctx.check(isinstance(count, int), f"mixed executemany must return an int, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 2, f"expected an affected row count of 2, got {count}")
+
+
+@_case(
+    "execute.nested-list-single-value",
+    "A nested list parameter stays one bound value and is not expanded before LIST_EXPANSION lands",
+    "instrumented",
+)
+async def _execute_nested_list(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    await commands.execute_async(
+        "UPDATE t SET label = ?label? WHERE id = ?ids?", params={"label": "x", "ids": [1, 2, 3]}
+    )
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("execute must reach the driver")
+    bound = tuple(execute_event.params or ())
+    ctx.check(
+        len(bound) == 2 and bound[1] == [1, 2, 3],
+        f"a nested list must bind as one value; driver saw {bound!r}",
+    )
+
+
+# --------------------------------------------------------------------------------------
+# rows, mapping, cardinality, scalars
+# --------------------------------------------------------------------------------------
+
+
+@_case("rows.query-buffered", "Buffered query returns ordered dict rows matching the dataset", "live")
+async def _rows_buffered(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    rows = await commands.query_async(ctx.sql("select_all"))
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"buffered query returned {rows!r}, expected {expected!r}")
+    first_keys = tuple(rows[0].keys())
+    expected_keys = tuple(ctx.col(name) for name in ("id", "label", "score", "note"))
+    ctx.check(first_keys == expected_keys, f"dict rows must preserve column order; got {first_keys!r}")
+
+
+@_case("rows.query-unbuffered", "Unbuffered query yields the same rows lazily", "live")
+async def _rows_unbuffered(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    generator = await commands.query_async(ctx.sql("select_all"), buffered=False)
+    rows = [row async for row in generator]
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"unbuffered query returned {rows!r}, expected {expected!r}")
+
+
+@_case("rows.mapper-receives-raw-row", "mapper= receives RawRow instances in driver order", "live")
+async def _rows_mapper(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    seen: List[Any] = []
+
+    def mapper(row: RawRow) -> int:
+        seen.append(row)
+        return row[ctx.col("id")]
+
+    ids = await commands.query_async(ctx.sql("select_all"), mapper=mapper)
+    ctx.check(all(isinstance(row, RawRow) for row in seen), "mapper must receive RawRow instances")
+    ctx.check(ids == [1, 2, 3], f"mapper results out of order: {ids!r}")
+
+
+@_case("rows.model-mapper-exclusive", "model= and mapper= are mutually exclusive", "instrumented")
+async def _rows_model_mapper_exclusive(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(ValueError):
+        await commands.query_async("SELECT id, label FROM t", model=dict, mapper=lambda row: row)  # type: ignore[call-overload]
+    ctx.check(connection.cursor_calls == 0, "the model/mapper conflict must fail before any cursor is acquired")
+
+
+@_case(
+    "rows.duplicate-columns-raise",
+    "Duplicate columns raise DuplicateColumnException with structured attributes during dict mapping",
+    "live",
+)
+async def _rows_duplicate_columns(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    with ctx.expect_raises(DuplicateColumnException) as caught:
+        await commands.query_async(ctx.sql("select_duplicate_columns"), params={"id": 1})
+    error = caught.exception
+    if not isinstance(error, DuplicateColumnException):
+        ctx.fail(f"expected a DuplicateColumnException, captured {error!r}")
+    duplicate = ctx.col("id")
+    ctx.check(error.columns == (duplicate, duplicate), f"structured columns attribute wrong: {error.columns!r}")
+    ctx.check(
+        error.duplicate_columns == (duplicate,),
+        f"structured duplicate_columns attribute wrong: {error.duplicate_columns!r}",
+    )
+    ctx.check(
+        error.duplicate_indexes == (0, 1),
+        f"structured duplicate_indexes attribute wrong: {error.duplicate_indexes!r}",
+    )
+    await ctx.recover(commands)
+
+
+@_case("rows.mapper-receives-duplicates", "An explicit mapper intentionally receives duplicate columns", "live")
+async def _rows_mapper_duplicates(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+
+    def mapper(row: RawRow) -> Tuple[Any, ...]:
+        return row.values
+
+    values = await commands.query_async(ctx.sql("select_duplicate_columns"), params={"id": 1}, mapper=mapper)
+    ctx.check(values == [(1, 1)], f"mapper must receive both duplicate column values, got {values!r}")
+
+
+@_case("cardinality.first-returns-first", "query_first_async returns the first of many rows", "live")
+async def _cardinality_first(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    row = await commands.query_first_async(ctx.sql("select_two"), params={"score": 10})
+    ctx.check(row[ctx.col("id")] == 1, f"query_first_async must return the first row; got {row!r}")
+
+
+@_case("cardinality.first-zero-raises", "query_first_async raises NoResultException on zero rows", "live")
+async def _cardinality_first_zero(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        await commands.query_first_async(ctx.sql("select_by_id"), params={"id": 999})
+    await ctx.recover(commands)
+
+
+@_case(
+    "cardinality.first-or-default",
+    "query_first_or_default_async returns the row when present and the default on zero rows",
+    "live",
+)
+async def _cardinality_first_or_default(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    sentinel = object()
+    row: Any = await commands.query_first_or_default_async(ctx.sql("select_by_id"), default=sentinel, params={"id": 1})
+    ctx.check(row is not sentinel and row[ctx.col("id")] == 1, f"expected row 1, got {row!r}")
+    missing = await commands.query_first_or_default_async(ctx.sql("select_by_id"), default=sentinel, params={"id": 999})
+    ctx.check(missing is sentinel, "query_first_or_default_async must return the default on zero rows")
+
+
+@_case("cardinality.single-one", "query_single_async returns the only matching row", "live")
+async def _cardinality_single(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    row = await commands.query_single_async(ctx.sql("select_by_id"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"query_single_async returned the wrong row: {row!r}")
+
+
+@_case("cardinality.single-zero-raises", "query_single_async raises NoResultException on zero rows", "live")
+async def _cardinality_single_zero(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        await commands.query_single_async(ctx.sql("select_by_id"), params={"id": 999})
+    await ctx.recover(commands)
+
+
+@_case(
+    "cardinality.single-many-raises",
+    "query_single_async raises MoreThanOneResultException on many rows",
+    "live",
+)
+async def _cardinality_single_many(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    with ctx.expect_raises(MoreThanOneResultException):
+        await commands.query_single_async(ctx.sql("select_two"), params={"score": 10})
+    await ctx.recover(commands)
+
+
+@_case(
+    "cardinality.single-or-default",
+    "query_single_or_default_async handles zero, one, and many rows",
+    "live",
+)
+async def _cardinality_single_or_default(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    sentinel = object()
+    missing = await commands.query_single_or_default_async(
+        ctx.sql("select_by_id"), default=sentinel, params={"id": 999}
+    )
+    ctx.check(missing is sentinel, "query_single_or_default_async must return the default on zero rows")
+    row: Any = await commands.query_single_or_default_async(ctx.sql("select_by_id"), default=sentinel, params={"id": 1})
+    ctx.check(row is not sentinel and row[ctx.col("id")] == 1, f"expected row 1, got {row!r}")
+    with ctx.expect_raises(MoreThanOneResultException):
+        await commands.query_single_or_default_async(ctx.sql("select_two"), default=sentinel, params={"score": 10})
+    await ctx.recover(commands)
+
+
+@_case(
+    "cardinality.single-bounded-fetch",
+    "Single-row cardinality checks consume at most two rows before deciding",
+    "instrumented",
+)
+async def _cardinality_bounded_fetch(ctx: AsyncCaseContext) -> None:
+    many_rows = ((1, "a"), (2, "b"), (3, "c"), (4, "d"))
+    connection = ctx.recording_connection(CursorScript(rows=many_rows))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(MoreThanOneResultException):
+        await commands.query_single_async("SELECT id, label FROM t")
+    fetchmany_events = connection.log.of_kind("fetchmany")
+    ctx.check(
+        len(fetchmany_events) == 1 and fetchmany_events[0].size == 2,
+        f"with fetchmany available, exactly one fetchmany(2) is expected; saw {fetchmany_events!r}",
+    )
+
+    fallback = ctx.recording_connection(CursorScript(rows=many_rows, supports_fetchmany=False))
+    commands = ctx.instrumented_commands(fallback)
+    with ctx.expect_raises(MoreThanOneResultException):
+        await commands.query_single_async("SELECT id, label FROM t")
+    exit_index = fallback.log.kinds().index("exit")
+    fetchone_before_decision = sum(1 for kind in fallback.log.kinds()[:exit_index] if kind == "fetchone")
+    ctx.check(
+        fetchone_before_decision <= 2,
+        f"without fetchmany, at most two fetchone calls may precede the cardinality decision; "
+        f"saw {fetchone_before_decision}",
+    )
+
+
+@_case("cardinality.falsey-row-is-result", "Falsey rows and values are results, never defaults", "live")
+async def _cardinality_falsey_row(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    sentinel = object()
+    row: Any = await commands.query_first_or_default_async(ctx.sql("select_by_id"), default=sentinel, params={"id": 2})
+    ctx.check(row is not sentinel, "a falsey row must not be replaced by the default")
+    ctx.check(row[ctx.col("score")] == 0, f"expected the falsey score row, got {row!r}")
+
+
+@_case("scalar.value", "execute_scalar_async returns the first column of the first row", "live")
+async def _scalar_value(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    value = await commands.execute_scalar_async(ctx.sql("scalar_label"), params={"id": 3})
+    ctx.check(value == "gamma", f"execute_scalar_async returned {value!r}, expected 'gamma'")
+
+
+@_case(
+    "scalar.no-row-raises",
+    "execute_scalar_async distinguishes no returned row by raising NoResultException",
+    "live",
+)
+async def _scalar_no_row(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        await commands.execute_scalar_async(ctx.sql("scalar_label"), params={"id": 999})
+    await ctx.recover(commands)
+
+
+@_case("scalar.null-returns-none", "execute_scalar_async returns None for a returned SQL NULL", "live")
+async def _scalar_null(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    value = await commands.execute_scalar_async(ctx.sql("scalar_note"), params={"id": 1})
+    ctx.check(value is None, f"a SQL NULL scalar must return None, got {value!r}")
+
+
+@_case("scalar.falsey-preserved", "Falsey first-column values are not treated as no result", "live")
+async def _scalar_falsey(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    score = await commands.execute_scalar_async(ctx.sql("scalar_score"), params={"id": 2})
+    ctx.check(score is not None and score == 0, f"a falsey 0 scalar must be preserved, got {score!r}")
+    label = await commands.execute_scalar_async(ctx.sql("scalar_label"), params={"id": 2})
+    if ctx.harness.supports_empty_strings:
+        ctx.check(label == "", f"a falsey empty-string scalar must be preserved, got {label!r}")
+    else:
+        ctx.check(label == "blank", f"the documented empty-string fallback value must round-trip, got {label!r}")
+
+
+# --------------------------------------------------------------------------------------
+# options and capability honesty
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "options.default-equivalence",
+    "Omitted options, options=None, and CommandOptions() behave identically",
+    "live",
+)
+async def _options_default_equivalence(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    sql = ctx.sql("select_by_id")
+    omitted = await commands.query_async(sql, params={"id": 1})
+    explicit_none = await commands.query_async(sql, params={"id": 1}, options=None)
+    default_options = await commands.query_async(sql, params={"id": 1}, options=CommandOptions())
+    ctx.check(
+        omitted == explicit_none == default_options,
+        "omitted options, options=None, and CommandOptions() must behave identically",
+    )
+
+
+@_case(
+    "options.unsupported-raises",
+    "Valid non-default options for undeclared capabilities raise UnsupportedFeatureError",
+    "live",
+)
+async def _options_unsupported(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    declared = _declared_capabilities(ctx)
+    for capability, options in _UNSUPPORTED_OPTION_PROBES:
+        if capability in declared:
+            continue
+        with ctx.expect_raises(UnsupportedFeatureError):
+            await commands.query_async(ctx.sql("select_all"), options=options)
+
+
+@_case(
+    "options.unsupported-before-driver-work",
+    "Unsupported options fail before cursor acquisition or driver work",
+    "instrumented",
+)
+async def _options_unsupported_no_driver_work(ctx: AsyncCaseContext) -> None:
+    declared = _declared_capabilities(ctx)
+    for capability, options in _UNSUPPORTED_OPTION_PROBES:
+        if capability in declared:
+            continue
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        with ctx.expect_raises(UnsupportedFeatureError):
+            await commands.query_async("SELECT id, label FROM t", options=options)
+        ctx.check(
+            connection.cursor_calls == 0,
+            f"options for undeclared capability {capability.value!r} must fail before any cursor is acquired",
+        )
+
+
+@_case("options.invalid-rejected", "Invalid options objects fail clearly with TypeError", "instrumented")
+async def _options_invalid(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    bad_options: Any = object()
+    with ctx.expect_raises(TypeError):
+        await commands.query_async("SELECT id, label FROM t", options=bad_options)
+    ctx.check(connection.cursor_calls == 0, "invalid options must fail before any cursor is acquired")
+
+
+@_case(
+    "capabilities.declaration-valid",
+    "The concrete class declares capabilities as a frozenset of AdapterCapability members",
+    "instrumented",
+)
+async def _capabilities_declaration_valid(ctx: AsyncCaseContext) -> None:
+    declared = getattr(ctx.command_class, "capabilities", None)
+    if not isinstance(declared, frozenset):
+        ctx.fail(
+            f"{ctx.command_class.__name__}.capabilities must be a frozenset of AdapterCapability members, "
+            f"got {type(declared).__name__}"
+        )
+    for member in declared:
+        if not isinstance(member, AdapterCapability):
+            ctx.fail(f"{ctx.command_class.__name__}.capabilities contains a non-AdapterCapability member: {member!r}")
+
+
+@_case(
+    "capabilities.supports-matches-declaration",
+    "supports() exactly matches the class declaration and rejects non-enum arguments",
+    "instrumented",
+)
+async def _capabilities_supports(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    declared = _declared_capabilities(ctx)
+    for member in AdapterCapability:
+        ctx.check(
+            commands.supports(member) == (member in declared),
+            f"supports({member.value!r}) must match the class declaration",
+        )
+    with ctx.expect_raises(TypeError):
+        commands.supports("transactions")  # type: ignore[arg-type]
+
+
+@_case(
+    "capabilities.declared-profile-populated",
+    "Every declared capability has a populated conformance profile for this mode",
+    "instrumented",
+)
+async def _capabilities_profiles_populated(ctx: AsyncCaseContext) -> None:
+    declared: Any = getattr(ctx.command_class, "capabilities", frozenset())
+    if not isinstance(declared, frozenset):
+        ctx.fail(f"cannot evaluate capability profiles: invalid declaration {declared!r}")
+    for member in declared:
+        if not isinstance(member, AdapterCapability):
+            ctx.fail(f"cannot evaluate capability profiles: non-enum member {member!r}")
+        profile = ctx.capability_catalog.get(member)
+        if profile is None:
+            ctx.fail(
+                f"declared capability {member.value!r} has no conformance profile; "
+                "a capability may only be declared once its reusable profile exists"
+            )
+        if not profile.async_cases:
+            ctx.fail(
+                f"declared capability {member.value!r} has no async conformance cases; "
+                "a declared capability must be covered in every declared mode"
+            )

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -29,6 +29,7 @@ from pydapper.rows import RawRow
 from ._checks import SyncCaseContext
 from ._instrumentation import CursorScript
 from ._profiles import SyncCase
+from ._profiles import capability_profiles
 
 _CASES: List[SyncCase] = []
 
@@ -42,8 +43,8 @@ def _case(case_id: str, description: str, kind: str) -> Callable[[Callable[[Sync
 
 
 def sync_core_cases() -> Tuple[SyncCase, ...]:
-    """Return the full, ordered ``core-sync`` case inventory."""
-    return tuple(_CASES)
+    """Return the full, ordered, immutable ``core-sync`` case inventory."""
+    return _FROZEN_CASES
 
 
 class _InjectedExecuteFault(Exception):
@@ -72,6 +73,7 @@ _UNSUPPORTED_OPTION_PROBES: Tuple[Tuple[AdapterCapability, CommandOptions], ...]
     (AdapterCapability.COMMAND_TIMEOUT, CommandOptions(timeout=1.5)),
     (AdapterCapability.STORED_PROCEDURES, CommandOptions(command_kind=CommandKind.STORED_PROCEDURE)),
     (AdapterCapability.READONLY, CommandOptions(readonly=True)),
+    (AdapterCapability.READONLY, CommandOptions(readonly=False)),
     (AdapterCapability.MAX_ROWS, CommandOptions(max_rows=5)),
 )
 
@@ -834,16 +836,29 @@ def _options_default_equivalence(ctx: SyncCaseContext) -> None:
     )
 
 
+def _probe_is_implemented(ctx: SyncCaseContext, capability: AdapterCapability) -> bool:
+    """An option probe is waived only for a capability the adapter declares AND whose
+    reusable profile exists in the *production* catalog for this mode.
+
+    Until the owning feature ships a real production profile, a declaration alone
+    never waives the probe, so a falsely declared capability cannot silently accept
+    the option it pretends to implement.
+    """
+    if capability not in _declared_capabilities(ctx):
+        return False
+    profile = capability_profiles().get(capability)
+    return profile is not None and bool(profile.sync_cases)
+
+
 @_case(
     "options.unsupported-raises",
-    "Valid non-default options for undeclared capabilities raise UnsupportedFeatureError",
+    "Valid non-default options for unimplemented capabilities raise UnsupportedFeatureError",
     "live",
 )
 def _options_unsupported(ctx: SyncCaseContext) -> None:
     commands = ctx.create_commands()
-    declared = _declared_capabilities(ctx)
     for capability, options in _UNSUPPORTED_OPTION_PROBES:
-        if capability in declared:
+        if _probe_is_implemented(ctx, capability):
             continue
         with ctx.expect_raises(UnsupportedFeatureError):
             commands.query(ctx.sql("select_all"), options=options)
@@ -855,9 +870,8 @@ def _options_unsupported(ctx: SyncCaseContext) -> None:
     "instrumented",
 )
 def _options_unsupported_no_driver_work(ctx: SyncCaseContext) -> None:
-    declared = _declared_capabilities(ctx)
     for capability, options in _UNSUPPORTED_OPTION_PROBES:
-        if capability in declared:
+        if _probe_is_implemented(ctx, capability):
             continue
         connection = ctx.recording_connection()
         commands = ctx.instrumented_commands(connection)
@@ -926,10 +940,12 @@ def _capabilities_profiles_populated(ctx: SyncCaseContext) -> None:
     for member in declared:
         if not isinstance(member, AdapterCapability):
             ctx.fail(f"cannot evaluate capability profiles: non-enum member {member!r}")
-        profile = ctx.capability_catalog.get(member)
+        # authoritative check against the production catalog: an injected catalog can
+        # add profiles to run, but it can never make a declaration look covered
+        profile = capability_profiles().get(member)
         if profile is None:
             ctx.fail(
-                f"declared capability {member.value!r} has no conformance profile; "
+                f"declared capability {member.value!r} has no production conformance profile; "
                 "a capability may only be declared once its reusable profile exists"
             )
         if not profile.sync_cases:
@@ -937,3 +953,8 @@ def _capabilities_profiles_populated(ctx: SyncCaseContext) -> None:
                 f"declared capability {member.value!r} has no sync conformance cases; "
                 "a declared capability must be covered in every declared mode"
             )
+
+
+#: The production inventory is frozen once at import; later mutation of the private
+#: registration list cannot alter what the runner executes.
+_FROZEN_CASES: Tuple[SyncCase, ...] = tuple(_CASES)

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -362,11 +362,7 @@ def _lifecycle_hook_order(ctx: SyncCaseContext) -> None:
     commands = ctx.instrumented_commands(connection)
     ctx.install_hook_recorder(commands, connection.log)
     commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1})
-    kinds = connection.log.kinds()
-    ctx.check(
-        kinds == ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"),
-        f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
-    )
+    ctx.check_event_order(connection.log, ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"))
     prepare_cursor_event = connection.log.first("prepare_cursor")
     if prepare_cursor_event is None or prepare_cursor_event.detail is None:  # pragma: no cover
         # unreachable: the event-order assertion above already proves the hook fired, and the

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -517,11 +517,13 @@ def _execute_rowcount(ctx: SyncCaseContext) -> None:
 @_case("execute.executemany-rowcount", "executemany through execute() returns the total affected row count", "live")
 def _execute_executemany(ctx: SyncCaseContext) -> None:
     commands = ctx.create_commands()
+    # every bound value is non-NULL: some drivers derive a parameter's type from its
+    # Python value and cannot bind an untyped None (see the docs' NULL parameter note).
     count = commands.execute(
         ctx.sql("insert_row"),
         params=[
-            {"id": 10, "label": "ten", "score": 1, "note": None},
-            {"id": 11, "label": "eleven", "score": 2, "note": None},
+            {"id": 10, "label": "ten", "score": 1, "note": "tenth"},
+            {"id": 11, "label": "eleven", "score": 2, "note": "eleventh"},
         ],
     )
     ctx.check(isinstance(count, int), f"executemany must return an int row count, got {type(count).__name__}")
@@ -560,8 +562,8 @@ def _execute_mixed_records(ctx: SyncCaseContext) -> None:
     count = commands.execute(
         ctx.sql("insert_row"),
         params=[
-            {"id": 20, "label": "twenty", "score": 1, "note": None},
-            Row(id=21, label="twentyone", score=2, note=None),
+            {"id": 20, "label": "twenty", "score": 1, "note": "twentieth"},
+            Row(id=21, label="twentyone", score=2, note="twentyfirst"),
         ],
     )
     ctx.check(isinstance(count, int), f"mixed executemany must return an int, got {type(count).__name__}")

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -368,7 +368,9 @@ def _lifecycle_hook_order(ctx: SyncCaseContext) -> None:
         f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
     )
     prepare_cursor_event = connection.log.first("prepare_cursor")
-    if prepare_cursor_event is None or prepare_cursor_event.detail is None:
+    if prepare_cursor_event is None or prepare_cursor_event.detail is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("the prepare-cursor hook was never observed")
     hook_cursor, hook_options = prepare_cursor_event.detail
     ctx.check(
@@ -383,12 +385,16 @@ def _lifecycle_hook_order(ctx: SyncCaseContext) -> None:
     ctx.install_hook_recorder(commands, connection.log)
     commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1}, options=explicit)
     prepare_command_event = connection.log.first("prepare_command")
-    if prepare_command_event is None or prepare_command_event.detail is None:
+    if prepare_command_event is None or prepare_command_event.detail is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("the prepare-command hook was never observed")
     _, handler, hook_options = prepare_command_event.detail
     ctx.check(hook_options is explicit, "hooks must receive the caller's normalized CommandOptions instance")
     execute_event = connection.log.first("execute")
-    if execute_event is None:
+    if execute_event is None:  # pragma: no cover
+        # unreachable: the event-order assertion above already proves the hook fired, and the
+        # framework always records its detail; the guard only narrows Optional for mypy
         ctx.fail("no execute reached the driver after the preparation hooks")
     ctx.check(
         getattr(handler, "prepared_sql", None) == execute_event.sql,
@@ -648,7 +654,9 @@ def _rows_duplicate_columns(ctx: SyncCaseContext) -> None:
     with ctx.expect_raises(DuplicateColumnException) as caught:
         commands.query(ctx.sql("select_duplicate_columns"), params={"id": 1})
     error = caught.exception
-    if not isinstance(error, DuplicateColumnException):
+    if not isinstance(error, DuplicateColumnException):  # pragma: no cover
+        # unreachable: expect_raises() captures only the expected type — any other exception
+        # propagates instead; the guard only narrows Optional for mypy
         ctx.fail(f"expected a DuplicateColumnException, captured {error!r}")
     duplicate = ctx.col("id")
     ctx.check(error.columns == (duplicate, duplicate), f"structured columns attribute wrong: {error.columns!r}")

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -1,0 +1,939 @@
+"""The complete ``core-sync`` case inventory.
+
+Case identifiers are stable public contract; ordering here is the deterministic
+execution and reporting order. ``live`` cases exercise the adapter through the
+harness's real database resources; ``instrumented`` cases wrap the real concrete
+command class around framework-owned recording/fault-injection connections so
+lifecycle, ordering, and no-driver-work guarantees are observed directly.
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from typing import Callable
+from typing import List
+from typing import Tuple
+
+import pydapper
+from pydapper.capabilities import AdapterCapability
+from pydapper.command_options import CommandKind
+from pydapper.command_options import CommandOptions
+from pydapper.exceptions import DuplicateColumnException
+from pydapper.exceptions import InvalidParameterShapeException
+from pydapper.exceptions import MissingParameterException
+from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import NoResultException
+from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.rows import RawRow
+
+from ._checks import SyncCaseContext
+from ._instrumentation import CursorScript
+from ._profiles import SyncCase
+
+_CASES: List[SyncCase] = []
+
+
+def _case(case_id: str, description: str, kind: str) -> Callable[[Callable[[SyncCaseContext], None]], Callable]:
+    def register(fn: Callable[[SyncCaseContext], None]) -> Callable[[SyncCaseContext], None]:
+        _CASES.append(SyncCase(case_id=case_id, description=description, kind=kind, run=fn))
+        return fn
+
+    return register
+
+
+def sync_core_cases() -> Tuple[SyncCase, ...]:
+    """Return the full, ordered ``core-sync`` case inventory."""
+    return tuple(_CASES)
+
+
+class _InjectedExecuteFault(Exception):
+    """Framework-injected execution failure."""
+
+
+class _InjectedFetchFault(Exception):
+    """Framework-injected fetch failure."""
+
+
+class _InjectedCleanupFault(Exception):
+    """Framework-injected cursor cleanup failure."""
+
+
+class _InjectedMapperFault(Exception):
+    """Framework-injected row mapper failure."""
+
+
+@dataclass
+class _ParamRecord:
+    id: int
+
+
+#: CommandOptions probes for capability honesty: (governing capability, options).
+_UNSUPPORTED_OPTION_PROBES: Tuple[Tuple[AdapterCapability, CommandOptions], ...] = (
+    (AdapterCapability.COMMAND_TIMEOUT, CommandOptions(timeout=1.5)),
+    (AdapterCapability.STORED_PROCEDURES, CommandOptions(command_kind=CommandKind.STORED_PROCEDURE)),
+    (AdapterCapability.READONLY, CommandOptions(readonly=True)),
+    (AdapterCapability.MAX_ROWS, CommandOptions(max_rows=5)),
+)
+
+
+def _declared_capabilities(ctx: Any) -> frozenset:
+    declared: Any = getattr(ctx.command_class, "capabilities", frozenset())
+    if isinstance(declared, frozenset) and all(isinstance(member, AdapterCapability) for member in declared):
+        return declared
+    return frozenset()
+
+
+# --------------------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "registration.explicit-adapter-selection",
+    "Explicit adapter selection through using(adapter=...) returns the declared concrete class",
+    "live",
+)
+def _registration_explicit(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    selected = pydapper.using(commands.connection, adapter=ctx.adapter_name)
+    ctx.check(
+        type(selected) is ctx.command_class,
+        f"using(adapter={ctx.adapter_name!r}) returned {type(selected).__name__}, "
+        f"expected {ctx.command_class.__name__}",
+    )
+
+
+@_case(
+    "registration.supplied-connection",
+    "A supplied connection works through the documented public selection path",
+    "live",
+)
+def _registration_supplied_connection(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    selected = pydapper.using(commands.connection, adapter=ctx.adapter_name)
+    rows = selected.query(ctx.sql("select_all"))
+    ctx.check(len(rows) == len(ctx.seeded_rows()), f"expected {len(ctx.seeded_rows())} rows, got {len(rows)}")
+
+
+@_case(
+    "registration.dsn-connect",
+    "The documented connect() path works with the harness-supplied DSN",
+    "live",
+)
+def _registration_dsn_connect(ctx: SyncCaseContext) -> None:
+    connected = pydapper.connect(ctx.connect_dsn, **dict(ctx.harness.connect_kwargs))
+    try:
+        ctx.check(
+            type(connected) is ctx.command_class,
+            f"connect() returned {type(connected).__name__}, expected {ctx.command_class.__name__}",
+        )
+        value = connected.execute_scalar(ctx.sql("select_literal"))
+        ctx.check(value == 1, f"connect()-built commands failed a trivial scalar query, got {value!r}")
+    finally:
+        close = getattr(connected.connection, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+
+# --------------------------------------------------------------------------------------
+# lifecycle (instrumented)
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "lifecycle.context-cursor-success",
+    "A context-manager cursor is acquired once, entered, used via the entered object, and exited once on success",
+    "instrumented",
+)
+def _lifecycle_context_success(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    rows = commands.query("SELECT id, label FROM t")
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_single_cursor_lifecycle(connection)
+    recorder = connection.recorders[0]
+    ctx.check(recorder.enter_calls == 1, "native cursor __enter__ must run exactly once")
+    ctx.check(recorder.exit_calls == 1, "native cursor __exit__ must run exactly once")
+    ctx.check(recorder.exit_args[-1] == (None, None, None), "successful exit must receive a clean exception triple")
+    for event in connection.log.of_kind("execute") + connection.log.of_kind("fetchall"):
+        ctx.check(event.on_entered is True, f"driver work must go through the entered cursor, saw {event!r}")
+
+
+@_case(
+    "lifecycle.plain-cursor-close",
+    "A plain cursor without a context manager is closed exactly once on success and on failure",
+    "instrumented",
+)
+def _lifecycle_plain_cursor(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(cursor_style="plain")
+    commands = ctx.instrumented_commands(connection)
+    commands.query("SELECT id, label FROM t")
+    ctx.check(connection.recorders[0].close_calls == 1, "plain cursor must be closed exactly once after success")
+
+    fault = _InjectedExecuteFault("boom")
+    failing = ctx.recording_connection(CursorScript(execute_error=fault), cursor_style="plain")
+    commands = ctx.instrumented_commands(failing)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must propagate as the same exception object")
+    ctx.check(failing.recorders[0].close_calls == 1, "plain cursor must be closed exactly once after failure")
+
+
+@_case(
+    "lifecycle.cleanup-after-failure",
+    "Cursor cleanup runs after an active command failure and receives the real exception triple",
+    "instrumented",
+)
+def _lifecycle_cleanup_after_failure(ctx: SyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must propagate as the same exception object")
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "cursor cleanup must run exactly once after failure")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the active error")
+    ctx.check(exit_event is not None and exit_event.tb_is_active is True, "native exit must receive the live traceback")
+
+
+@_case(
+    "lifecycle.active-error-precedence",
+    "An active command error is not replaced by a cursor cleanup failure",
+    "instrumented",
+)
+def _lifecycle_error_precedence(ctx: SyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault, exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must win over a cleanup failure")
+
+    plain = ctx.recording_connection(
+        CursorScript(execute_error=fault, close_error=cleanup),
+        cursor_style="plain",
+    )
+    commands = ctx.instrumented_commands(plain)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the active command error must win over a plain close() failure")
+
+
+@_case(
+    "lifecycle.truthy-exit-not-suppressing",
+    "A truthy cursor exit cannot suppress an active command error or fabricate a return value",
+    "instrumented",
+)
+def _lifecycle_truthy_exit(ctx: SyncCaseContext) -> None:
+    fault = _InjectedExecuteFault("boom")
+    connection = ctx.recording_connection(CursorScript(execute_error=fault, exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedExecuteFault) as caught:
+        commands.query_first("SELECT id, label FROM t")
+    ctx.check(
+        caught.exception is fault,
+        "a truthy cursor exit must not suppress the command error or produce a fabricated result",
+    )
+
+    fetch_fault = _InjectedFetchFault("fetch")
+    connection = ctx.recording_connection(CursorScript(fetchall_error=fetch_fault, exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedFetchFault) as caught_fetch:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught_fetch.exception is fetch_fault, "a truthy cursor exit must not suppress a fetch error")
+
+
+@_case(
+    "lifecycle.cleanup-error-after-success",
+    "A cursor cleanup failure with no active command error propagates",
+    "instrumented",
+)
+def _lifecycle_cleanup_error_after_success(ctx: SyncCaseContext) -> None:
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedCleanupFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is cleanup, "with no active error the cleanup failure itself must propagate")
+
+
+@_case(
+    "lifecycle.fetch-error-precedence",
+    "A fetch failure is the active error and wins over cursor cleanup failures",
+    "instrumented",
+)
+def _lifecycle_fetch_error(ctx: SyncCaseContext) -> None:
+    fault = _InjectedFetchFault("fetch")
+    cleanup = _InjectedCleanupFault("cleanup")
+    connection = ctx.recording_connection(CursorScript(fetchall_error=fault, exit_error=cleanup))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedFetchFault) as caught:
+        commands.query("SELECT id, label FROM t")
+    ctx.check(caught.exception is fault, "the fetch error must propagate unchanged")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the fetch error")
+
+
+@_case(
+    "lifecycle.mapper-error-cleanup",
+    "A mapper failure propagates and the cursor is still cleaned up with the mapper error active",
+    "instrumented",
+)
+def _lifecycle_mapper_error(ctx: SyncCaseContext) -> None:
+    fault = _InjectedMapperFault("mapper")
+
+    def broken_mapper(row: RawRow) -> Any:
+        raise fault
+
+    connection = ctx.recording_connection(CursorScript(exit_result=True))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedMapperFault) as caught:
+        commands.query("SELECT id, label FROM t", mapper=broken_mapper)
+    ctx.check(caught.exception is fault, "the mapper error must propagate as the same exception object")
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "cursor cleanup must still run after a mapper failure")
+    exit_event = connection.log.first("exit")
+    ctx.check(exit_event is not None and exit_event.exc_value is fault, "native exit must receive the mapper error")
+
+
+@_case(
+    "lifecycle.model-error-cleanup",
+    "A model construction failure propagates and the cursor is still cleaned up",
+    "instrumented",
+)
+def _lifecycle_model_error(ctx: SyncCaseContext) -> None:
+    class ExplodingModel:
+        def __init__(self, **kwargs: Any) -> None:
+            raise _InjectedMapperFault("model")
+
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedMapperFault):
+        commands.query("SELECT id, label FROM t", model=ExplodingModel)
+    ctx.check(connection.recorders[0].exit_calls == 1, "cursor cleanup must still run after a model failure")
+
+
+@_case(
+    "lifecycle.unbuffered-exhaustion-cleanup",
+    "Unbuffered results acquire lazily and clean up the cursor on exhaustion",
+    "instrumented",
+)
+def _lifecycle_unbuffered_exhaustion(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    generator = commands.query("SELECT id, label FROM t", buffered=False)
+    ctx.check(connection.cursor_calls == 0, "an unconsumed unbuffered query must not acquire a cursor")
+    values = list(generator)
+    ctx.check(len(values) == 2, f"unbuffered query yielded {len(values)} rows, expected 2")
+    ctx.check(connection.recorders[0].exit_calls == 1, "exhaustion must clean up the cursor exactly once")
+
+
+@_case(
+    "lifecycle.unbuffered-explicit-close",
+    "Unbuffered results clean up the cursor exactly once on explicit close()",
+    "instrumented",
+)
+def _lifecycle_unbuffered_close(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"), (3, "gamma"))))
+    commands = ctx.instrumented_commands(connection)
+    generator = commands.query("SELECT id, label FROM t", buffered=False)
+    first = next(generator)
+    ctx.check(first == {"id": 1, "label": "alpha"}, f"unexpected first unbuffered row {first!r}")
+    generator.close()
+    recorder = connection.recorders[0]
+    ctx.check(recorder.exit_calls == 1, "explicit close() must clean up the cursor exactly once")
+
+
+@_case(
+    "lifecycle.hook-order",
+    "Preparation hooks run once per cursor/handler, in order, on the entered cursor, with normalized options",
+    "instrumented",
+)
+def _lifecycle_hook_order(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rowcount=1))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1})
+    kinds = connection.log.kinds()
+    ctx.check(
+        kinds == ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "exit"),
+        f"hook order must be cursor/enter/prepare_cursor/prepare_command/execute/exit, observed {kinds!r}",
+    )
+    prepare_cursor_event = connection.log.first("prepare_cursor")
+    if prepare_cursor_event is None or prepare_cursor_event.detail is None:
+        ctx.fail("the prepare-cursor hook was never observed")
+    hook_cursor, hook_options = prepare_cursor_event.detail
+    ctx.check(
+        hook_cursor is getattr(connection.cursors[0], "entered_cursor", None),
+        "prepare-cursor hook must receive the entered cursor object",
+    )
+    ctx.check(hook_options == CommandOptions(), "hooks must receive normalized default CommandOptions")
+
+    explicit = CommandOptions()
+    connection = ctx.recording_connection(CursorScript(rowcount=1))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params={"label": "x", "id": 1}, options=explicit)
+    prepare_command_event = connection.log.first("prepare_command")
+    if prepare_command_event is None or prepare_command_event.detail is None:
+        ctx.fail("the prepare-command hook was never observed")
+    _, handler, hook_options = prepare_command_event.detail
+    ctx.check(hook_options is explicit, "hooks must receive the caller's normalized CommandOptions instance")
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("no execute reached the driver after the preparation hooks")
+    ctx.check(
+        getattr(handler, "prepared_sql", None) == execute_event.sql,
+        "the prepare-command hook must observe the handler whose prepared SQL is executed",
+    )
+
+
+# --------------------------------------------------------------------------------------
+# parameters and execution
+# --------------------------------------------------------------------------------------
+
+
+@_case("params.params-keyword", "The preferred params= spelling binds values", "live")
+def _params_keyword(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    row = commands.query_first(ctx.sql("select_by_id"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"params= lookup returned the wrong row: {row!r}")
+
+
+@_case("params.param-alias", "The compatibility param= spelling binds values", "live")
+def _params_alias(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    row = commands.query_first(ctx.sql("select_by_id"), param={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"param= lookup returned the wrong row: {row!r}")
+
+
+@_case(
+    "params.both-rejected-before-driver-work",
+    "Supplying both params= and param= fails before cursor acquisition or driver work",
+    "instrumented",
+)
+def _params_both_rejected(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(ValueError):
+        commands.query("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1}, param={"id": 2})  # type: ignore[call-overload]
+    ctx.check(connection.cursor_calls == 0, "the params/param conflict must fail before any cursor is acquired")
+
+
+@_case(
+    "params.repeated-placeholders",
+    "Repeated placeholders preserve occurrence order and reuse the correct value",
+    "live",
+)
+def _params_repeated(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    row = commands.query_first(ctx.sql("select_repeated_placeholder"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"repeated placeholder query returned the wrong row: {row!r}")
+
+
+@_case(
+    "params.repeated-placeholders-binding",
+    "Repeated placeholders bind the same value once per occurrence, in order",
+    "instrumented",
+)
+def _params_repeated_binding(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    commands.query("SELECT id, label FROM t WHERE id = ?id? AND ?id? = id", params={"id": 7})
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("execute must reach the driver")
+    ctx.check(
+        tuple(execute_event.params or ()) == (7, 7),
+        f"repeated placeholders must bind (7, 7); driver saw {execute_event.params!r}",
+    )
+
+
+@_case(
+    "params.missing-raises",
+    "A missing parameter raises MissingParameterException before driver work",
+    "instrumented",
+)
+def _params_missing(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(MissingParameterException):
+        commands.query("SELECT id, label FROM t WHERE id = ?id?", params={"other": 1})
+    with ctx.expect_raises(MissingParameterException):
+        commands.query("SELECT id, label FROM t WHERE id = ?id?")
+    ctx.check(connection.cursor_calls == 0, "missing parameters must fail before any cursor is acquired")
+
+
+@_case(
+    "params.invalid-shape-raises",
+    "Invalid parameter record and list shapes raise InvalidParameterShapeException before driver work",
+    "instrumented",
+)
+def _params_invalid_shape(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(InvalidParameterShapeException):
+        commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params=42)
+    with ctx.expect_raises(InvalidParameterShapeException):
+        commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params=[42])
+    with ctx.expect_raises(InvalidParameterShapeException):
+        commands.query("SELECT id, label FROM t WHERE id = ?id?", params=[{"id": 1}])
+    ctx.check(connection.cursor_calls == 0, "invalid parameter shapes must fail before any cursor is acquired")
+
+
+@_case(
+    "params.record-representations",
+    "Mappings, attribute objects, and dataclass instances all work as parameter records",
+    "live",
+)
+def _params_representations(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    sql = ctx.sql("select_by_id")
+    for record in ({"id": 1}, SimpleNamespace(id=1), _ParamRecord(id=1)):
+        row = commands.query_first(sql, params=record)
+        ctx.check(
+            row[ctx.col("id")] == 1,
+            f"parameter record {type(record).__name__} returned the wrong row: {row!r}",
+        )
+
+
+@_case("execute.rowcount", "execute() returns the affected row count", "live")
+def _execute_rowcount(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    count = commands.execute(ctx.sql("update_label"), params={"label": "delta", "id": 1})
+    ctx.check(isinstance(count, int), f"execute() must return an int row count, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 1, f"expected an affected row count of 1, got {count}")
+
+
+@_case("execute.executemany-rowcount", "executemany through execute() returns the total affected row count", "live")
+def _execute_executemany(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    count = commands.execute(
+        ctx.sql("insert_row"),
+        params=[
+            {"id": 10, "label": "ten", "score": 1, "note": None},
+            {"id": 11, "label": "eleven", "score": 2, "note": None},
+        ],
+    )
+    ctx.check(isinstance(count, int), f"executemany must return an int row count, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 2, f"expected an affected row count of 2, got {count}")
+
+
+@_case(
+    "execute.executemany-empty-noop",
+    "An empty executemany list is a no-op returning 0 without cursor acquisition",
+    "instrumented",
+)
+def _execute_empty_noop(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    result = commands.execute("UPDATE t SET label = ?label? WHERE id = ?id?", params=[])
+    ctx.check(result == 0, f"empty executemany must return 0, got {result!r}")
+    ctx.check(connection.cursor_calls == 0, "empty executemany must not acquire a cursor")
+
+
+@_case(
+    "execute.executemany-mixed-records",
+    "Mixed supported executemany record representations work together",
+    "live",
+)
+def _execute_mixed_records(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+
+    @dataclass
+    class Row:
+        id: int
+        label: str
+        score: int
+        note: Any
+
+    count = commands.execute(
+        ctx.sql("insert_row"),
+        params=[
+            {"id": 20, "label": "twenty", "score": 1, "note": None},
+            Row(id=21, label="twentyone", score=2, note=None),
+        ],
+    )
+    ctx.check(isinstance(count, int), f"mixed executemany must return an int, got {type(count).__name__}")
+    if ctx.harness.strict_rowcounts:
+        ctx.check(count == 2, f"expected an affected row count of 2, got {count}")
+
+
+@_case(
+    "execute.nested-list-single-value",
+    "A nested list parameter stays one bound value and is not expanded before LIST_EXPANSION lands",
+    "instrumented",
+)
+def _execute_nested_list(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    commands.execute("UPDATE t SET label = ?label? WHERE id = ?ids?", params={"label": "x", "ids": [1, 2, 3]})
+    execute_event = connection.log.first("execute")
+    if execute_event is None:
+        ctx.fail("execute must reach the driver")
+    bound = tuple(execute_event.params or ())
+    ctx.check(
+        len(bound) == 2 and bound[1] == [1, 2, 3],
+        f"a nested list must bind as one value; driver saw {bound!r}",
+    )
+
+
+# --------------------------------------------------------------------------------------
+# rows, mapping, cardinality, scalars
+# --------------------------------------------------------------------------------------
+
+
+@_case("rows.query-buffered", "Buffered query returns ordered dict rows matching the dataset", "live")
+def _rows_buffered(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    rows = commands.query(ctx.sql("select_all"))
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"buffered query returned {rows!r}, expected {expected!r}")
+    first_keys = tuple(rows[0].keys())
+    expected_keys = tuple(ctx.col(name) for name in ("id", "label", "score", "note"))
+    ctx.check(first_keys == expected_keys, f"dict rows must preserve column order; got {first_keys!r}")
+
+
+@_case("rows.query-unbuffered", "Unbuffered query yields the same rows lazily", "live")
+def _rows_unbuffered(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    generator = commands.query(ctx.sql("select_all"), buffered=False)
+    rows = list(generator)
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"unbuffered query returned {rows!r}, expected {expected!r}")
+
+
+@_case("rows.mapper-receives-raw-row", "mapper= receives RawRow instances in driver order", "live")
+def _rows_mapper(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    seen: List[Any] = []
+
+    def mapper(row: RawRow) -> int:
+        seen.append(row)
+        return row[ctx.col("id")]
+
+    ids = commands.query(ctx.sql("select_all"), mapper=mapper)
+    ctx.check(all(isinstance(row, RawRow) for row in seen), "mapper must receive RawRow instances")
+    ctx.check(ids == [1, 2, 3], f"mapper results out of order: {ids!r}")
+
+
+@_case("rows.model-mapper-exclusive", "model= and mapper= are mutually exclusive", "instrumented")
+def _rows_model_mapper_exclusive(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(ValueError):
+        commands.query("SELECT id, label FROM t", model=dict, mapper=lambda row: row)  # type: ignore[call-overload]
+    ctx.check(connection.cursor_calls == 0, "the model/mapper conflict must fail before any cursor is acquired")
+
+
+@_case(
+    "rows.duplicate-columns-raise",
+    "Duplicate columns raise DuplicateColumnException with structured attributes during dict mapping",
+    "live",
+)
+def _rows_duplicate_columns(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    with ctx.expect_raises(DuplicateColumnException) as caught:
+        commands.query(ctx.sql("select_duplicate_columns"), params={"id": 1})
+    error = caught.exception
+    if not isinstance(error, DuplicateColumnException):
+        ctx.fail(f"expected a DuplicateColumnException, captured {error!r}")
+    duplicate = ctx.col("id")
+    ctx.check(error.columns == (duplicate, duplicate), f"structured columns attribute wrong: {error.columns!r}")
+    ctx.check(
+        error.duplicate_columns == (duplicate,),
+        f"structured duplicate_columns attribute wrong: {error.duplicate_columns!r}",
+    )
+    ctx.check(
+        error.duplicate_indexes == (0, 1),
+        f"structured duplicate_indexes attribute wrong: {error.duplicate_indexes!r}",
+    )
+    ctx.recover(commands)
+
+
+@_case("rows.mapper-receives-duplicates", "An explicit mapper intentionally receives duplicate columns", "live")
+def _rows_mapper_duplicates(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+
+    def mapper(row: RawRow) -> Tuple[Any, ...]:
+        return row.values
+
+    values = commands.query(ctx.sql("select_duplicate_columns"), params={"id": 1}, mapper=mapper)
+    ctx.check(values == [(1, 1)], f"mapper must receive both duplicate column values, got {values!r}")
+
+
+@_case("cardinality.first-returns-first", "query_first returns the first of many rows", "live")
+def _cardinality_first(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    row = commands.query_first(ctx.sql("select_two"), params={"score": 10})
+    ctx.check(row[ctx.col("id")] == 1, f"query_first must return the first row; got {row!r}")
+
+
+@_case("cardinality.first-zero-raises", "query_first raises NoResultException on zero rows", "live")
+def _cardinality_first_zero(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        commands.query_first(ctx.sql("select_by_id"), params={"id": 999})
+    ctx.recover(commands)
+
+
+@_case(
+    "cardinality.first-or-default",
+    "query_first_or_default returns the row when present and the default on zero rows",
+    "live",
+)
+def _cardinality_first_or_default(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    sentinel = object()
+    row: Any = commands.query_first_or_default(ctx.sql("select_by_id"), default=sentinel, params={"id": 1})
+    ctx.check(row is not sentinel and row[ctx.col("id")] == 1, f"expected row 1, got {row!r}")
+    missing = commands.query_first_or_default(ctx.sql("select_by_id"), default=sentinel, params={"id": 999})
+    ctx.check(missing is sentinel, "query_first_or_default must return the default on zero rows")
+
+
+@_case("cardinality.single-one", "query_single returns the only matching row", "live")
+def _cardinality_single(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    row = commands.query_single(ctx.sql("select_by_id"), params={"id": 1})
+    ctx.check(row[ctx.col("id")] == 1, f"query_single returned the wrong row: {row!r}")
+
+
+@_case("cardinality.single-zero-raises", "query_single raises NoResultException on zero rows", "live")
+def _cardinality_single_zero(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        commands.query_single(ctx.sql("select_by_id"), params={"id": 999})
+    ctx.recover(commands)
+
+
+@_case("cardinality.single-many-raises", "query_single raises MoreThanOneResultException on many rows", "live")
+def _cardinality_single_many(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    with ctx.expect_raises(MoreThanOneResultException):
+        commands.query_single(ctx.sql("select_two"), params={"score": 10})
+    ctx.recover(commands)
+
+
+@_case(
+    "cardinality.single-or-default",
+    "query_single_or_default handles zero, one, and many rows",
+    "live",
+)
+def _cardinality_single_or_default(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    sentinel = object()
+    missing = commands.query_single_or_default(ctx.sql("select_by_id"), default=sentinel, params={"id": 999})
+    ctx.check(missing is sentinel, "query_single_or_default must return the default on zero rows")
+    row: Any = commands.query_single_or_default(ctx.sql("select_by_id"), default=sentinel, params={"id": 1})
+    ctx.check(row is not sentinel and row[ctx.col("id")] == 1, f"expected row 1, got {row!r}")
+    with ctx.expect_raises(MoreThanOneResultException):
+        commands.query_single_or_default(ctx.sql("select_two"), default=sentinel, params={"score": 10})
+    ctx.recover(commands)
+
+
+@_case(
+    "cardinality.single-bounded-fetch",
+    "Single-row cardinality checks consume at most two rows before deciding",
+    "instrumented",
+)
+def _cardinality_bounded_fetch(ctx: SyncCaseContext) -> None:
+    many_rows = ((1, "a"), (2, "b"), (3, "c"), (4, "d"))
+    connection = ctx.recording_connection(CursorScript(rows=many_rows))
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(MoreThanOneResultException):
+        commands.query_single("SELECT id, label FROM t")
+    fetchmany_events = connection.log.of_kind("fetchmany")
+    ctx.check(
+        len(fetchmany_events) == 1 and fetchmany_events[0].size == 2,
+        f"with fetchmany available, exactly one fetchmany(2) is expected; saw {fetchmany_events!r}",
+    )
+
+    fallback = ctx.recording_connection(CursorScript(rows=many_rows, supports_fetchmany=False))
+    commands = ctx.instrumented_commands(fallback)
+    with ctx.expect_raises(MoreThanOneResultException):
+        commands.query_single("SELECT id, label FROM t")
+    exit_index = fallback.log.kinds().index("exit")
+    fetchone_before_decision = sum(1 for kind in fallback.log.kinds()[:exit_index] if kind == "fetchone")
+    ctx.check(
+        fetchone_before_decision <= 2,
+        f"without fetchmany, at most two fetchone calls may precede the cardinality decision; "
+        f"saw {fetchone_before_decision}",
+    )
+
+
+@_case("cardinality.falsey-row-is-result", "Falsey rows and values are results, never defaults", "live")
+def _cardinality_falsey_row(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    sentinel = object()
+    row: Any = commands.query_first_or_default(ctx.sql("select_by_id"), default=sentinel, params={"id": 2})
+    ctx.check(row is not sentinel, "a falsey row must not be replaced by the default")
+    ctx.check(row[ctx.col("score")] == 0, f"expected the falsey score row, got {row!r}")
+
+
+@_case("scalar.value", "execute_scalar returns the first column of the first row", "live")
+def _scalar_value(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    value = commands.execute_scalar(ctx.sql("scalar_label"), params={"id": 3})
+    ctx.check(value == "gamma", f"execute_scalar returned {value!r}, expected 'gamma'")
+
+
+@_case("scalar.no-row-raises", "execute_scalar distinguishes no returned row by raising NoResultException", "live")
+def _scalar_no_row(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    with ctx.expect_raises(NoResultException):
+        commands.execute_scalar(ctx.sql("scalar_label"), params={"id": 999})
+    ctx.recover(commands)
+
+
+@_case("scalar.null-returns-none", "execute_scalar returns None for a returned SQL NULL", "live")
+def _scalar_null(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    value = commands.execute_scalar(ctx.sql("scalar_note"), params={"id": 1})
+    ctx.check(value is None, f"a SQL NULL scalar must return None, got {value!r}")
+
+
+@_case("scalar.falsey-preserved", "Falsey first-column values are not treated as no result", "live")
+def _scalar_falsey(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    score = commands.execute_scalar(ctx.sql("scalar_score"), params={"id": 2})
+    ctx.check(score is not None and score == 0, f"a falsey 0 scalar must be preserved, got {score!r}")
+    label = commands.execute_scalar(ctx.sql("scalar_label"), params={"id": 2})
+    if ctx.harness.supports_empty_strings:
+        ctx.check(label == "", f"a falsey empty-string scalar must be preserved, got {label!r}")
+    else:
+        ctx.check(label == "blank", f"the documented empty-string fallback value must round-trip, got {label!r}")
+
+
+# --------------------------------------------------------------------------------------
+# options and capability honesty
+# --------------------------------------------------------------------------------------
+
+
+@_case(
+    "options.default-equivalence",
+    "Omitted options, options=None, and CommandOptions() behave identically",
+    "live",
+)
+def _options_default_equivalence(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    sql = ctx.sql("select_by_id")
+    omitted = commands.query(sql, params={"id": 1})
+    explicit_none = commands.query(sql, params={"id": 1}, options=None)
+    default_options = commands.query(sql, params={"id": 1}, options=CommandOptions())
+    ctx.check(
+        omitted == explicit_none == default_options,
+        "omitted options, options=None, and CommandOptions() must behave identically",
+    )
+
+
+@_case(
+    "options.unsupported-raises",
+    "Valid non-default options for undeclared capabilities raise UnsupportedFeatureError",
+    "live",
+)
+def _options_unsupported(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    declared = _declared_capabilities(ctx)
+    for capability, options in _UNSUPPORTED_OPTION_PROBES:
+        if capability in declared:
+            continue
+        with ctx.expect_raises(UnsupportedFeatureError):
+            commands.query(ctx.sql("select_all"), options=options)
+
+
+@_case(
+    "options.unsupported-before-driver-work",
+    "Unsupported options fail before cursor acquisition or driver work",
+    "instrumented",
+)
+def _options_unsupported_no_driver_work(ctx: SyncCaseContext) -> None:
+    declared = _declared_capabilities(ctx)
+    for capability, options in _UNSUPPORTED_OPTION_PROBES:
+        if capability in declared:
+            continue
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        with ctx.expect_raises(UnsupportedFeatureError):
+            commands.query("SELECT id, label FROM t", options=options)
+        ctx.check(
+            connection.cursor_calls == 0,
+            f"options for undeclared capability {capability.value!r} must fail before any cursor is acquired",
+        )
+
+
+@_case("options.invalid-rejected", "Invalid options objects fail clearly with TypeError", "instrumented")
+def _options_invalid(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    bad_options: Any = object()
+    with ctx.expect_raises(TypeError):
+        commands.query("SELECT id, label FROM t", options=bad_options)
+    ctx.check(connection.cursor_calls == 0, "invalid options must fail before any cursor is acquired")
+
+
+@_case(
+    "capabilities.declaration-valid",
+    "The concrete class declares capabilities as a frozenset of AdapterCapability members",
+    "instrumented",
+)
+def _capabilities_declaration_valid(ctx: SyncCaseContext) -> None:
+    declared = getattr(ctx.command_class, "capabilities", None)
+    if not isinstance(declared, frozenset):
+        ctx.fail(
+            f"{ctx.command_class.__name__}.capabilities must be a frozenset of AdapterCapability members, "
+            f"got {type(declared).__name__}"
+        )
+    for member in declared:
+        if not isinstance(member, AdapterCapability):
+            ctx.fail(f"{ctx.command_class.__name__}.capabilities contains a non-AdapterCapability member: {member!r}")
+
+
+@_case(
+    "capabilities.supports-matches-declaration",
+    "supports() exactly matches the class declaration and rejects non-enum arguments",
+    "instrumented",
+)
+def _capabilities_supports(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    declared = _declared_capabilities(ctx)
+    for member in AdapterCapability:
+        ctx.check(
+            commands.supports(member) == (member in declared),
+            f"supports({member.value!r}) must match the class declaration",
+        )
+    with ctx.expect_raises(TypeError):
+        commands.supports("transactions")  # type: ignore[arg-type]
+
+
+@_case(
+    "capabilities.declared-profile-populated",
+    "Every declared capability has a populated conformance profile for this mode",
+    "instrumented",
+)
+def _capabilities_profiles_populated(ctx: SyncCaseContext) -> None:
+    declared: Any = getattr(ctx.command_class, "capabilities", frozenset())
+    if not isinstance(declared, frozenset):
+        ctx.fail(f"cannot evaluate capability profiles: invalid declaration {declared!r}")
+    for member in declared:
+        if not isinstance(member, AdapterCapability):
+            ctx.fail(f"cannot evaluate capability profiles: non-enum member {member!r}")
+        profile = ctx.capability_catalog.get(member)
+        if profile is None:
+            ctx.fail(
+                f"declared capability {member.value!r} has no conformance profile; "
+                "a capability may only be declared once its reusable profile exists"
+            )
+        if not profile.sync_cases:
+            ctx.fail(
+                f"declared capability {member.value!r} has no sync conformance cases; "
+                "a declared capability must be covered in every declared mode"
+            )

--- a/pydapper/testing/adapter_conformance/_checks.py
+++ b/pydapper/testing/adapter_conformance/_checks.py
@@ -1,0 +1,288 @@
+"""Case execution contexts and framework-owned assertion helpers.
+
+Every behavioral assertion lives in the framework: case implementations call
+:meth:`check`/:meth:`fail`/:meth:`expect_raises`, which raise
+:class:`~pydapper.testing.adapter_conformance._results.CaseCheckError` converted by
+the runner into failed results. Harness- or adapter-provided code has no channel to
+declare a case passed.
+"""
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import List
+from typing import Mapping
+from typing import NoReturn
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
+
+from pydapper.capabilities import AdapterCapability
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+
+from ._harness import AsyncAdapterHarness
+from ._harness import SyncAdapterHarness
+from ._instrumentation import CursorScript
+from ._instrumentation import RecordedEvent
+from ._instrumentation import RecordingAsyncConnection
+from ._instrumentation import RecordingConnection
+from ._instrumentation import RecordingLog
+from ._instrumentation import SynchronousCursorRecordingAsyncConnection
+from ._results import CaseCheckError
+from ._results import HarnessDefinitionError
+from ._sqlspec import expected_column
+from ._sqlspec import expected_row_dict
+from ._sqlspec import render_statement
+from ._sqlspec import seed_rows
+
+if TYPE_CHECKING:
+    from pydapper.types import AsyncConnectionType
+    from pydapper.types import ConnectionType
+
+    from ._profiles import ConformanceProfile
+
+
+class ExpectedRaise:
+    """Context manager asserting that a block raises one of the expected types.
+
+    The caught exception is exposed as :attr:`exception` for structured-attribute
+    assertions. A missing exception fails the case; an unexpected exception type
+    propagates and the runner records it as the case's cause.
+    """
+
+    def __init__(self, exc_types: Tuple[Type[BaseException], ...], description: str) -> None:
+        self._exc_types = exc_types
+        self._description = description
+        self.exception: Optional[BaseException] = None
+
+    def __enter__(self) -> "ExpectedRaise":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        if exc_type is None:
+            names = ", ".join(t.__name__ for t in self._exc_types)
+            raise CaseCheckError(f"{self._description}: expected {names} to be raised, but nothing was raised")
+        if issubclass(exc_type, self._exc_types):
+            self.exception = exc_val
+            return True
+        return False
+
+
+class _BaseCaseContext:
+    """State and helpers shared by the sync and async case contexts."""
+
+    def __init__(self, profile_id: str, case_id: str, catalog: Mapping[AdapterCapability, "ConformanceProfile"]):
+        self.profile_id = profile_id
+        self.case_id = case_id
+        self.capability_catalog = catalog
+
+    # -- framework-owned assertions -------------------------------------------------
+
+    def check(self, condition: bool, message: str) -> None:
+        if not condition:
+            raise CaseCheckError(message)
+
+    def fail(self, message: str, cause: Optional[BaseException] = None) -> NoReturn:
+        raise CaseCheckError(message, cause=cause)
+
+    def expect_raises(self, *exc_types: Type[BaseException], description: str = "") -> ExpectedRaise:
+        return ExpectedRaise(exc_types, description or f"case {self.case_id!r}")
+
+    def check_event_order(self, log: RecordingLog, expected_kinds: Sequence[str]) -> None:
+        self.check(
+            log.kinds() == tuple(expected_kinds),
+            f"expected driver interaction order {tuple(expected_kinds)!r}, observed {log.kinds()!r}",
+        )
+
+    def check_single_cursor_lifecycle(self, connection: Any) -> None:
+        self.check(
+            connection.cursor_calls == 1, f"expected exactly one cursor acquisition, saw {connection.cursor_calls}"
+        )
+        recorder = connection.recorders[0]
+        cleanup_calls = recorder.exit_calls + recorder.close_calls
+        self.check(cleanup_calls == 1, f"expected exactly one cursor cleanup, saw {cleanup_calls}")
+
+    def missing_field(self, field_name: str) -> HarnessDefinitionError:
+        return HarnessDefinitionError(self.profile_id, self.case_id, field_name)
+
+    # -- harness field access -------------------------------------------------------
+
+    def _require_attr(self, harness: Any, name: str) -> Any:
+        value = getattr(harness, name, None)
+        if value is None:
+            raise self.missing_field(name)
+        return value
+
+    def _require_override(self, harness: Any, base_class: type, name: str) -> None:
+        if getattr(type(harness), name, None) is getattr(base_class, name):
+            raise self.missing_field(name)
+
+
+class SyncCaseContext(_BaseCaseContext):
+    """Execution context handed to every ``core-sync`` case implementation."""
+
+    def __init__(
+        self,
+        harness: SyncAdapterHarness,
+        profile_id: str,
+        case_id: str,
+        catalog: Mapping[AdapterCapability, "ConformanceProfile"],
+    ) -> None:
+        super().__init__(profile_id, case_id, catalog)
+        self.harness = harness
+        self.created_commands: List[Commands] = []
+
+    # -- harness surface ------------------------------------------------------------
+
+    @property
+    def adapter_name(self) -> str:
+        return self._require_attr(self.harness, "adapter_name")
+
+    @property
+    def command_class(self) -> Type[Commands]:
+        return self._require_attr(self.harness, "command_class")
+
+    @property
+    def connect_dsn(self) -> str:
+        return self._require_attr(self.harness, "connect_dsn")
+
+    def create_commands(self) -> Commands:
+        self._require_override(self.harness, SyncAdapterHarness, "create_commands")
+        self._require_override(self.harness, SyncAdapterHarness, "teardown_commands")
+        commands = self.harness.create_commands()
+        self.created_commands.append(commands)
+        return commands
+
+    def recover(self, commands: Commands) -> None:
+        self.harness.recover_after_error(commands)
+
+    # -- canonical SQL and data -----------------------------------------------------
+
+    def sql(self, statement_id: str) -> str:
+        return render_statement(statement_id, self.harness.table_name, self.harness.sql_overrides)
+
+    def col(self, name: str) -> str:
+        return expected_column(name, self.harness.column_case)
+
+    def seeded_rows(self) -> Tuple[Tuple[Any, ...], ...]:
+        return seed_rows(self.harness.supports_empty_strings)
+
+    def expected_row(self, row: Tuple[Any, ...]) -> Mapping[str, Any]:
+        return expected_row_dict(row, self.harness.column_case)
+
+    # -- instrumentation ------------------------------------------------------------
+
+    def recording_connection(
+        self,
+        scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
+        cursor_style: str = "context",
+    ) -> RecordingConnection:
+        return RecordingConnection(scripts, cursor_style=cursor_style)
+
+    def instrumented_commands(self, connection: RecordingConnection) -> Commands:
+        return self.command_class(cast("ConnectionType", connection))  # type: ignore[abstract]
+
+    def install_hook_recorder(self, commands: Commands, log: RecordingLog) -> None:
+        original_prepare_cursor = type(commands)._prepare_cursor
+        original_prepare_command = type(commands)._prepare_command
+
+        def prepare_cursor(cursor: Any, *, options: Any) -> None:
+            log.add(RecordedEvent(kind="prepare_cursor", detail=(cursor, options)))
+            original_prepare_cursor(commands, cursor, options=options)
+
+        def prepare_command(cursor: Any, handler: Any, *, options: Any) -> None:
+            log.add(RecordedEvent(kind="prepare_command", detail=(cursor, handler, options)))
+            original_prepare_command(commands, cursor, handler, options=options)
+
+        # instance attributes shadow the class methods for this command object only,
+        # so the concrete class's own hook implementations still run via delegation
+        commands._prepare_cursor = prepare_cursor  # type: ignore[method-assign]
+        commands._prepare_command = prepare_command  # type: ignore[method-assign]
+
+
+class AsyncCaseContext(_BaseCaseContext):
+    """Execution context handed to every ``core-async`` case implementation."""
+
+    def __init__(
+        self,
+        harness: AsyncAdapterHarness,
+        profile_id: str,
+        case_id: str,
+        catalog: Mapping[AdapterCapability, "ConformanceProfile"],
+    ) -> None:
+        super().__init__(profile_id, case_id, catalog)
+        self.harness = harness
+        self.created_commands: List[CommandsAsync] = []
+
+    # -- harness surface ------------------------------------------------------------
+
+    @property
+    def adapter_name(self) -> str:
+        return self._require_attr(self.harness, "adapter_name")
+
+    @property
+    def command_class(self) -> Type[CommandsAsync]:
+        return self._require_attr(self.harness, "command_class")
+
+    @property
+    def connect_dsn(self) -> str:
+        return self._require_attr(self.harness, "connect_dsn")
+
+    async def create_commands(self) -> CommandsAsync:
+        self._require_override(self.harness, AsyncAdapterHarness, "create_commands")
+        self._require_override(self.harness, AsyncAdapterHarness, "teardown_commands")
+        commands = await self.harness.create_commands()
+        self.created_commands.append(commands)
+        return commands
+
+    async def recover(self, commands: CommandsAsync) -> None:
+        await self.harness.recover_after_error(commands)
+
+    # -- canonical SQL and data -----------------------------------------------------
+
+    def sql(self, statement_id: str) -> str:
+        return render_statement(statement_id, self.harness.table_name, self.harness.sql_overrides)
+
+    def col(self, name: str) -> str:
+        return expected_column(name, self.harness.column_case)
+
+    def seeded_rows(self) -> Tuple[Tuple[Any, ...], ...]:
+        return seed_rows(self.harness.supports_empty_strings)
+
+    def expected_row(self, row: Tuple[Any, ...]) -> Mapping[str, Any]:
+        return expected_row_dict(row, self.harness.column_case)
+
+    # -- instrumentation ------------------------------------------------------------
+
+    def recording_connection(
+        self,
+        scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
+        cursor_style: str = "context",
+        close_style: str = "sync",
+    ) -> RecordingAsyncConnection:
+        if self.harness.cursor_factory_style == "synchronous":
+            return SynchronousCursorRecordingAsyncConnection(
+                scripts, cursor_style=cursor_style, close_style=close_style
+            )
+        return RecordingAsyncConnection(scripts, cursor_style=cursor_style, close_style=close_style)
+
+    def instrumented_commands(self, connection: RecordingAsyncConnection) -> CommandsAsync:
+        return self.command_class(cast("AsyncConnectionType", connection))  # type: ignore[abstract]
+
+    def install_hook_recorder(self, commands: CommandsAsync, log: RecordingLog) -> None:
+        original_prepare_cursor = type(commands)._prepare_cursor_async
+        original_prepare_command = type(commands)._prepare_command_async
+
+        async def prepare_cursor_async(cursor: Any, *, options: Any) -> None:
+            log.add(RecordedEvent(kind="prepare_cursor", detail=(cursor, options)))
+            await original_prepare_cursor(commands, cursor, options=options)
+
+        async def prepare_command_async(cursor: Any, handler: Any, *, options: Any) -> None:
+            log.add(RecordedEvent(kind="prepare_command", detail=(cursor, handler, options)))
+            await original_prepare_command(commands, cursor, handler, options=options)
+
+        commands._prepare_cursor_async = prepare_cursor_async  # type: ignore[method-assign]
+        commands._prepare_command_async = prepare_command_async  # type: ignore[method-assign]

--- a/pydapper/testing/adapter_conformance/_checks.py
+++ b/pydapper/testing/adapter_conformance/_checks.py
@@ -5,6 +5,12 @@ Every behavioral assertion lives in the framework: case implementations call
 :class:`~pydapper.testing.adapter_conformance._results.CaseCheckError` converted by
 the runner into failed results. Harness- or adapter-provided code has no channel to
 declare a case passed.
+
+``create_commands`` additionally wraps the harness's *own* factory call — and only
+that call, never the framework's own validation or bookkeeping around it — in
+:class:`~pydapper.testing.adapter_conformance._results.HarnessSetupError`, so a
+harness that cannot build a connection or seed the canonical dataset is reported as a
+broken harness instead of as many identical-looking adapter failures.
 """
 
 from typing import TYPE_CHECKING
@@ -33,6 +39,7 @@ from ._instrumentation import RecordingLog
 from ._instrumentation import SynchronousCursorRecordingAsyncConnection
 from ._results import CaseCheckError
 from ._results import HarnessDefinitionError
+from ._results import HarnessSetupError
 from ._sqlspec import expected_column
 from ._sqlspec import expected_row_dict
 from ._sqlspec import render_statement
@@ -152,7 +159,10 @@ class SyncCaseContext(_BaseCaseContext):
     def create_commands(self) -> Commands:
         self._require_override(self.harness, SyncAdapterHarness, "create_commands")
         self._require_override(self.harness, SyncAdapterHarness, "teardown_commands")
-        commands = self.harness.create_commands()
+        try:
+            commands = self.harness.create_commands()
+        except Exception as error:  # noqa: BLE001 - re-raised as a structured harness setup failure
+            raise HarnessSetupError(self.profile_id, self.case_id, error) from error
         self.created_commands.append(commands)
         return commands
 
@@ -234,7 +244,10 @@ class AsyncCaseContext(_BaseCaseContext):
     async def create_commands(self) -> CommandsAsync:
         self._require_override(self.harness, AsyncAdapterHarness, "create_commands")
         self._require_override(self.harness, AsyncAdapterHarness, "teardown_commands")
-        commands = await self.harness.create_commands()
+        try:
+            commands = await self.harness.create_commands()
+        except Exception as error:  # noqa: BLE001 - re-raised as a structured harness setup failure
+            raise HarnessSetupError(self.profile_id, self.case_id, error) from error
         self.created_commands.append(commands)
         return commands
 

--- a/pydapper/testing/adapter_conformance/_harness.py
+++ b/pydapper/testing/adapter_conformance/_harness.py
@@ -11,7 +11,6 @@ profiles independently.
 """
 
 from typing import Any
-from typing import ClassVar
 from typing import Literal
 from typing import Mapping
 from typing import Optional
@@ -43,7 +42,9 @@ from pydapper.commands import CommandsAsync
 class SyncAdapterHarness:
     """Harness contract for running ``core-sync`` against one concrete sync adapter.
 
-    Required class attributes / overrides:
+    Required attributes / overrides. Configuration fields may be declared on the
+    subclass or assigned per instance (for example a ``connect_dsn`` that is only
+    known once a test container has started):
 
     * ``adapter_name`` — the registered adapter name (exact, case-sensitive).
     * ``command_class`` — the declared concrete :class:`~pydapper.commands.Commands`
@@ -57,15 +58,15 @@ class SyncAdapterHarness:
     * :meth:`teardown_commands` — release everything :meth:`create_commands` built.
     """
 
-    adapter_name: ClassVar[Optional[str]] = None
-    command_class: ClassVar[Optional[Type[Commands]]] = None
-    connect_dsn: ClassVar[Optional[str]] = None
-    connect_kwargs: ClassVar[Mapping[str, Any]] = {}
-    table_name: ClassVar[str] = "pydapper_conformance"
-    column_case: ClassVar[Literal["lower", "upper"]] = "lower"
-    supports_empty_strings: ClassVar[bool] = True
-    strict_rowcounts: ClassVar[bool] = True
-    sql_overrides: ClassVar[Mapping[str, str]] = {}
+    adapter_name: Optional[str] = None
+    command_class: Optional[Type[Commands]] = None
+    connect_dsn: Optional[str] = None
+    connect_kwargs: Mapping[str, Any] = {}
+    table_name: str = "pydapper_conformance"
+    column_case: Literal["lower", "upper"] = "lower"
+    supports_empty_strings: bool = True
+    strict_rowcounts: bool = True
+    sql_overrides: Mapping[str, str] = {}
 
     def create_commands(self) -> Commands:
         """Return a fresh, isolated command instance with the dataset freshly seeded."""
@@ -86,8 +87,9 @@ class SyncAdapterHarness:
 class AsyncAdapterHarness:
     """Harness contract for running ``core-async`` against one concrete async adapter.
 
-    Required class attributes / overrides mirror :class:`SyncAdapterHarness` with
-    awaitable factories. ``cursor_factory_style`` additionally tells the framework
+    Required attributes / overrides mirror :class:`SyncAdapterHarness` with awaitable
+    factories, and configuration fields may likewise be declared on the subclass or
+    assigned per instance. ``cursor_factory_style`` additionally tells the framework
     which instrumented connection shape the adapter's ``cursor()`` contract expects:
 
     * ``"awaitable"`` — ``connection.cursor()`` returns an awaitable (the
@@ -96,16 +98,16 @@ class AsyncAdapterHarness:
       command class normalizes it (e.g. psycopg3 async).
     """
 
-    adapter_name: ClassVar[Optional[str]] = None
-    command_class: ClassVar[Optional[Type[CommandsAsync]]] = None
-    connect_dsn: ClassVar[Optional[str]] = None
-    connect_kwargs: ClassVar[Mapping[str, Any]] = {}
-    table_name: ClassVar[str] = "pydapper_conformance"
-    column_case: ClassVar[Literal["lower", "upper"]] = "lower"
-    supports_empty_strings: ClassVar[bool] = True
-    strict_rowcounts: ClassVar[bool] = True
-    sql_overrides: ClassVar[Mapping[str, str]] = {}
-    cursor_factory_style: ClassVar[Literal["awaitable", "synchronous"]] = "awaitable"
+    adapter_name: Optional[str] = None
+    command_class: Optional[Type[CommandsAsync]] = None
+    connect_dsn: Optional[str] = None
+    connect_kwargs: Mapping[str, Any] = {}
+    table_name: str = "pydapper_conformance"
+    column_case: Literal["lower", "upper"] = "lower"
+    supports_empty_strings: bool = True
+    strict_rowcounts: bool = True
+    sql_overrides: Mapping[str, str] = {}
+    cursor_factory_style: Literal["awaitable", "synchronous"] = "awaitable"
 
     async def create_commands(self) -> CommandsAsync:
         """Return a fresh, isolated async command instance with the dataset freshly seeded."""

--- a/pydapper/testing/adapter_conformance/_harness.py
+++ b/pydapper/testing/adapter_conformance/_harness.py
@@ -1,0 +1,119 @@
+"""Typed harness base classes adapter authors implement to run conformance profiles.
+
+A harness supplies factories, per-case dataset isolation, and the narrow, documented
+dialect knobs. It never owns behavioral assertions and has no channel to declare a
+case passed: every assertion belongs to the framework runner.
+
+Sync-only adapters implement :class:`SyncAdapterHarness` only; async-only adapters
+implement :class:`AsyncAdapterHarness` only. Neither base requires fields from the
+other mode. A dual-mode adapter implements both and must pass both mandatory
+profiles independently.
+"""
+
+from typing import Any
+from typing import ClassVar
+from typing import Literal
+from typing import Mapping
+from typing import Optional
+from typing import Type
+
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+
+#: Documented per-mode dialect knobs shared by both harness bases:
+#:
+#: ``table_name``
+#:     Name (optionally schema/dataset qualified) of the canonical conformance table.
+#: ``column_case``
+#:     ``"lower"`` (default) or ``"upper"`` for dialects that fold unquoted
+#:     identifiers to uppercase (for example Oracle).
+#: ``supports_empty_strings``
+#:     ``False`` only for dialects that cannot store an empty string distinctly from
+#:     SQL NULL (for example Oracle). Row 2's label then seeds as ``"blank"`` and the
+#:     empty-string sub-assertion is replaced by the documented fallback value.
+#: ``strict_rowcounts``
+#:     ``False`` only for drivers/emulators whose DML rowcount reporting is
+#:     documented as unreliable (for example the BigQuery emulator). Rowcount cases
+#:     still execute and must return an ``int``; only exact-count equality is relaxed.
+#: ``sql_overrides``
+#:     Statement-id -> SQL overrides for the narrow cases where portable SQL is
+#:     insufficient. Overrides still use pydapper ``?name?`` placeholders.
+
+
+class SyncAdapterHarness:
+    """Harness contract for running ``core-sync`` against one concrete sync adapter.
+
+    Required class attributes / overrides:
+
+    * ``adapter_name`` — the registered adapter name (exact, case-sensitive).
+    * ``command_class`` — the declared concrete :class:`~pydapper.commands.Commands`
+      subclass for the sync mode.
+    * ``connect_dsn`` — a DSN that safely reaches an isolated test database through
+      ``pydapper.connect()``.
+    * :meth:`create_commands` — return a fresh command instance over a fresh
+      connection with the canonical dataset freshly seeded (see
+      ``pydapper.testing.adapter_conformance.CONFORMANCE_ROWS`` /
+      ``seed_rows()``). Called once per case; cases never share state.
+    * :meth:`teardown_commands` — release everything :meth:`create_commands` built.
+    """
+
+    adapter_name: ClassVar[Optional[str]] = None
+    command_class: ClassVar[Optional[Type[Commands]]] = None
+    connect_dsn: ClassVar[Optional[str]] = None
+    connect_kwargs: ClassVar[Mapping[str, Any]] = {}
+    table_name: ClassVar[str] = "pydapper_conformance"
+    column_case: ClassVar[Literal["lower", "upper"]] = "lower"
+    supports_empty_strings: ClassVar[bool] = True
+    strict_rowcounts: ClassVar[bool] = True
+    sql_overrides: ClassVar[Mapping[str, str]] = {}
+
+    def create_commands(self) -> Commands:
+        """Return a fresh, isolated command instance with the dataset freshly seeded."""
+        raise NotImplementedError
+
+    def teardown_commands(self, commands: Commands) -> None:
+        """Release the connection and any per-case resources behind ``commands``."""
+        raise NotImplementedError
+
+    def recover_after_error(self, commands: Commands) -> None:
+        """Perform backend recovery required after an intentionally failed command.
+
+        Called by the runner after cases that intentionally fail a command, before
+        the same command instance is reused. The default is a no-op.
+        """
+
+
+class AsyncAdapterHarness:
+    """Harness contract for running ``core-async`` against one concrete async adapter.
+
+    Required class attributes / overrides mirror :class:`SyncAdapterHarness` with
+    awaitable factories. ``cursor_factory_style`` additionally tells the framework
+    which instrumented connection shape the adapter's ``cursor()`` contract expects:
+
+    * ``"awaitable"`` — ``connection.cursor()`` returns an awaitable (the
+      :class:`~pydapper.commands.CommandsAsync` base contract, e.g. aiopg).
+    * ``"synchronous"`` — ``connection.cursor()`` returns the cursor directly and the
+      command class normalizes it (e.g. psycopg3 async).
+    """
+
+    adapter_name: ClassVar[Optional[str]] = None
+    command_class: ClassVar[Optional[Type[CommandsAsync]]] = None
+    connect_dsn: ClassVar[Optional[str]] = None
+    connect_kwargs: ClassVar[Mapping[str, Any]] = {}
+    table_name: ClassVar[str] = "pydapper_conformance"
+    column_case: ClassVar[Literal["lower", "upper"]] = "lower"
+    supports_empty_strings: ClassVar[bool] = True
+    strict_rowcounts: ClassVar[bool] = True
+    sql_overrides: ClassVar[Mapping[str, str]] = {}
+    cursor_factory_style: ClassVar[Literal["awaitable", "synchronous"]] = "awaitable"
+
+    async def create_commands(self) -> CommandsAsync:
+        """Return a fresh, isolated async command instance with the dataset freshly seeded."""
+        raise NotImplementedError
+
+    async def teardown_commands(self, commands: CommandsAsync) -> None:
+        """Release the connection and any per-case resources behind ``commands``."""
+        raise NotImplementedError
+
+    async def recover_after_error(self, commands: CommandsAsync) -> None:
+        """Perform backend recovery required after an intentionally failed command."""

--- a/pydapper/testing/adapter_conformance/_instrumentation.py
+++ b/pydapper/testing/adapter_conformance/_instrumentation.py
@@ -1,0 +1,444 @@
+"""Framework-owned, driver-neutral recording and fault-injection instrumentation.
+
+Interaction-level conformance cases instantiate the adapter's real concrete command
+class around these connections so lifecycle behavior — cursor acquisition counts,
+enter/exit pairing, ``close()``/``aclose()``, call ordering, bounded fetches, error
+precedence, and absence of driver work — is observed rather than inferred from
+returned values.
+
+Everything here is standard library only and embeds no first-party fixtures. The
+event log is owned by the framework; adapter- or harness-provided code has no API to
+mark a case as passed.
+"""
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+
+
+@dataclass(frozen=True)
+class RecordedEvent:
+    """One observed interaction between a command class and the instrumented driver."""
+
+    kind: str
+    sql: Optional[str] = None
+    params: Optional[Any] = None
+    size: Optional[int] = None
+    on_entered: Optional[bool] = None
+    exc_type: Optional[type] = None
+    exc_value: Optional[BaseException] = field(default=None, repr=False)
+    tb_is_active: Optional[bool] = None
+    detail: Optional[Any] = field(default=None, repr=False)
+
+
+class RecordingLog:
+    """An append-only, framework-owned timeline shared by one instrumented run."""
+
+    def __init__(self) -> None:
+        self.events: List[RecordedEvent] = []
+
+    def add(self, event: RecordedEvent) -> None:
+        self.events.append(event)
+
+    def kinds(self) -> Tuple[str, ...]:
+        return tuple(event.kind for event in self.events)
+
+    def count(self, kind: str) -> int:
+        return sum(1 for event in self.events if event.kind == kind)
+
+    def first(self, kind: str) -> Optional[RecordedEvent]:
+        for event in self.events:
+            if event.kind == kind:
+                return event
+        return None
+
+    def of_kind(self, kind: str) -> Tuple[RecordedEvent, ...]:
+        return tuple(event for event in self.events if event.kind == kind)
+
+
+@dataclass
+class CursorScript:
+    """Scripted results and fault injection for one instrumented cursor.
+
+    ``rows``/``columns`` describe the result set every ``execute`` produces.
+    ``*_error`` fields inject a failure at the named interaction. ``exit_result``
+    probes truthy context-manager exits. ``supports_fetchmany`` controls whether the
+    cursor exposes ``fetchmany`` (which changes the bounded single-row fetch path).
+    """
+
+    columns: Tuple[str, ...] = ("id", "label")
+    rows: Tuple[Tuple[Any, ...], ...] = ((1, "alpha"), (2, "beta"))
+    rowcount: int = 1
+    rowcount_from_executemany_length: bool = True
+    execute_error: Optional[BaseException] = None
+    executemany_error: Optional[BaseException] = None
+    fetchone_error: Optional[BaseException] = None
+    fetchall_error: Optional[BaseException] = None
+    fetchmany_error: Optional[BaseException] = None
+    close_error: Optional[BaseException] = None
+    exit_error: Optional[BaseException] = None
+    exit_result: Any = False
+    supports_fetchmany: bool = True
+
+
+class CursorRecorder:
+    """Shared recording core behind every instrumented cursor facade."""
+
+    def __init__(self, script: CursorScript, log: RecordingLog) -> None:
+        self.script = script
+        self.log = log
+        self.pending_rows: List[Tuple[Any, ...]] = []
+        self.rowcount = -1
+        self.close_calls = 0
+        self.enter_calls = 0
+        self.exit_calls = 0
+        self.exit_args: List[Tuple[Any, Any, Any]] = []
+
+    @property
+    def description(self) -> Tuple[Tuple[Any, ...], ...]:
+        return tuple((name, None, None, None, None, None, None) for name in self.script.columns)
+
+    def _record(self, kind: str, on_entered: Optional[bool], **payload: Any) -> None:
+        self.log.add(RecordedEvent(kind=kind, on_entered=on_entered, **payload))
+
+    def do_execute(self, sql: str, parameters: Any, on_entered: bool) -> None:
+        self._record("execute", on_entered, sql=sql, params=parameters)
+        if self.script.execute_error is not None:
+            raise self.script.execute_error
+        self.pending_rows = list(self.script.rows)
+        self.rowcount = self.script.rowcount
+
+    def do_executemany(self, sql: str, seq_of_parameters: Any, on_entered: bool) -> None:
+        params = list(seq_of_parameters) if seq_of_parameters is not None else []
+        self._record("executemany", on_entered, sql=sql, params=params)
+        if self.script.executemany_error is not None:
+            raise self.script.executemany_error
+        self.pending_rows = []
+        if self.script.rowcount_from_executemany_length:
+            self.rowcount = len(params)
+        else:
+            self.rowcount = self.script.rowcount
+
+    def do_fetchone(self, on_entered: bool) -> Optional[Tuple[Any, ...]]:
+        self._record("fetchone", on_entered)
+        if self.script.fetchone_error is not None:
+            raise self.script.fetchone_error
+        if not self.pending_rows:
+            return None
+        return self.pending_rows.pop(0)
+
+    def do_fetchall(self, on_entered: bool) -> Tuple[Tuple[Any, ...], ...]:
+        self._record("fetchall", on_entered)
+        if self.script.fetchall_error is not None:
+            raise self.script.fetchall_error
+        rows = tuple(self.pending_rows)
+        self.pending_rows = []
+        return rows
+
+    def do_fetchmany(self, size: int, on_entered: bool) -> Tuple[Tuple[Any, ...], ...]:
+        self._record("fetchmany", on_entered, size=size)
+        if self.script.fetchmany_error is not None:
+            raise self.script.fetchmany_error
+        rows = tuple(self.pending_rows[:size])
+        del self.pending_rows[:size]
+        return rows
+
+    def do_close(self, on_entered: bool = False) -> None:
+        self.close_calls += 1
+        self._record("close", on_entered)
+        if self.script.close_error is not None:
+            raise self.script.close_error
+
+    def do_enter(self) -> None:
+        self.enter_calls += 1
+        self._record("enter", None)
+
+    def do_exit(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        self.exit_calls += 1
+        self.exit_args.append((exc_type, exc_val, exc_tb))
+        tb_is_active = None
+        if exc_val is not None:
+            tb_is_active = exc_tb is getattr(exc_val, "__traceback__", None)
+        self._record("exit", None, exc_type=exc_type, exc_value=exc_val, tb_is_active=tb_is_active)
+        if self.script.exit_error is not None:
+            raise self.script.exit_error
+        return self.script.exit_result
+
+
+class _SyncCursorFacade:
+    """Sync DBAPI surface over a :class:`CursorRecorder`."""
+
+    _entered = False
+
+    def __init__(self, recorder: CursorRecorder) -> None:
+        self.recorder = recorder
+
+    @property
+    def description(self) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.description
+
+    @property
+    def rowcount(self) -> int:
+        return self.recorder.rowcount
+
+    def execute(self, sql: str, parameters: Any = None) -> None:
+        self.recorder.do_execute(sql, parameters, self._entered)
+
+    def executemany(self, sql: str, seq_of_parameters: Any = None) -> None:
+        self.recorder.do_executemany(sql, seq_of_parameters, self._entered)
+
+    def fetchone(self) -> Optional[Tuple[Any, ...]]:
+        return self.recorder.do_fetchone(self._entered)
+
+    def fetchall(self) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.do_fetchall(self._entered)
+
+    def fetchmany(self, size: int = 1) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.do_fetchmany(size, self._entered)
+
+    def close(self) -> None:
+        self.recorder.do_close(self._entered)
+
+
+class EnteredRecordingCursor(_SyncCursorFacade):
+    """The distinct object a context-managed cursor's ``__enter__`` returns.
+
+    Sharing the recorder while being a different object lets the framework prove
+    commands operate on the *entered* cursor rather than the raw one.
+    """
+
+    _entered = True
+
+
+class _NoFetchmanyEnteredRecordingCursor(EnteredRecordingCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class PlainRecordingCursor(_SyncCursorFacade):
+    """A cursor with no context-manager protocol; cleanup must go through ``close()``."""
+
+
+class _NoFetchmanyPlainRecordingCursor(PlainRecordingCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class ContextRecordingCursor(_SyncCursorFacade):
+    """A native context-manager cursor whose ``__enter__`` returns a distinct object."""
+
+    def __init__(self, recorder: CursorRecorder) -> None:
+        super().__init__(recorder)
+        entered_class = (
+            EnteredRecordingCursor if recorder.script.supports_fetchmany else _NoFetchmanyEnteredRecordingCursor
+        )
+        self.entered_cursor = entered_class(recorder)
+
+    def __enter__(self) -> EnteredRecordingCursor:
+        self.recorder.do_enter()
+        return self.entered_cursor
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        return self.recorder.do_exit(exc_type, exc_val, exc_tb)
+
+
+class _NoFetchmanyContextRecordingCursor(ContextRecordingCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class _AsyncCursorFacade:
+    """Async DBAPI surface over a :class:`CursorRecorder`."""
+
+    _entered = False
+
+    def __init__(self, recorder: CursorRecorder) -> None:
+        self.recorder = recorder
+
+    @property
+    def description(self) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.description
+
+    @property
+    def rowcount(self) -> int:
+        return self.recorder.rowcount
+
+    async def execute(self, sql: str, parameters: Any = None) -> None:
+        self.recorder.do_execute(sql, parameters, self._entered)
+
+    async def executemany(self, sql: str, seq_of_parameters: Any = None) -> None:
+        self.recorder.do_executemany(sql, seq_of_parameters, self._entered)
+
+    async def fetchone(self) -> Optional[Tuple[Any, ...]]:
+        return self.recorder.do_fetchone(self._entered)
+
+    async def fetchall(self) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.do_fetchall(self._entered)
+
+    async def fetchmany(self, size: int = 1) -> Tuple[Tuple[Any, ...], ...]:
+        return self.recorder.do_fetchmany(size, self._entered)
+
+
+class EnteredRecordingAsyncCursor(_AsyncCursorFacade):
+    """Distinct entered object shared-state proxy for async context-manager cursors."""
+
+    _entered = True
+
+
+class _NoFetchmanyEnteredRecordingAsyncCursor(EnteredRecordingAsyncCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class PlainRecordingAsyncCursor(_AsyncCursorFacade):
+    """An async cursor with no context-manager protocol.
+
+    ``close_style`` selects whether ``close()`` completes synchronously or returns an
+    awaitable, covering both plain-cursor cleanup shapes.
+    """
+
+    def __init__(self, recorder: CursorRecorder, close_style: str = "sync") -> None:
+        super().__init__(recorder)
+        self._close_style = close_style
+
+    def close(self) -> Any:
+        if self._close_style == "awaitable":
+
+            async def _aclose() -> None:
+                self.recorder.do_close(self._entered)
+
+            return _aclose()
+        self.recorder.do_close(self._entered)
+        return None
+
+
+class _NoFetchmanyPlainRecordingAsyncCursor(PlainRecordingAsyncCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class ContextRecordingAsyncCursor(_AsyncCursorFacade):
+    """A native async context-manager cursor; ``__aenter__`` returns a distinct object."""
+
+    def __init__(self, recorder: CursorRecorder) -> None:
+        super().__init__(recorder)
+        entered_class = (
+            EnteredRecordingAsyncCursor
+            if recorder.script.supports_fetchmany
+            else _NoFetchmanyEnteredRecordingAsyncCursor
+        )
+        self.entered_cursor = entered_class(recorder)
+
+    async def __aenter__(self) -> EnteredRecordingAsyncCursor:
+        self.recorder.do_enter()
+        return self.entered_cursor
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        return self.recorder.do_exit(exc_type, exc_val, exc_tb)
+
+
+class _NoFetchmanyContextRecordingAsyncCursor(ContextRecordingAsyncCursor):
+    fetchmany = None  # type: ignore[assignment]
+
+
+class RecordingConnection:
+    """A sync DBAPI-shaped connection serving instrumented cursors from scripts.
+
+    ``scripts`` supplies one :class:`CursorScript` per acquired cursor; the last
+    script repeats if more cursors are acquired than scripts were given.
+    ``cursor_style`` selects the cursor shape: ``"context"`` (native context manager)
+    or ``"plain"`` (close-only).
+    """
+
+    def __init__(
+        self,
+        scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
+        cursor_style: str = "context",
+    ) -> None:
+        if scripts is None:
+            scripts = CursorScript()
+        if isinstance(scripts, CursorScript):
+            scripts = [scripts]
+        self._scripts = list(scripts)
+        self._cursor_style = cursor_style
+        self.log = RecordingLog()
+        self.cursor_calls = 0
+        self.recorders: List[CursorRecorder] = []
+        self.cursors: List[_SyncCursorFacade] = []
+
+    def cursor(self, *args: Any, **kwargs: Any) -> _SyncCursorFacade:
+        self.cursor_calls += 1
+        self.log.add(RecordedEvent(kind="cursor"))
+        script = self._scripts[min(self.cursor_calls - 1, len(self._scripts) - 1)]
+        recorder = CursorRecorder(script, self.log)
+        self.recorders.append(recorder)
+        cursor: _SyncCursorFacade
+        if self._cursor_style == "plain":
+            plain_class = PlainRecordingCursor if script.supports_fetchmany else _NoFetchmanyPlainRecordingCursor
+            cursor = plain_class(recorder)
+        else:
+            context_class = ContextRecordingCursor if script.supports_fetchmany else _NoFetchmanyContextRecordingCursor
+            cursor = context_class(recorder)
+        self.cursors.append(cursor)
+        return cursor
+
+
+class RecordingAsyncConnection:
+    """An async connection whose ``cursor()`` returns an awaitable (the base contract).
+
+    ``cursor_style`` is ``"context"`` or ``"plain"``; ``close_style`` selects sync vs
+    awaitable ``close()`` for plain cursors.
+    """
+
+    def __init__(
+        self,
+        scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
+        cursor_style: str = "context",
+        close_style: str = "sync",
+    ) -> None:
+        if scripts is None:
+            scripts = CursorScript()
+        if isinstance(scripts, CursorScript):
+            scripts = [scripts]
+        self._scripts = list(scripts)
+        self._cursor_style = cursor_style
+        self._close_style = close_style
+        self.log = RecordingLog()
+        self.cursor_calls = 0
+        self.recorders: List[CursorRecorder] = []
+        self.cursors: List[_AsyncCursorFacade] = []
+
+    def _build_cursor(self) -> _AsyncCursorFacade:
+        self.cursor_calls += 1
+        self.log.add(RecordedEvent(kind="cursor"))
+        script = self._scripts[min(self.cursor_calls - 1, len(self._scripts) - 1)]
+        recorder = CursorRecorder(script, self.log)
+        self.recorders.append(recorder)
+        cursor: _AsyncCursorFacade
+        if self._cursor_style == "plain":
+            plain_class = (
+                PlainRecordingAsyncCursor if script.supports_fetchmany else _NoFetchmanyPlainRecordingAsyncCursor
+            )
+            cursor = plain_class(recorder, close_style=self._close_style)
+        else:
+            context_class = (
+                ContextRecordingAsyncCursor if script.supports_fetchmany else _NoFetchmanyContextRecordingAsyncCursor
+            )
+            cursor = context_class(recorder)
+        self.cursors.append(cursor)
+        return cursor
+
+    async def cursor(self, *args: Any, **kwargs: Any) -> _AsyncCursorFacade:
+        return self._build_cursor()
+
+
+class SynchronousCursorRecordingAsyncConnection(RecordingAsyncConnection):
+    """An async connection whose ``cursor()`` returns the cursor directly.
+
+    This is the psycopg3-async shape: the command class is responsible for
+    normalizing the synchronous cursor factory (by overriding ``cursor()``), and the
+    conformance suite exercises that normalization through the real class.
+    """
+
+    def cursor(self, *args: Any, **kwargs: Any) -> _AsyncCursorFacade:  # type: ignore[override]
+        return self._build_cursor()

--- a/pydapper/testing/adapter_conformance/_profiles.py
+++ b/pydapper/testing/adapter_conformance/_profiles.py
@@ -6,6 +6,11 @@ members; each future capability feature adds its own independent profile here in
 same change that implements the feature. The production catalog is immutable and is
 intentionally empty until the first capability feature lands — an unimplemented
 capability must never appear covered.
+
+Because no capability profile ships yet, the public capability surface here
+(:class:`ConformanceProfile`, :class:`SyncCase`, :class:`AsyncCase`, and
+:func:`capability_profiles`) is **provisional** and may change with the first real
+capability feature. The mandatory core profiles are not provisional.
 """
 
 from dataclasses import dataclass
@@ -40,7 +45,11 @@ CASE_KINDS = ("live", "instrumented")
 
 @dataclass(frozen=True)
 class SyncCase:
-    """One named synchronous conformance case. ``run`` is framework-owned."""
+    """One named synchronous conformance case. ``run`` is framework-owned.
+
+    Provisional alongside :class:`ConformanceProfile` until the first capability
+    profile ships; adapter authors do not write cases today.
+    """
 
     case_id: str
     description: str
@@ -50,7 +59,10 @@ class SyncCase:
 
 @dataclass(frozen=True)
 class AsyncCase:
-    """One named asynchronous conformance case. ``run`` is framework-owned."""
+    """One named asynchronous conformance case. ``run`` is framework-owned.
+
+    Provisional alongside :class:`ConformanceProfile`; see :class:`SyncCase`.
+    """
 
     case_id: str
     description: str
@@ -71,6 +83,10 @@ def _validate_cases(profile_id: str, cases: Tuple[Any, ...], mode: str) -> None:
 @dataclass(frozen=True)
 class ConformanceProfile:
     """A named, per-mode set of conformance cases.
+
+    Provisional: outside the two mandatory core profiles, nothing constructs this yet
+    (the production capability catalog is empty), so its shape may change with the first
+    capability feature.
 
     A profile must contain at least one case; zero-case profiles are rejected so an
     empty profile can never make a capability appear covered. Case identifiers are
@@ -115,9 +131,11 @@ def capability_profiles() -> Mapping[AdapterCapability, ConformanceProfile]:
     """Return the production catalog of optional capability profiles.
 
     The catalog is immutable and currently empty: no optional capability is
-    implemented yet, so no capability profile exists. Future capability features
-    register their profile here in the same change that implements the capability,
-    keyed by the owning :class:`AdapterCapability` member.
+    implemented yet, so no capability profile exists and there is nothing here for an
+    adapter author to act on. Future capability features register their profile here in
+    the same change that implements the capability, keyed by the owning
+    :class:`AdapterCapability` member; until the first one lands this function and the
+    profile/case types it returns are provisional and may change.
     """
     return MappingProxyType({})
 

--- a/pydapper/testing/adapter_conformance/_profiles.py
+++ b/pydapper/testing/adapter_conformance/_profiles.py
@@ -1,0 +1,149 @@
+"""Profile and case definitions plus the production capability-profile catalog.
+
+``core-sync`` and ``core-async`` are the mandatory per-mode profiles. Optional
+capability profiles are keyed to :class:`~pydapper.capabilities.AdapterCapability`
+members; each future capability feature adds its own independent profile here in the
+same change that implements the feature. The production catalog is immutable and is
+intentionally empty until the first capability feature lands — an unimplemented
+capability must never appear covered.
+"""
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+
+from pydapper.capabilities import AdapterCapability
+
+from ._results import ProfileDefinitionError
+
+if TYPE_CHECKING:
+    from ._checks import AsyncCaseContext
+    from ._checks import SyncCaseContext
+
+#: Stable identifier of the mandatory synchronous core profile.
+CORE_SYNC = "core-sync"
+
+#: Stable identifier of the mandatory asynchronous core profile.
+CORE_ASYNC = "core-async"
+
+#: Case kinds: ``"live"`` cases run through the harness's real database resources;
+#: ``"instrumented"`` cases run the real concrete command class around
+#: framework-owned recording/fault-injection connections.
+CASE_KINDS = ("live", "instrumented")
+
+
+@dataclass(frozen=True)
+class SyncCase:
+    """One named synchronous conformance case. ``run`` is framework-owned."""
+
+    case_id: str
+    description: str
+    kind: str
+    run: Callable[["SyncCaseContext"], None]
+
+
+@dataclass(frozen=True)
+class AsyncCase:
+    """One named asynchronous conformance case. ``run`` is framework-owned."""
+
+    case_id: str
+    description: str
+    kind: str
+    run: Callable[["AsyncCaseContext"], Awaitable[None]]
+
+
+def _validate_cases(profile_id: str, cases: Tuple[Any, ...], mode: str) -> None:
+    seen = set()
+    for case in cases:
+        if case.kind not in CASE_KINDS:
+            raise ProfileDefinitionError(profile_id, f"{mode} case {case.case_id!r} has invalid kind {case.kind!r}")
+        if case.case_id in seen:
+            raise ProfileDefinitionError(profile_id, f"duplicate {mode} case id {case.case_id!r}")
+        seen.add(case.case_id)
+
+
+@dataclass(frozen=True)
+class ConformanceProfile:
+    """A named, per-mode set of conformance cases.
+
+    A profile must contain at least one case; zero-case profiles are rejected so an
+    empty profile can never make a capability appear covered. Case identifiers are
+    unique per mode and case order is the deterministic execution and reporting
+    order.
+    """
+
+    profile_id: str
+    capability: Optional[AdapterCapability]
+    sync_cases: Tuple[SyncCase, ...] = ()
+    async_cases: Tuple[AsyncCase, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.profile_id or not isinstance(self.profile_id, str):
+            raise ProfileDefinitionError(str(self.profile_id), "profile_id must be a non-empty string")
+        if self.capability is not None and not isinstance(self.capability, AdapterCapability):
+            raise ProfileDefinitionError(
+                self.profile_id,
+                f"capability must be an AdapterCapability member or None, got {type(self.capability).__name__}",
+            )
+        if not self.sync_cases and not self.async_cases:
+            raise ProfileDefinitionError(self.profile_id, "a conformance profile must define at least one case")
+        _validate_cases(self.profile_id, tuple(self.sync_cases), "sync")
+        _validate_cases(self.profile_id, tuple(self.async_cases), "async")
+
+
+def core_sync_profile() -> ConformanceProfile:
+    """Build the mandatory ``core-sync`` profile with its full case inventory."""
+    from ._cases_sync import sync_core_cases
+
+    return ConformanceProfile(profile_id=CORE_SYNC, capability=None, sync_cases=sync_core_cases())
+
+
+def core_async_profile() -> ConformanceProfile:
+    """Build the mandatory ``core-async`` profile with its full case inventory."""
+    from ._cases_async import async_core_cases
+
+    return ConformanceProfile(profile_id=CORE_ASYNC, capability=None, async_cases=async_core_cases())
+
+
+def capability_profiles() -> Mapping[AdapterCapability, ConformanceProfile]:
+    """Return the production catalog of optional capability profiles.
+
+    The catalog is immutable and currently empty: no optional capability is
+    implemented yet, so no capability profile exists. Future capability features
+    register their profile here in the same change that implements the capability,
+    keyed by the owning :class:`AdapterCapability` member.
+    """
+    return MappingProxyType({})
+
+
+def validate_capability_catalog(catalog: Mapping[AdapterCapability, ConformanceProfile]) -> None:
+    """Validate a capability-profile catalog's structural integrity.
+
+    Keys must be :class:`AdapterCapability` members and each profile must declare the
+    same capability it is keyed under. Zero-case profiles are already impossible by
+    construction.
+    """
+    for capability, profile in catalog.items():
+        if not isinstance(capability, AdapterCapability):
+            raise ProfileDefinitionError(
+                getattr(profile, "profile_id", "<unknown>"),
+                f"capability catalog key must be an AdapterCapability member, got {type(capability).__name__}",
+            )
+        if not isinstance(profile, ConformanceProfile):
+            raise ProfileDefinitionError(
+                "<unknown>",
+                f"capability catalog value for {capability.value!r} must be a ConformanceProfile, "
+                f"got {type(profile).__name__}",
+            )
+        if profile.capability is not capability:
+            raise ProfileDefinitionError(
+                profile.profile_id,
+                f"profile is keyed under capability {capability.value!r} but declares "
+                f"{profile.capability.value if profile.capability else None!r}",
+            )

--- a/pydapper/testing/adapter_conformance/_results.py
+++ b/pydapper/testing/adapter_conformance/_results.py
@@ -1,8 +1,8 @@
 """Structured results and exceptions for adapter conformance runs.
 
 Every failure is identified by structured attributes (profile id, case id, original
-cause, and — for harness validation failures — the missing harness field) so callers
-never need to parse exception prose.
+cause, whether the harness's own setup raised, and — for harness validation failures
+— the missing harness field) so callers never need to parse exception prose.
 """
 
 from dataclasses import dataclass
@@ -41,6 +41,62 @@ class HarnessDefinitionError(ConformanceError):
         super().__init__(detail)
 
 
+class HarnessSetupError(ConformanceError):
+    """The harness's own ``create_commands()`` raised while preparing a case.
+
+    This is a harness failure — a broken connection factory or a broken seeding
+    statement — and not a verdict on the adapter, whose behavior under test never got
+    to run. Raised by the case context around the harness call only, and converted by
+    the runner into a failed :class:`CaseResult` with ``harness_setup_failed=True``
+    whose ``cause`` is the original :attr:`cause` exception, so it never reaches
+    callers itself.
+    """
+
+    def __init__(self, profile_id: str, case_id: str, cause: BaseException) -> None:
+        self.profile_id = profile_id
+        self.case_id = case_id
+        self.cause = cause
+        super().__init__(
+            f"harness setup failed: the harness's own create_commands() raised "
+            f"{type(cause).__name__}: {cause} while preparing conformance case {profile_id!r}/{case_id!r}. "
+            "This is a harness failure (connection factory or dataset seeding), not adapter behavior "
+            "under test; fix the harness before reading anything into this run."
+        )
+
+
+class CaseSelectionError(ConformanceError):
+    """A ``case_ids`` selection does not name a runnable subset of the planned cases.
+
+    Raised before any case runs, so a mistyped id can never be silently reduced to a
+    vacuous "everything selected passed" run. Carries the profile id, the requested
+    ids, and the unknown ids as structured attributes; ``unknown_case_ids`` is empty
+    when the selection itself was empty.
+    """
+
+    def __init__(
+        self,
+        profile_id: str,
+        requested_case_ids: Tuple[str, ...],
+        unknown_case_ids: Tuple[str, ...],
+    ) -> None:
+        self.profile_id = profile_id
+        self.requested_case_ids = requested_case_ids
+        self.unknown_case_ids = unknown_case_ids
+        if unknown_case_ids:
+            detail = (
+                f"case_ids named {len(unknown_case_ids)} case(s) that profile {profile_id!r} does not plan: "
+                f"{', '.join(repr(case_id) for case_id in unknown_case_ids)}. "
+                "List the planned ids with core_sync_profile().sync_cases / core_async_profile().async_cases "
+                "plus any declared-capability profile cases."
+            )
+        else:
+            detail = (
+                f"case_ids selected no conformance cases for profile {profile_id!r}; "
+                "an empty selection is not a conformance run. Pass case_ids=None to run the full profile."
+            )
+        super().__init__(detail)
+
+
 class CaseCheckError(ConformanceError):
     """A conformance assertion made by the framework runner failed.
 
@@ -62,6 +118,13 @@ class CaseResult:
     ``missing_field`` names the absent harness field when harness validation failed.
     ``cleanup_error`` retains a harness teardown failure as structured secondary
     information; it never replaces an active case failure.
+
+    ``harness_setup_failed`` is ``True`` only when the harness's own
+    ``create_commands()`` raised — the connection factory or the dataset seeding
+    broke — so this result says nothing about the adapter's behavior. It is
+    ``repr``-visible on purpose: a printed result must show at a glance that the
+    harness, not the adapter, is what failed. It defaults to ``False``, so every
+    other failure kind keeps its existing shape.
     """
 
     profile_id: str
@@ -71,6 +134,7 @@ class CaseResult:
     cause: Optional[BaseException] = field(default=None, repr=False)
     missing_field: Optional[str] = None
     cleanup_error: Optional[BaseException] = field(default=None, repr=False)
+    harness_setup_failed: bool = False
 
 
 class ConformanceFailureError(ConformanceError):
@@ -88,6 +152,17 @@ class ConformanceFailureError(ConformanceError):
             f"{len(self.failures)} conformance case(s) failed for profile {report.profile_id!r} "
             f"({report.adapter_name!r} / {report.command_class_name})"
         )
+        setup_failures = tuple(failure for failure in self.failures if failure.harness_setup_failed)
+        if setup_failures:
+            summary = (
+                f"{summary} [HARNESS SETUP FAILED: {len(setup_failures)} of {len(self.failures)} failure(s) "
+                f"came from the harness's own create_commands(), not adapter behavior; fix the harness first]"
+            )
+        if not report.covers_full_inventory:
+            summary = (
+                f"{summary} [PARTIAL RUN: a case_ids filter was applied, so this run "
+                f"covered only {len(report.results)} planned case(s) and is not a conformance run]"
+            )
         if first is not None:
             summary = f"{summary}; first failure: {first.case_id!r}: {first.message}"
         super().__init__(summary)
@@ -99,12 +174,22 @@ class ConformanceReport:
 
     ``results`` preserves the declared profile/case order, so pass/fail output is
     stable across runs.
+
+    ``covers_full_inventory`` records completeness: it is ``True`` only when the run
+    executed every planned case (the profile's cases plus any declared-capability
+    profile cases), and ``False`` when a ``case_ids`` filter narrowed the run. It is a
+    separate axis from :attr:`passed` — a filtered run can pass every case it ran and
+    still not be a conformance run — so anything that claims conformance (a CI gate, a
+    published report) must require ``report.passed and report.covers_full_inventory``.
+    It defaults to ``True`` because every report produced without a filter, including
+    every report produced before filtering existed, covered its full inventory.
     """
 
     profile_id: str
     adapter_name: str
     command_class_name: str
     results: Tuple[CaseResult, ...]
+    covers_full_inventory: bool = True
 
     @property
     def passed(self) -> bool:
@@ -113,6 +198,16 @@ class ConformanceReport:
     @property
     def failures(self) -> Tuple[CaseResult, ...]:
         return tuple(result for result in self.results if not result.passed)
+
+    @property
+    def harness_setup_failed(self) -> bool:
+        """``True`` when any case failed inside the harness's own ``create_commands()``.
+
+        One broken harness setup call fails every case that needs a fixture, so a run
+        with this set is not a verdict on the adapter: treat the whole run as suspect
+        and fix the harness first. Callers should not parse messages to discover this.
+        """
+        return any(result.harness_setup_failed for result in self.results)
 
     def raise_for_failures(self) -> None:
         """Raise :class:`ConformanceFailureError` if any case in this run failed."""

--- a/pydapper/testing/adapter_conformance/_results.py
+++ b/pydapper/testing/adapter_conformance/_results.py
@@ -1,0 +1,120 @@
+"""Structured results and exceptions for adapter conformance runs.
+
+Every failure is identified by structured attributes (profile id, case id, original
+cause, and — for harness validation failures — the missing harness field) so callers
+never need to parse exception prose.
+"""
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Optional
+from typing import Tuple
+
+
+class ConformanceError(Exception):
+    """Base class for every error raised by the adapter conformance framework."""
+
+
+class ProfileDefinitionError(ConformanceError):
+    """A conformance profile definition is invalid (zero cases or duplicate case ids)."""
+
+    def __init__(self, profile_id: str, message: str) -> None:
+        self.profile_id = profile_id
+        super().__init__(f"Invalid conformance profile {profile_id!r}: {message}")
+
+
+class HarnessDefinitionError(ConformanceError):
+    """A harness does not supply a field a conformance case requires.
+
+    Carries the profile id, the case id that needed the field, and the missing
+    harness field name as structured attributes.
+    """
+
+    def __init__(self, profile_id: str, case_id: str, missing_field: str, message: Optional[str] = None) -> None:
+        self.profile_id = profile_id
+        self.case_id = case_id
+        self.missing_field = missing_field
+        detail = message or (
+            f"Harness is missing required field {missing_field!r} "
+            f"needed by conformance case {profile_id!r}/{case_id!r}"
+        )
+        super().__init__(detail)
+
+
+class CaseCheckError(ConformanceError):
+    """A conformance assertion made by the framework runner failed.
+
+    Raised internally by case implementations and converted by the runner into a
+    failed :class:`CaseResult`. The optional ``cause`` preserves the adapter-raised
+    exception that triggered the failure, when there is one.
+    """
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None) -> None:
+        self.cause = cause
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """The outcome of one named conformance case in one profile run.
+
+    ``cause`` preserves the original exception behind a failure when one exists, and
+    ``missing_field`` names the absent harness field when harness validation failed.
+    ``cleanup_error`` retains a harness teardown failure as structured secondary
+    information; it never replaces an active case failure.
+    """
+
+    profile_id: str
+    case_id: str
+    passed: bool
+    message: str = ""
+    cause: Optional[BaseException] = field(default=None, repr=False)
+    missing_field: Optional[str] = None
+    cleanup_error: Optional[BaseException] = field(default=None, repr=False)
+
+
+class ConformanceFailureError(ConformanceError):
+    """Raised by :meth:`ConformanceReport.raise_for_failures` when any case failed.
+
+    ``failures`` is the deterministic, profile-ordered tuple of failed case results;
+    ``report`` is the full run report.
+    """
+
+    def __init__(self, report: "ConformanceReport") -> None:
+        self.report = report
+        self.failures: Tuple[CaseResult, ...] = report.failures
+        first = self.failures[0] if self.failures else None
+        summary = (
+            f"{len(self.failures)} conformance case(s) failed for profile {report.profile_id!r} "
+            f"({report.adapter_name!r} / {report.command_class_name})"
+        )
+        if first is not None:
+            summary = f"{summary}; first failure: {first.case_id!r}: {first.message}"
+        super().__init__(summary)
+
+
+@dataclass(frozen=True)
+class ConformanceReport:
+    """A deterministic record of one profile run against one adapter mode.
+
+    ``results`` preserves the declared profile/case order, so pass/fail output is
+    stable across runs.
+    """
+
+    profile_id: str
+    adapter_name: str
+    command_class_name: str
+    results: Tuple[CaseResult, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(result.passed for result in self.results)
+
+    @property
+    def failures(self) -> Tuple[CaseResult, ...]:
+        return tuple(result for result in self.results if not result.passed)
+
+    def raise_for_failures(self) -> None:
+        """Raise :class:`ConformanceFailureError` if any case in this run failed."""
+        if not self.passed:
+            raise ConformanceFailureError(self)

--- a/pydapper/testing/adapter_conformance/_runner.py
+++ b/pydapper/testing/adapter_conformance/_runner.py
@@ -7,9 +7,11 @@ failure. When both a case and its teardown fail, the case failure is preserved a
 the teardown failure is retained as structured secondary information.
 
 ``run_core_async`` is a plain awaitable and never starts an event loop, so it can be
-awaited inside an existing loop.
+awaited inside an existing loop, and task cancellation propagates promptly after the
+active case's resources are released.
 """
 
+import asyncio
 from typing import Callable
 from typing import List
 from typing import Mapping
@@ -85,9 +87,11 @@ def run_core_sync(
 
     Returns a :class:`ConformanceReport` whose results follow the declared case
     order; call :meth:`ConformanceReport.raise_for_failures` for exception-style
-    reporting. ``capability_catalog`` defaults to the production catalog and exists
-    so future capability features (and the framework's own tests) can extend the
-    run; it never weakens core cases.
+    reporting. ``capability_catalog`` defaults to the production catalog and only
+    selects which capability profiles *additionally run*; the capability-honesty
+    core cases always consult the production :func:`capability_profiles` catalog,
+    so an injected catalog cannot make an unimplemented capability appear covered
+    or weaken any core case.
     """
     if not isinstance(harness, SyncAdapterHarness):
         raise TypeError(
@@ -105,7 +109,13 @@ def run_core_sync(
     results: List[CaseResult] = []
     for case_profile_id, case in planned:
         ctx = SyncCaseContext(harness, case_profile_id, case.case_id, catalog)
-        result = _run_sync_case(ctx, case)
+        try:
+            result = _run_sync_case(ctx, case)
+        except BaseException:
+            # cancellation/shutdown propagates, but the case's live resources are
+            # still released first
+            _teardown_sync(harness, ctx)
+            raise
         cleanup_error = _teardown_sync(harness, ctx)
         results.append(_merge_cleanup(result, cleanup_error))
 
@@ -143,7 +153,13 @@ async def run_core_async(
     results: List[CaseResult] = []
     for case_profile_id, case in planned:
         ctx = AsyncCaseContext(harness, case_profile_id, case.case_id, catalog)
-        result = await _run_async_case(ctx, case)
+        try:
+            result = await _run_async_case(ctx, case)
+        except BaseException:
+            # cancellation/shutdown propagates, but the case's live resources are
+            # still released first
+            await _teardown_async(harness, ctx)
+            raise
         cleanup_error = await _teardown_async(harness, ctx)
         results.append(_merge_cleanup(result, cleanup_error))
 
@@ -153,6 +169,11 @@ async def run_core_async(
         command_class_name=command_class_name,
         results=tuple(results),
     )
+
+
+#: Exceptions the runner must never convert into case failures: cancellation and
+#: interpreter shutdown propagate after per-case teardown has run.
+_PROPAGATED = (KeyboardInterrupt, SystemExit, asyncio.CancelledError)
 
 
 def _run_sync_case(ctx: SyncCaseContext, case: SyncCase) -> CaseResult:
@@ -178,6 +199,8 @@ def _execute_case(ctx: SyncCaseContext, run: Callable[[], None]) -> CaseResult:
 def _failure_from_error(ctx: object, error: BaseException) -> CaseResult:
     profile_id = getattr(ctx, "profile_id", "<unknown>")
     case_id = getattr(ctx, "case_id", "<unknown>")
+    if isinstance(error, _PROPAGATED):
+        raise error
     if isinstance(error, HarnessDefinitionError):
         return CaseResult(
             profile_id=profile_id,
@@ -195,8 +218,6 @@ def _failure_from_error(ctx: object, error: BaseException) -> CaseResult:
             message=str(error),
             cause=error.cause if error.cause is not None else error,
         )
-    if isinstance(error, (KeyboardInterrupt, SystemExit)):
-        raise error
     return CaseResult(
         profile_id=profile_id,
         case_id=case_id,
@@ -238,6 +259,7 @@ def _merge_cleanup(result: CaseResult, cleanup_error: Optional[BaseException]) -
             passed=False,
             message=f"harness teardown failed after a passing case: {cleanup_error}",
             cause=cleanup_error,
+            cleanup_error=cleanup_error,
         )
     return CaseResult(
         profile_id=result.profile_id,

--- a/pydapper/testing/adapter_conformance/_runner.py
+++ b/pydapper/testing/adapter_conformance/_runner.py
@@ -1,0 +1,250 @@
+"""The synchronous and asynchronous core conformance runners.
+
+The runner owns every behavioral assertion and every result: cases pass only when
+the framework's own checks pass, results are reported in the deterministic declared
+order, per-case resources are isolated, and harness teardown runs after success and
+failure. When both a case and its teardown fail, the case failure is preserved and
+the teardown failure is retained as structured secondary information.
+
+``run_core_async`` is a plain awaitable and never starts an event loop, so it can be
+awaited inside an existing loop.
+"""
+
+from typing import Callable
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+
+from pydapper.capabilities import AdapterCapability
+
+from ._checks import AsyncCaseContext
+from ._checks import SyncCaseContext
+from ._harness import AsyncAdapterHarness
+from ._harness import SyncAdapterHarness
+from ._profiles import AsyncCase
+from ._profiles import ConformanceProfile
+from ._profiles import SyncCase
+from ._profiles import capability_profiles
+from ._profiles import core_async_profile
+from ._profiles import core_sync_profile
+from ._profiles import validate_capability_catalog
+from ._results import CaseCheckError
+from ._results import CaseResult
+from ._results import ConformanceReport
+from ._results import HarnessDefinitionError
+
+_HARNESS_CASE_ID = "<harness-validation>"
+
+
+def _require_harness_identity(harness: object, profile_id: str) -> Tuple[str, str]:
+    adapter_name = getattr(harness, "adapter_name", None)
+    if not isinstance(adapter_name, str) or not adapter_name:
+        raise HarnessDefinitionError(profile_id, _HARNESS_CASE_ID, "adapter_name")
+    command_class = getattr(harness, "command_class", None)
+    if not isinstance(command_class, type):
+        raise HarnessDefinitionError(profile_id, _HARNESS_CASE_ID, "command_class")
+    return adapter_name, f"{command_class.__module__}.{command_class.__qualname__}"
+
+
+def _declared_capability_cases(
+    harness: object,
+    catalog: Mapping[AdapterCapability, ConformanceProfile],
+    mode: str,
+) -> List[Tuple[str, object]]:
+    """Collect (profile_id, case) pairs for every declared capability with a profile.
+
+    A declared capability *without* a populated profile is reported by the core
+    ``capabilities.declared-profile-populated`` case; here we only run the profiles
+    that exist. Order is deterministic: enum definition order, then declared case
+    order.
+    """
+    command_class = getattr(harness, "command_class", None)
+    declared: object = getattr(command_class, "capabilities", frozenset())
+    if not isinstance(declared, frozenset):
+        return []
+    pairs: List[Tuple[str, object]] = []
+    for member in AdapterCapability:
+        if member not in declared:
+            continue
+        profile = catalog.get(member)
+        if profile is None:
+            continue
+        cases = profile.sync_cases if mode == "sync" else profile.async_cases
+        for case in cases:
+            pairs.append((profile.profile_id, case))
+    return pairs
+
+
+def run_core_sync(
+    harness: SyncAdapterHarness,
+    *,
+    capability_catalog: Optional[Mapping[AdapterCapability, ConformanceProfile]] = None,
+) -> ConformanceReport:
+    """Run the mandatory ``core-sync`` profile against one sync adapter harness.
+
+    Returns a :class:`ConformanceReport` whose results follow the declared case
+    order; call :meth:`ConformanceReport.raise_for_failures` for exception-style
+    reporting. ``capability_catalog`` defaults to the production catalog and exists
+    so future capability features (and the framework's own tests) can extend the
+    run; it never weakens core cases.
+    """
+    if not isinstance(harness, SyncAdapterHarness):
+        raise TypeError(
+            f"run_core_sync requires a SyncAdapterHarness; got {type(harness).__name__}. "
+            "Async adapters run through run_core_async with an AsyncAdapterHarness."
+        )
+    profile = core_sync_profile()
+    catalog = capability_profiles() if capability_catalog is None else capability_catalog
+    validate_capability_catalog(catalog)
+    adapter_name, command_class_name = _require_harness_identity(harness, profile.profile_id)
+
+    planned: List[Tuple[str, SyncCase]] = [(profile.profile_id, case) for case in profile.sync_cases]
+    planned.extend(_declared_capability_cases(harness, catalog, "sync"))  # type: ignore[arg-type]
+
+    results: List[CaseResult] = []
+    for case_profile_id, case in planned:
+        ctx = SyncCaseContext(harness, case_profile_id, case.case_id, catalog)
+        result = _run_sync_case(ctx, case)
+        cleanup_error = _teardown_sync(harness, ctx)
+        results.append(_merge_cleanup(result, cleanup_error))
+
+    return ConformanceReport(
+        profile_id=profile.profile_id,
+        adapter_name=adapter_name,
+        command_class_name=command_class_name,
+        results=tuple(results),
+    )
+
+
+async def run_core_async(
+    harness: AsyncAdapterHarness,
+    *,
+    capability_catalog: Optional[Mapping[AdapterCapability, ConformanceProfile]] = None,
+) -> ConformanceReport:
+    """Run the mandatory ``core-async`` profile against one async adapter harness.
+
+    This coroutine is awaited inside the caller's existing event loop; the framework
+    never calls ``asyncio.run()``. Semantics otherwise match :func:`run_core_sync`.
+    """
+    if not isinstance(harness, AsyncAdapterHarness):
+        raise TypeError(
+            f"run_core_async requires an AsyncAdapterHarness; got {type(harness).__name__}. "
+            "Sync adapters run through run_core_sync with a SyncAdapterHarness."
+        )
+    profile = core_async_profile()
+    catalog = capability_profiles() if capability_catalog is None else capability_catalog
+    validate_capability_catalog(catalog)
+    adapter_name, command_class_name = _require_harness_identity(harness, profile.profile_id)
+
+    planned: List[Tuple[str, AsyncCase]] = [(profile.profile_id, case) for case in profile.async_cases]
+    planned.extend(_declared_capability_cases(harness, catalog, "async"))  # type: ignore[arg-type]
+
+    results: List[CaseResult] = []
+    for case_profile_id, case in planned:
+        ctx = AsyncCaseContext(harness, case_profile_id, case.case_id, catalog)
+        result = await _run_async_case(ctx, case)
+        cleanup_error = await _teardown_async(harness, ctx)
+        results.append(_merge_cleanup(result, cleanup_error))
+
+    return ConformanceReport(
+        profile_id=profile.profile_id,
+        adapter_name=adapter_name,
+        command_class_name=command_class_name,
+        results=tuple(results),
+    )
+
+
+def _run_sync_case(ctx: SyncCaseContext, case: SyncCase) -> CaseResult:
+    return _execute_case(ctx, lambda: case.run(ctx))
+
+
+async def _run_async_case(ctx: AsyncCaseContext, case: AsyncCase) -> CaseResult:
+    try:
+        await case.run(ctx)
+    except BaseException as error:  # noqa: BLE001 - converted to structured results below
+        return _failure_from_error(ctx, error)
+    return CaseResult(profile_id=ctx.profile_id, case_id=ctx.case_id, passed=True)
+
+
+def _execute_case(ctx: SyncCaseContext, run: Callable[[], None]) -> CaseResult:
+    try:
+        run()
+    except BaseException as error:  # noqa: BLE001 - converted to structured results below
+        return _failure_from_error(ctx, error)
+    return CaseResult(profile_id=ctx.profile_id, case_id=ctx.case_id, passed=True)
+
+
+def _failure_from_error(ctx: object, error: BaseException) -> CaseResult:
+    profile_id = getattr(ctx, "profile_id", "<unknown>")
+    case_id = getattr(ctx, "case_id", "<unknown>")
+    if isinstance(error, HarnessDefinitionError):
+        return CaseResult(
+            profile_id=profile_id,
+            case_id=case_id,
+            passed=False,
+            message=str(error),
+            cause=error,
+            missing_field=error.missing_field,
+        )
+    if isinstance(error, CaseCheckError):
+        return CaseResult(
+            profile_id=profile_id,
+            case_id=case_id,
+            passed=False,
+            message=str(error),
+            cause=error.cause if error.cause is not None else error,
+        )
+    if isinstance(error, (KeyboardInterrupt, SystemExit)):
+        raise error
+    return CaseResult(
+        profile_id=profile_id,
+        case_id=case_id,
+        passed=False,
+        message=f"unexpected {type(error).__name__}: {error}",
+        cause=error,
+    )
+
+
+def _teardown_sync(harness: SyncAdapterHarness, ctx: SyncCaseContext) -> Optional[BaseException]:
+    first_error: Optional[BaseException] = None
+    for commands in ctx.created_commands:
+        try:
+            harness.teardown_commands(commands)
+        except Exception as error:  # noqa: BLE001 - retained as structured cleanup info
+            if first_error is None:
+                first_error = error
+    return first_error
+
+
+async def _teardown_async(harness: AsyncAdapterHarness, ctx: AsyncCaseContext) -> Optional[BaseException]:
+    first_error: Optional[BaseException] = None
+    for commands in ctx.created_commands:
+        try:
+            await harness.teardown_commands(commands)
+        except Exception as error:  # noqa: BLE001 - retained as structured cleanup info
+            if first_error is None:
+                first_error = error
+    return first_error
+
+
+def _merge_cleanup(result: CaseResult, cleanup_error: Optional[BaseException]) -> CaseResult:
+    if cleanup_error is None:
+        return result
+    if result.passed:
+        return CaseResult(
+            profile_id=result.profile_id,
+            case_id=result.case_id,
+            passed=False,
+            message=f"harness teardown failed after a passing case: {cleanup_error}",
+            cause=cleanup_error,
+        )
+    return CaseResult(
+        profile_id=result.profile_id,
+        case_id=result.case_id,
+        passed=False,
+        message=result.message,
+        cause=result.cause,
+        missing_field=result.missing_field,
+        cleanup_error=cleanup_error,
+    )

--- a/pydapper/testing/adapter_conformance/_runner.py
+++ b/pydapper/testing/adapter_conformance/_runner.py
@@ -6,6 +6,16 @@ order, per-case resources are isolated, and harness teardown runs after success 
 failure. When both a case and its teardown fail, the case failure is preserved and
 the teardown failure is retained as structured secondary information.
 
+Failures are attributed to whoever caused them: a failure inside the harness's own
+``create_commands()`` is reported as a harness setup failure
+(``CaseResult.harness_setup_failed``), never as adapter misbehavior, so one broken
+seeding call cannot masquerade as dozens of behavioral failures.
+
+Both runners accept an optional ``case_ids`` filter for debugging one case against a
+slow backend. Filtering is applied to the planned case list after planning and never
+weakens reporting: unknown or empty selections raise before anything runs, and a
+filtered report carries ``covers_full_inventory=False``.
+
 ``run_core_async`` is a plain awaitable and never starts an event loop, so it can be
 awaited inside an existing loop, and task cancellation propagates promptly after the
 active case's resources are released.
@@ -13,10 +23,12 @@ active case's resources are released.
 
 import asyncio
 from typing import Callable
+from typing import Collection
 from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Tuple
+from typing import TypeVar
 
 from pydapper.capabilities import AdapterCapability
 
@@ -33,10 +45,14 @@ from ._profiles import core_sync_profile
 from ._profiles import validate_capability_catalog
 from ._results import CaseCheckError
 from ._results import CaseResult
+from ._results import CaseSelectionError
 from ._results import ConformanceReport
 from ._results import HarnessDefinitionError
+from ._results import HarnessSetupError
 
 _HARNESS_CASE_ID = "<harness-validation>"
+
+_CaseT = TypeVar("_CaseT", SyncCase, AsyncCase)
 
 
 def _require_harness_identity(harness: object, profile_id: str) -> Tuple[str, str]:
@@ -78,10 +94,43 @@ def _declared_capability_cases(
     return pairs
 
 
+def _select_cases(
+    profile_id: str,
+    planned: List[Tuple[str, _CaseT]],
+    case_ids: Optional[Collection[str]],
+) -> Tuple[List[Tuple[str, _CaseT]], bool]:
+    """Narrow ``planned`` to ``case_ids``, returning the cases to run and completeness.
+
+    ``case_ids`` is a debugging aid, not a conformance option: it is applied to the
+    already-planned list (core profile cases plus declared-capability profile cases),
+    so an id from either source selects. Every requested id must be planned and the
+    selection must be non-empty — both failures raise :class:`CaseSelectionError`
+    before any case runs, so a typo can never masquerade as a passing run. The second
+    return value is ``True`` only when the run covers the full planned inventory.
+    """
+    if case_ids is None:
+        return planned, True
+    if isinstance(case_ids, str):
+        raise TypeError(
+            f"case_ids must be a collection of case ids, not a single string; pass e.g. case_ids=[{case_ids!r}]."
+        )
+    requested = tuple(dict.fromkeys(case_ids))
+    if not requested:
+        raise CaseSelectionError(profile_id, requested, ())
+    known = {case.case_id for _, case in planned}
+    unknown = tuple(case_id for case_id in requested if case_id not in known)
+    if unknown:
+        raise CaseSelectionError(profile_id, requested, unknown)
+    wanted = set(requested)
+    selected = [(case_profile_id, case) for case_profile_id, case in planned if case.case_id in wanted]
+    return selected, len(selected) == len(planned)
+
+
 def run_core_sync(
     harness: SyncAdapterHarness,
     *,
     capability_catalog: Optional[Mapping[AdapterCapability, ConformanceProfile]] = None,
+    case_ids: Optional[Collection[str]] = None,
 ) -> ConformanceReport:
     """Run the mandatory ``core-sync`` profile against one sync adapter harness.
 
@@ -92,6 +141,14 @@ def run_core_sync(
     core cases always consult the production :func:`capability_profiles` catalog,
     so an injected catalog cannot make an unimplemented capability appear covered
     or weaken any core case.
+
+    ``case_ids`` narrows the run to the named cases and exists only to shorten the
+    debug loop against slow backends; it defaults to ``None``, which runs the full
+    planned inventory exactly as before. Ids from the core profile and from any
+    declared-capability profile both select. Unknown ids and empty selections raise
+    :class:`CaseSelectionError` before any case runs, and a filtered run's report
+    reports ``covers_full_inventory=False``, so a subset run can never be presented
+    as conformance.
     """
     if not isinstance(harness, SyncAdapterHarness):
         raise TypeError(
@@ -105,9 +162,10 @@ def run_core_sync(
 
     planned: List[Tuple[str, SyncCase]] = [(profile.profile_id, case) for case in profile.sync_cases]
     planned.extend(_declared_capability_cases(harness, catalog, "sync"))  # type: ignore[arg-type]
+    selected, covers_full_inventory = _select_cases(profile.profile_id, planned, case_ids)
 
     results: List[CaseResult] = []
-    for case_profile_id, case in planned:
+    for case_profile_id, case in selected:
         ctx = SyncCaseContext(harness, case_profile_id, case.case_id, catalog)
         try:
             result = _run_sync_case(ctx, case)
@@ -124,6 +182,7 @@ def run_core_sync(
         adapter_name=adapter_name,
         command_class_name=command_class_name,
         results=tuple(results),
+        covers_full_inventory=covers_full_inventory,
     )
 
 
@@ -131,11 +190,13 @@ async def run_core_async(
     harness: AsyncAdapterHarness,
     *,
     capability_catalog: Optional[Mapping[AdapterCapability, ConformanceProfile]] = None,
+    case_ids: Optional[Collection[str]] = None,
 ) -> ConformanceReport:
     """Run the mandatory ``core-async`` profile against one async adapter harness.
 
     This coroutine is awaited inside the caller's existing event loop; the framework
-    never calls ``asyncio.run()``. Semantics otherwise match :func:`run_core_sync`.
+    never calls ``asyncio.run()``. Semantics — including ``case_ids`` filtering and
+    ``ConformanceReport.covers_full_inventory`` — otherwise match :func:`run_core_sync`.
     """
     if not isinstance(harness, AsyncAdapterHarness):
         raise TypeError(
@@ -149,9 +210,10 @@ async def run_core_async(
 
     planned: List[Tuple[str, AsyncCase]] = [(profile.profile_id, case) for case in profile.async_cases]
     planned.extend(_declared_capability_cases(harness, catalog, "async"))  # type: ignore[arg-type]
+    selected, covers_full_inventory = _select_cases(profile.profile_id, planned, case_ids)
 
     results: List[CaseResult] = []
-    for case_profile_id, case in planned:
+    for case_profile_id, case in selected:
         ctx = AsyncCaseContext(harness, case_profile_id, case.case_id, catalog)
         try:
             result = await _run_async_case(ctx, case)
@@ -168,6 +230,7 @@ async def run_core_async(
         adapter_name=adapter_name,
         command_class_name=command_class_name,
         results=tuple(results),
+        covers_full_inventory=covers_full_inventory,
     )
 
 
@@ -209,6 +272,17 @@ def _failure_from_error(ctx: object, error: BaseException) -> CaseResult:
             message=str(error),
             cause=error,
             missing_field=error.missing_field,
+        )
+    if isinstance(error, HarnessSetupError):
+        # the harness's own create_commands() broke: report the harness, not the adapter,
+        # while preserving the original exception as the cause
+        return CaseResult(
+            profile_id=profile_id,
+            case_id=case_id,
+            passed=False,
+            message=str(error),
+            cause=error.cause,
+            harness_setup_failed=True,
         )
     if isinstance(error, CaseCheckError):
         return CaseResult(
@@ -269,4 +343,5 @@ def _merge_cleanup(result: CaseResult, cleanup_error: Optional[BaseException]) -
         cause=result.cause,
         missing_field=result.missing_field,
         cleanup_error=cleanup_error,
+        harness_setup_failed=result.harness_setup_failed,
     )

--- a/pydapper/testing/adapter_conformance/_sqlspec.py
+++ b/pydapper/testing/adapter_conformance/_sqlspec.py
@@ -1,0 +1,97 @@
+"""The canonical conformance dataset and framework-owned SQL statement catalog.
+
+The framework owns every query and DML statement so behavioral assertions never
+depend on harness-authored SQL. Statements use pydapper's portable ``?name?``
+placeholder syntax, so they run unchanged on every adapter; the harness owns only
+dialect-specific concerns: creating and seeding the dataset, the (optionally
+qualified) table name, identifier case, and narrow documented overrides through
+``sql_overrides``.
+"""
+
+from types import MappingProxyType
+from typing import Any
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+
+#: Column names of the canonical conformance table, in declaration order.
+CONFORMANCE_COLUMNS: Tuple[str, ...] = ("id", "label", "score", "note")
+
+#: The label value substituted for the empty string when a harness declares
+#: ``supports_empty_strings = False`` (for example Oracle, which stores ``''`` as NULL).
+FALLBACK_EMPTY_LABEL = "blank"
+
+#: Canonical rows the harness must seed per case, as (id, label, score, note).
+#: Row 2 exercises falsey values (empty label where supported, score 0); row 1
+#: carries a SQL NULL note for the scalar NULL case.
+CONFORMANCE_ROWS: Tuple[Tuple[Any, ...], ...] = (
+    (1, "alpha", 10, None),
+    (2, "", 0, "noted"),
+    (3, "gamma", 10, "third"),
+)
+
+_STATEMENTS: Mapping[str, str] = MappingProxyType(
+    {
+        "select_literal": "SELECT 1",
+        "select_all": "SELECT id, label, score, note FROM {table} ORDER BY id",
+        "select_by_id": "SELECT id, label, score, note FROM {table} WHERE id = ?id?",
+        "select_two": "SELECT id, label, score, note FROM {table} WHERE score = ?score? ORDER BY id",
+        "select_id_label": "SELECT id, label FROM {table} WHERE id = ?id?",
+        "select_duplicate_columns": "SELECT id, id FROM {table} WHERE id = ?id?",
+        "select_repeated_placeholder": ("SELECT id, label, score, note FROM {table} WHERE id = ?id? AND ?id? = id"),
+        "scalar_label": "SELECT label FROM {table} WHERE id = ?id?",
+        "scalar_score": "SELECT score FROM {table} WHERE id = ?id?",
+        "scalar_note": "SELECT note FROM {table} WHERE id = ?id?",
+        "insert_row": "INSERT INTO {table} (id, label, score, note) VALUES (?id?, ?label?, ?score?, ?note?)",
+        "update_label": "UPDATE {table} SET label = ?label? WHERE id = ?id?",
+    }
+)
+
+
+def statement_ids() -> Tuple[str, ...]:
+    """Return the stable identifiers of every framework-owned statement."""
+    return tuple(sorted(_STATEMENTS))
+
+
+def render_statement(
+    statement_id: str,
+    table_name: str,
+    sql_overrides: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Render one framework statement for a harness's table, honoring overrides.
+
+    ``sql_overrides`` maps statement ids to replacement SQL (still using pydapper
+    ``?name?`` placeholders and the ``{table}`` slot) for the narrow, documented
+    situations where portable SQL is insufficient for a dialect.
+    """
+    if sql_overrides and statement_id in sql_overrides:
+        template = sql_overrides[statement_id]
+    else:
+        try:
+            template = _STATEMENTS[statement_id]
+        except KeyError:
+            raise KeyError(f"Unknown conformance statement id {statement_id!r}") from None
+    return template.format(table=table_name)
+
+
+def expected_column(name: str, column_case: str) -> str:
+    """Map a canonical (lowercase) column name to the case the adapter reports."""
+    return name.upper() if column_case == "upper" else name
+
+
+def expected_row_dict(row: Tuple[Any, ...], column_case: str) -> Mapping[str, Any]:
+    """Build the expected dict projection of one canonical row."""
+    return {expected_column(name, column_case): value for name, value in zip(CONFORMANCE_COLUMNS, row)}
+
+
+def seed_rows(supports_empty_strings: bool) -> Tuple[Tuple[Any, ...], ...]:
+    """Return the canonical rows a harness must seed, honoring the empty-string knob."""
+    if supports_empty_strings:
+        return CONFORMANCE_ROWS
+    adjusted = []
+    for row in CONFORMANCE_ROWS:
+        values = list(row)
+        if values[1] == "":
+            values[1] = FALLBACK_EMPTY_LABEL
+        adjusted.append(tuple(values))
+    return tuple(adjusted)

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -315,7 +315,7 @@ class Sqlite3ConformanceHarness(SyncAdapterHarness):
         commands.connection.close()
 
 
-_SEED_INSERT = "INSERT INTO {table} (id, label, score, note) VALUES (?id?, ?label?, ?score?, ?note?)"
+SEED_INSERT = "INSERT INTO {table} (id, label, score, note) VALUES (?id?, ?label?, ?score?, ?note?)"
 
 
 def seed_records(supports_empty_strings: bool = True) -> List[Dict[str, Any]]:
@@ -324,14 +324,14 @@ def seed_records(supports_empty_strings: bool = True) -> List[Dict[str, Any]]:
 
 def seed_through_adapter(commands: Commands, table_name: str, supports_empty_strings: bool = True) -> None:
     """Seed the canonical dataset through the adapter's own execute path."""
-    commands.execute(_SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
+    commands.execute(SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
 
 
 async def seed_through_adapter_async(
     commands: CommandsAsync, table_name: str, supports_empty_strings: bool = True
 ) -> None:
     """Async twin of :func:`seed_through_adapter`."""
-    await commands.execute_async(_SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
+    await commands.execute_async(SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
 
 
 @dataclass(frozen=True)

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -344,13 +344,22 @@ class FirstPartyConformanceEntry:
     test_module: str
 
 
+def _build_entries(*entries: FirstPartyConformanceEntry) -> Dict[Tuple[str, str], FirstPartyConformanceEntry]:
+    built: Dict[Tuple[str, str], FirstPartyConformanceEntry] = {}
+    for entry in entries:
+        key = (entry.adapter_name, entry.mode)
+        if key in built:
+            raise ValueError(f"duplicate first-party conformance entry {key!r}")
+        built[key] = entry
+    return built
+
+
 #: Single source of truth for first-party conformance adoption, keyed by
 #: (adapter entry-point name, mode). The drift test derives the expected contents
 #: from the installed ``pydapper.adapters`` entry points, so additions or removals
 #: of first-party adapters fail loudly here instead of going silently untested.
-FIRST_PARTY_CONFORMANCE_ENTRIES: Dict[Tuple[str, str], FirstPartyConformanceEntry] = {
-    (entry.adapter_name, entry.mode): entry
-    for entry in (
+FIRST_PARTY_CONFORMANCE_ENTRIES: Dict[Tuple[str, str], FirstPartyConformanceEntry] = _build_entries(
+    *(
         FirstPartyConformanceEntry("sqlite3", "sync", Sqlite3Commands, "tests/test_sqlite/test_conformance.py"),
         FirstPartyConformanceEntry("psycopg2", "sync", Psycopg2Commands, "tests/test_postgresql/test_conformance.py"),
         FirstPartyConformanceEntry("psycopg", "sync", Psycopg3Commands, "tests/test_postgresql/test_conformance.py"),
@@ -367,4 +376,4 @@ FIRST_PARTY_CONFORMANCE_ENTRIES: Dict[Tuple[str, str], FirstPartyConformanceEntr
             "google", "sync", GoogleBigqueryClientCommands, "tests/test_bigquery/test_conformance.py"
         ),
     )
-}
+)

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -1,0 +1,370 @@
+"""Shared repository-test support for the adapter conformance suite.
+
+This module is test infrastructure, not part of the shipped helper. It provides:
+
+* a pure-Python in-memory fake DBAPI (no sqlite3, no drivers) plus mock sync/async
+  command classes, so framework failures are visible with no database at all;
+* a real in-memory SQLite harness factory for live ``core-sync`` coverage; and
+* :data:`FIRST_PARTY_CONFORMANCE_ENTRIES` — the single source of truth mapping every
+  installed first-party adapter mode to its concrete command class and the backend
+  test module holding its live conformance entry. The drift test in
+  ``tests/test_adapter_conformance.py`` checks this registry against the installed
+  ``pydapper.adapters`` entry points, so no second manually maintained list can
+  silently go stale.
+"""
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Type
+from typing import Union
+
+from pydapper.bigquery import GoogleBigqueryClientCommands
+from pydapper.commands import BaseSqlParamHandler
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+from pydapper.mssql import PymssqlCommands
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.oracle import OracledbCommands
+from pydapper.postgresql import AiopgCommands
+from pydapper.postgresql import Psycopg2Commands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.sqlite import Sqlite3Commands
+from pydapper.testing.adapter_conformance import CONFORMANCE_COLUMNS
+from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import seed_rows
+
+MOCK_SYNC_ADAPTER_NAME = "conformance-mock-sync"
+MOCK_ASYNC_ADAPTER_NAME = "conformance-mock-async"
+
+_COLUMNS = ("id", "label", "score", "note")
+
+_SELECT_RE = re.compile(r"^SELECT (?P<cols>.+?) FROM (?P<table>\S+)(?: WHERE (?P<where>.+?))?(?P<order> ORDER BY id)?$")
+_INSERT_RE = re.compile(r"^INSERT INTO (?P<table>\S+) \((?P<cols>[^)]+)\) VALUES \((?P<vals>.+)\)$")
+_UPDATE_RE = re.compile(r"^UPDATE (?P<table>\S+) SET label = %s WHERE id = %s$")
+
+
+class MiniDbError(Exception):
+    """Raised by the fake driver for SQL it does not model."""
+
+
+class MiniDb:
+    """A tiny pure-Python store understanding the conformance statement shapes."""
+
+    def __init__(self, rows: Sequence[Tuple[Any, ...]] = ()) -> None:
+        self.rows: List[Dict[str, Any]] = [dict(zip(_COLUMNS, row)) for row in rows]
+
+    def _eval_where(self, where: Optional[str], row: Dict[str, Any], params: Sequence[Any]) -> bool:
+        if where is None:
+            return True
+        if where == "id = %s":
+            return row["id"] == params[0]
+        if where == "score = %s":
+            return row["score"] == params[0]
+        if where == "id = %s AND %s = id":
+            return row["id"] == params[0] and params[1] == row["id"]
+        raise MiniDbError(f"unsupported WHERE clause: {where!r}")
+
+    def select(self, sql: str, params: Sequence[Any]) -> Tuple[Tuple[str, ...], List[Tuple[Any, ...]]]:
+        if sql == "SELECT 1":
+            return ("1",), [(1,)]
+        match = _SELECT_RE.match(sql)
+        if match is None:
+            raise MiniDbError(f"unsupported SELECT: {sql!r}")
+        columns = tuple(part.strip() for part in match.group("cols").split(","))
+        matched = [row for row in self.rows if self._eval_where(match.group("where"), row, params)]
+        if match.group("order"):
+            matched.sort(key=lambda row: row["id"])
+        return columns, [tuple(row[column] for column in columns) for row in matched]
+
+    def insert(self, sql: str, params: Sequence[Any]) -> int:
+        match = _INSERT_RE.match(sql)
+        if match is None:
+            raise MiniDbError(f"unsupported INSERT: {sql!r}")
+        columns = tuple(part.strip() for part in match.group("cols").split(","))
+        self.rows.append(dict(zip(columns, params)))
+        return 1
+
+    def update(self, sql: str, params: Sequence[Any]) -> int:
+        if _UPDATE_RE.match(sql) is None:
+            raise MiniDbError(f"unsupported UPDATE: {sql!r}")
+        label, row_id = params
+        matched = [row for row in self.rows if row["id"] == row_id]
+        for row in matched:
+            row["label"] = label
+        return len(matched)
+
+
+class FakeSyncCursor:
+    """A plain (close-only) sync cursor over :class:`MiniDb`."""
+
+    def __init__(self, db: MiniDb) -> None:
+        self._db = db
+        self._results: List[Tuple[Any, ...]] = []
+        self._columns: Tuple[str, ...] = ()
+        self.rowcount = -1
+        self.closed = False
+
+    @property
+    def description(self) -> Tuple[Tuple[Any, ...], ...]:
+        return tuple((name, None, None, None, None, None, None) for name in self._columns)
+
+    def _run(self, sql: str, params: Sequence[Any]) -> None:
+        statement = sql.strip()
+        if statement.upper().startswith("SELECT"):
+            self._columns, self._results = self._db.select(statement, params)
+            self.rowcount = -1
+        elif statement.upper().startswith("INSERT"):
+            self.rowcount = self._db.insert(statement, params)
+            self._results = []
+        elif statement.upper().startswith("UPDATE"):
+            self.rowcount = self._db.update(statement, params)
+            self._results = []
+        else:
+            raise MiniDbError(f"unsupported statement: {statement!r}")
+
+    def execute(self, sql: str, parameters: Optional[Sequence[Any]] = None) -> None:
+        self._run(sql, tuple(parameters or ()))
+
+    def executemany(self, sql: str, seq_of_parameters: Optional[Sequence[Sequence[Any]]] = None) -> None:
+        total = 0
+        for parameters in seq_of_parameters or []:
+            self._run(sql, tuple(parameters))
+            total += max(self.rowcount, 0)
+        self.rowcount = total
+
+    def fetchone(self) -> Optional[Tuple[Any, ...]]:
+        if not self._results:
+            return None
+        return self._results.pop(0)
+
+    def fetchall(self) -> List[Tuple[Any, ...]]:
+        results = self._results
+        self._results = []
+        return results
+
+    def fetchmany(self, size: int = 1) -> List[Tuple[Any, ...]]:
+        results = self._results[:size]
+        del self._results[:size]
+        return results
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSyncConnection:
+    """A minimal sync DBAPI connection over :class:`MiniDb`."""
+
+    def __init__(self, db: Optional[MiniDb] = None) -> None:
+        self.db = db if db is not None else MiniDb()
+        self.closed = False
+
+    def cursor(self, *args: Any, **kwargs: Any) -> FakeSyncCursor:
+        return FakeSyncCursor(self.db)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeAsyncCursor:
+    """A plain async cursor (awaitable methods, synchronous ``close``) over :class:`MiniDb`."""
+
+    def __init__(self, db: MiniDb) -> None:
+        self._inner = FakeSyncCursor(db)
+
+    @property
+    def description(self) -> Tuple[Tuple[Any, ...], ...]:
+        return self._inner.description
+
+    @property
+    def rowcount(self) -> int:
+        return self._inner.rowcount
+
+    async def execute(self, sql: str, parameters: Optional[Sequence[Any]] = None) -> None:
+        self._inner.execute(sql, parameters)
+
+    async def executemany(self, sql: str, seq_of_parameters: Optional[Sequence[Sequence[Any]]] = None) -> None:
+        self._inner.executemany(sql, seq_of_parameters)
+
+    async def fetchone(self) -> Optional[Tuple[Any, ...]]:
+        return self._inner.fetchone()
+
+    async def fetchall(self) -> List[Tuple[Any, ...]]:
+        return self._inner.fetchall()
+
+    async def fetchmany(self, size: int = 1) -> List[Tuple[Any, ...]]:
+        return self._inner.fetchmany(size)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class FakeAsyncConnection:
+    """A minimal async DBAPI connection whose ``cursor()`` returns an awaitable."""
+
+    def __init__(self, db: Optional[MiniDb] = None) -> None:
+        self.db = db if db is not None else MiniDb()
+        self.closed = False
+
+    async def cursor(self, *args: Any, **kwargs: Any) -> FakeAsyncCursor:
+        return FakeAsyncCursor(self.db)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MockSyncConformanceCommands(Commands):
+    """A third-party-shaped sync command class over the fake driver."""
+
+    class SqlParamHandler(BaseSqlParamHandler):
+        def get_param_placeholder(self, param_name: str) -> str:
+            return "%s"
+
+    @classmethod
+    def connect(cls, parsed_dsn: Any, **connect_kwargs: Any) -> "MockSyncConformanceCommands":
+        return cls(FakeSyncConnection())
+
+
+class MockAsyncConformanceCommands(CommandsAsync):
+    """A third-party-shaped async command class over the fake driver."""
+
+    class SqlParamHandler(BaseSqlParamHandler):
+        def get_param_placeholder(self, param_name: str) -> str:
+            return "%s"
+
+    @classmethod
+    async def connect_async(cls, parsed_dsn: Any, **connect_kwargs: Any) -> "MockAsyncConformanceCommands":
+        return cls(FakeAsyncConnection())
+
+
+def seeded_mini_db(supports_empty_strings: bool = True) -> MiniDb:
+    return MiniDb(seed_rows(supports_empty_strings))
+
+
+class MockSyncConformanceHarness(SyncAdapterHarness):
+    """Service-free mock sync harness; requires the mock adapter to be registered."""
+
+    adapter_name = MOCK_SYNC_ADAPTER_NAME
+    command_class = MockSyncConformanceCommands
+    connect_dsn = f"sqlite+{MOCK_SYNC_ADAPTER_NAME}://mock"
+
+    def create_commands(self) -> Commands:
+        return MockSyncConformanceCommands(FakeSyncConnection(seeded_mini_db()))
+
+    def teardown_commands(self, commands: Commands) -> None:
+        commands.connection.close()
+
+
+class MockAsyncConformanceHarness(AsyncAdapterHarness):
+    """Service-free mock async harness; requires the mock adapter to be registered."""
+
+    adapter_name = MOCK_ASYNC_ADAPTER_NAME
+    command_class = MockAsyncConformanceCommands
+    connect_dsn = f"sqlite+{MOCK_ASYNC_ADAPTER_NAME}://mock"
+
+    async def create_commands(self) -> CommandsAsync:
+        return MockAsyncConformanceCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    async def teardown_commands(self, commands: CommandsAsync) -> None:
+        commands.connection.close()
+
+
+SQLITE_CONFORMANCE_DDL = (
+    "CREATE TABLE pydapper_conformance (id INTEGER PRIMARY KEY, label TEXT, score INTEGER, note TEXT)"
+)
+
+
+def seed_sqlite_connection(connection: sqlite3.Connection, supports_empty_strings: bool = True) -> None:
+    connection.execute(SQLITE_CONFORMANCE_DDL)
+    connection.executemany(
+        "INSERT INTO pydapper_conformance (id, label, score, note) VALUES (?, ?, ?, ?)",
+        seed_rows(supports_empty_strings),
+    )
+    connection.commit()
+
+
+class Sqlite3ConformanceHarness(SyncAdapterHarness):
+    """Live ``core-sync`` harness for the first-party sqlite3 adapter.
+
+    Each case gets a fresh in-memory database; the ``connect()`` path uses a
+    disposable file database under ``workdir``.
+    """
+
+    adapter_name = "sqlite3"
+    command_class = Sqlite3Commands
+
+    def __init__(self, workdir: Union[str, Path]) -> None:
+        self.workdir = Path(workdir)
+        self.connect_dsn = f"sqlite:///{(self.workdir / 'conformance_connect.db').resolve()}"  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        connection = sqlite3.connect(":memory:")
+        seed_sqlite_connection(connection)
+        return Sqlite3Commands(connection)
+
+    def teardown_commands(self, commands: Commands) -> None:
+        commands.connection.close()
+
+
+_SEED_INSERT = "INSERT INTO {table} (id, label, score, note) VALUES (?id?, ?label?, ?score?, ?note?)"
+
+
+def seed_records(supports_empty_strings: bool = True) -> List[Dict[str, Any]]:
+    return [dict(zip(CONFORMANCE_COLUMNS, row)) for row in seed_rows(supports_empty_strings)]
+
+
+def seed_through_adapter(commands: Commands, table_name: str, supports_empty_strings: bool = True) -> None:
+    """Seed the canonical dataset through the adapter's own execute path."""
+    commands.execute(_SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
+
+
+async def seed_through_adapter_async(
+    commands: CommandsAsync, table_name: str, supports_empty_strings: bool = True
+) -> None:
+    """Async twin of :func:`seed_through_adapter`."""
+    await commands.execute_async(_SEED_INSERT.format(table=table_name), params=seed_records(supports_empty_strings))
+
+
+@dataclass(frozen=True)
+class FirstPartyConformanceEntry:
+    """One installed first-party adapter mode's conformance entry."""
+
+    adapter_name: str
+    mode: str
+    command_class: Union[Type[Commands], Type[CommandsAsync]]
+    test_module: str
+
+
+#: Single source of truth for first-party conformance adoption, keyed by
+#: (adapter entry-point name, mode). The drift test derives the expected contents
+#: from the installed ``pydapper.adapters`` entry points, so additions or removals
+#: of first-party adapters fail loudly here instead of going silently untested.
+FIRST_PARTY_CONFORMANCE_ENTRIES: Dict[Tuple[str, str], FirstPartyConformanceEntry] = {
+    (entry.adapter_name, entry.mode): entry
+    for entry in (
+        FirstPartyConformanceEntry("sqlite3", "sync", Sqlite3Commands, "tests/test_sqlite/test_conformance.py"),
+        FirstPartyConformanceEntry("psycopg2", "sync", Psycopg2Commands, "tests/test_postgresql/test_conformance.py"),
+        FirstPartyConformanceEntry("psycopg", "sync", Psycopg3Commands, "tests/test_postgresql/test_conformance.py"),
+        FirstPartyConformanceEntry(
+            "psycopg", "async", Psycopg3CommandsAsync, "tests/test_postgresql/test_conformance.py"
+        ),
+        FirstPartyConformanceEntry("aiopg", "async", AiopgCommands, "tests/test_postgresql/test_conformance.py"),
+        FirstPartyConformanceEntry(
+            "mysql", "sync", MySqlConnectorPythonCommands, "tests/test_mysql/test_conformance.py"
+        ),
+        FirstPartyConformanceEntry("pymssql", "sync", PymssqlCommands, "tests/test_mssql/test_conformance.py"),
+        FirstPartyConformanceEntry("oracledb", "sync", OracledbCommands, "tests/test_oracle/test_conformance.py"),
+        FirstPartyConformanceEntry(
+            "google", "sync", GoogleBigqueryClientCommands, "tests/test_bigquery/test_conformance.py"
+        ),
+    )
+}

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -304,7 +304,7 @@ class Sqlite3ConformanceHarness(SyncAdapterHarness):
 
     def __init__(self, workdir: Union[str, Path]) -> None:
         self.workdir = Path(workdir)
-        self.connect_dsn = f"sqlite:///{(self.workdir / 'conformance_connect.db').resolve()}"  # type: ignore[misc]
+        self.connect_dsn = f"sqlite:///{(self.workdir / 'conformance_connect.db').resolve()}"
 
     def create_commands(self) -> Commands:
         connection = sqlite3.connect(":memory:")

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -40,6 +40,7 @@ from pydapper.testing.adapter_conformance import CORE_SYNC
 from pydapper.testing.adapter_conformance import AsyncAdapterHarness
 from pydapper.testing.adapter_conformance import AsyncCase
 from pydapper.testing.adapter_conformance import CaseResult
+from pydapper.testing.adapter_conformance import CaseSelectionError
 from pydapper.testing.adapter_conformance import ConformanceFailureError
 from pydapper.testing.adapter_conformance import ConformanceProfile
 from pydapper.testing.adapter_conformance import ConformanceReport
@@ -1183,7 +1184,7 @@ class _RaisingCloseConnectCommands(MockSyncConformanceCommands):
 )
 def test_dsn_connect_case_tolerates_unclosable_connections(isolated_registry, commands_class):
     """The connect() case verifies the adapter, never the connection's close behavior."""
-    name = f"conformance-mock-{commands_class.__name__.strip(chr(95)).lower()}"
+    name = f"conformance-mock-{commands_class.__name__.lstrip('_').lower()}"
     _register_mock_sync(name=name, commands=commands_class)
 
     class _Harness(MockSyncConformanceHarness):
@@ -1227,7 +1228,7 @@ class _RaisingCloseConnectAsyncCommands(MockAsyncConformanceCommands):
     ids=["no-close", "close-raises"],
 )
 async def test_async_dsn_connect_case_tolerates_unclosable_connections(isolated_registry, commands_class):
-    name = f"conformance-mock-{commands_class.__name__.strip(chr(95)).lower()}"
+    name = f"conformance-mock-{commands_class.__name__.lstrip('_').lower()}"
     _register_mock_async(name=name, async_commands=commands_class)
 
     class _Harness(MockAsyncConformanceHarness):
@@ -1666,3 +1667,411 @@ async def test_async_teardown_reports_the_first_error_across_several_commands(is
     assert len(created) == 2
     torn_down = [command for command in created if any(command is attempt for attempt in attempts)]
     assert len(torn_down) == 2, "every created command must be torn down even after the first failure"
+
+
+# ------------------------------------------------------------------ sync/async inventory parity
+
+#: The only intentional divergence between the two core inventories: the unbuffered
+#: cleanup case is named after the generator-teardown API each mode actually exposes.
+#: Every other case id must exist in both modes so a fix can never land in one mode
+#: only. Extend these sets in the same change that adds a genuinely mode-specific case.
+DOCUMENTED_SYNC_ONLY_CASE_IDS = frozenset({"lifecycle.unbuffered-explicit-close"})
+DOCUMENTED_ASYNC_ONLY_CASE_IDS = frozenset({"lifecycle.unbuffered-explicit-aclose"})
+
+
+def test_core_sync_and_async_case_inventories_stay_in_parity():
+    sync_ids = {case.case_id for case in core_sync_profile().sync_cases}
+    async_ids = {case.case_id for case in core_async_profile().async_cases}
+
+    sync_only = sync_ids - async_ids
+    async_only = async_ids - sync_ids
+
+    assert (sync_only, async_only) == (DOCUMENTED_SYNC_ONLY_CASE_IDS, DOCUMENTED_ASYNC_ONLY_CASE_IDS), (
+        "the core-sync and core-async case inventories drifted; every case id must exist in "
+        "both modes apart from the documented unbuffered-close pair.\n"
+        f"  sync-only, missing an async twin: {sorted(sync_only - DOCUMENTED_SYNC_ONLY_CASE_IDS)}\n"
+        f"  async-only, missing a sync twin: {sorted(async_only - DOCUMENTED_ASYNC_ONLY_CASE_IDS)}\n"
+        f"  documented sync-only ids no longer sync-only: {sorted(DOCUMENTED_SYNC_ONLY_CASE_IDS - sync_only)}\n"
+        f"  documented async-only ids no longer async-only: {sorted(DOCUMENTED_ASYNC_ONLY_CASE_IDS - async_only)}"
+    )
+
+
+# ------------------------------------------------------------------ case_ids filtering
+
+#: Two real ids present in both core inventories, used to prove a narrow debug run.
+FILTER_CASE_IDS = ("params.params-keyword", "scalar.null-returns-none")
+
+
+def test_case_ids_runs_only_the_requested_sync_cases(isolated_registry, tmp_path):
+    """A filtered run executes exactly the named cases, in declared order, and says so."""
+    declared = [case.case_id for case in core_sync_profile().sync_cases]
+    expected = [case_id for case_id in declared if case_id in FILTER_CASE_IDS]
+
+    # duplicates in the request are de-duplicated, never run twice
+    report = run_core_sync(Sqlite3ConformanceHarness(tmp_path), case_ids=[*FILTER_CASE_IDS, FILTER_CASE_IDS[0]])
+
+    assert [result.case_id for result in report.results] == expected
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert report.covers_full_inventory is False, "a filtered run must never claim full coverage"
+    assert report.profile_id == CORE_SYNC
+
+
+@pytest.mark.asyncio
+async def test_case_ids_runs_only_the_requested_async_cases(isolated_registry):
+    _register_mock_async()
+    declared = [case.case_id for case in core_async_profile().async_cases]
+    expected = [case_id for case_id in declared if case_id in FILTER_CASE_IDS]
+
+    report = await run_core_async(MockAsyncConformanceHarness(), case_ids=list(FILTER_CASE_IDS))
+
+    assert [result.case_id for result in report.results] == expected
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert report.covers_full_inventory is False
+    assert report.profile_id == CORE_ASYNC
+
+
+def test_unfiltered_and_fully_named_sync_runs_both_cover_the_inventory(isolated_registry):
+    """``case_ids=None`` and a selection naming every planned case are both complete."""
+    _register_mock_sync()
+    every_id = [case.case_id for case in core_sync_profile().sync_cases]
+
+    unfiltered = run_core_sync(MockSyncConformanceHarness())
+    fully_named = run_core_sync(MockSyncConformanceHarness(), case_ids=every_id)
+
+    assert unfiltered.covers_full_inventory is True
+    assert fully_named.covers_full_inventory is True, "naming every planned case is still full coverage"
+    assert [result.case_id for result in fully_named.results] == [result.case_id for result in unfiltered.results]
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_and_fully_named_async_runs_both_cover_the_inventory(isolated_registry):
+    _register_mock_async()
+    every_id = [case.case_id for case in core_async_profile().async_cases]
+
+    unfiltered = await run_core_async(MockAsyncConformanceHarness())
+    fully_named = await run_core_async(MockAsyncConformanceHarness(), case_ids=every_id)
+
+    assert unfiltered.covers_full_inventory is True
+    assert fully_named.covers_full_inventory is True
+    assert [result.case_id for result in fully_named.results] == [result.case_id for result in unfiltered.results]
+
+
+def test_case_ids_can_select_a_declared_capability_profile_case(isolated_registry):
+    """Filtering is applied after planning, so a capability profile's case id selects."""
+    name = "conformance-mock-filter-txn"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+    ran = []
+
+    def _txn_case(ctx):
+        ran.append(ctx.case_id)
+
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.smoke", "synthetic", "instrumented", _txn_case),),
+    )
+    report = run_core_sync(
+        _Harness(),
+        capability_catalog={AdapterCapability.TRANSACTIONS: profile},
+        case_ids=["transactions.smoke"],
+    )
+
+    assert ran == ["transactions.smoke"]
+    assert [(result.profile_id, result.case_id) for result in report.results] == [
+        ("transactions", "transactions.smoke")
+    ]
+    assert report.covers_full_inventory is False
+
+
+def test_case_ids_rejects_unknown_ids_before_running_anything(isolated_registry):
+    """A typo raises immediately and names the unknown ids; nothing runs."""
+    _register_mock_sync()
+    created = []
+
+    class _Harness(MockSyncConformanceHarness):
+        def create_commands(self):
+            created.append(1)
+            return super().create_commands()
+
+    with pytest.raises(CaseSelectionError) as exc_info:
+        run_core_sync(_Harness(), case_ids=["params.params-keyword", "params.params-keyord", "nope"])
+
+    error = exc_info.value
+    assert error.unknown_case_ids == ("params.params-keyord", "nope")
+    assert error.requested_case_ids == ("params.params-keyword", "params.params-keyord", "nope")
+    assert error.profile_id == CORE_SYNC
+    assert "params.params-keyord" in str(error) and "nope" in str(error)
+    assert created == [], "an invalid selection must raise before any case runs"
+
+
+@pytest.mark.asyncio
+async def test_async_case_ids_rejects_unknown_ids(isolated_registry):
+    _register_mock_async()
+
+    with pytest.raises(CaseSelectionError) as exc_info:
+        await run_core_async(MockAsyncConformanceHarness(), case_ids=["lifecycle.unbuffered-explicit-close"])
+
+    error = exc_info.value
+    assert error.unknown_case_ids == ("lifecycle.unbuffered-explicit-close",), "sync-only ids are unknown here"
+    assert error.profile_id == CORE_ASYNC
+
+
+def test_case_ids_empty_selection_is_an_error(isolated_registry):
+    _register_mock_sync()
+
+    with pytest.raises(CaseSelectionError) as exc_info:
+        run_core_sync(MockSyncConformanceHarness(), case_ids=())
+
+    error = exc_info.value
+    assert error.requested_case_ids == ()
+    assert error.unknown_case_ids == ()
+    assert "empty selection is not a conformance run" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_async_case_ids_empty_selection_is_an_error(isolated_registry):
+    _register_mock_async()
+
+    with pytest.raises(CaseSelectionError) as exc_info:
+        await run_core_async(MockAsyncConformanceHarness(), case_ids=set())
+
+    assert exc_info.value.profile_id == CORE_ASYNC
+    assert "empty selection is not a conformance run" in str(exc_info.value)
+
+
+def test_case_ids_rejects_a_bare_string(isolated_registry):
+    """A single string is a collection of characters; reject it instead of reporting 20 typos."""
+    _register_mock_sync()
+
+    with pytest.raises(TypeError) as exc_info:
+        run_core_sync(MockSyncConformanceHarness(), case_ids="params.params-keyword")
+
+    assert "not a single string" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_case_ids_rejects_a_bare_string(isolated_registry):
+    _register_mock_async()
+
+    with pytest.raises(TypeError) as exc_info:
+        await run_core_async(MockAsyncConformanceHarness(), case_ids="params.params-keyword")
+
+    assert "not a single string" in str(exc_info.value)
+
+
+def test_conformance_failure_error_marks_a_partial_run():
+    """A pasted traceback from a filtered run cannot be mistaken for a full run."""
+    failing = CaseResult(CORE_SYNC, "scalar.value", False, message="boom")
+    partial = ConformanceReport(
+        profile_id=CORE_SYNC,
+        adapter_name="mock",
+        command_class_name="Mock",
+        results=(failing,),
+        covers_full_inventory=False,
+    )
+    full = dataclasses.replace(partial, covers_full_inventory=True)
+
+    with pytest.raises(ConformanceFailureError) as exc_info:
+        partial.raise_for_failures()
+    assert "PARTIAL RUN" in str(exc_info.value)
+    assert "covered only 1 planned case(s)" in str(exc_info.value)
+    assert exc_info.value.report.covers_full_inventory is False
+
+    with pytest.raises(ConformanceFailureError) as full_info:
+        full.raise_for_failures()
+    assert "PARTIAL RUN" not in str(full_info.value)
+
+
+def test_raise_for_failures_ignores_completeness(isolated_registry, tmp_path):
+    """``raise_for_failures`` is about failures only; completeness is a separate axis."""
+    report = run_core_sync(Sqlite3ConformanceHarness(tmp_path), case_ids=[FILTER_CASE_IDS[0]])
+
+    assert report.passed
+    assert report.covers_full_inventory is False
+    assert report.raise_for_failures() is None, "a passing filtered run must not raise"
+
+
+# ------------------------------------------------------------------ harness setup failures
+
+
+class _SeedingFailure(RuntimeError):
+    """Stands in for a driver error raised while the harness seeds the canonical dataset."""
+
+
+def test_sync_harness_setup_failure_is_attributed_to_the_harness(isolated_registry):
+    """A harness that cannot seed reports a harness failure, not adapter misbehavior.
+
+    This is the BigQuery seeding regression in miniature: one broken ``create_commands()``
+    used to surface as dozens of identical "unexpected ProgrammingError" case failures
+    indistinguishable from a genuinely broken adapter.
+    """
+    _register_mock_sync()
+    boom = _SeedingFailure("Encountered parameter None with only None values")
+
+    class _BrokenSeedHarness(MockSyncConformanceHarness):
+        def create_commands(self):
+            raise boom
+
+    report = run_core_sync(_BrokenSeedHarness())
+    named = next(result for result in report.results if result.case_id == "params.params-keyword")
+
+    assert not named.passed
+    assert named.harness_setup_failed is True
+    assert named.cause is boom, "the original exception object must be preserved unchanged"
+    assert named.missing_field is None, "a raising factory is not a missing harness field"
+    assert "harness setup failed" in named.message
+    assert "create_commands()" in named.message
+    assert "not adapter behavior" in named.message
+    assert str(boom) in named.message, "the underlying driver error is still visible"
+    assert "harness_setup_failed=True" in repr(named), "the flag must be visible in a printed result"
+    assert report.harness_setup_failed is True
+    assert len([failure for failure in report.failures if failure.harness_setup_failed]) > 1
+
+
+@pytest.mark.asyncio
+async def test_async_harness_setup_failure_is_attributed_to_the_harness(isolated_registry):
+    _register_mock_async()
+    boom = _SeedingFailure("async seeding boom")
+
+    class _BrokenSeedHarness(MockAsyncConformanceHarness):
+        async def create_commands(self):
+            raise boom
+
+    report = await run_core_async(_BrokenSeedHarness())
+    named = next(result for result in report.results if result.case_id == "params.params-keyword")
+
+    assert not named.passed
+    assert named.harness_setup_failed is True
+    assert named.cause is boom
+    assert "harness setup failed" in named.message and "create_commands()" in named.message
+    assert f"{CORE_ASYNC!r}/'params.params-keyword'" in named.message
+    assert report.harness_setup_failed is True
+
+
+def test_missing_create_commands_is_not_reported_as_a_setup_failure(isolated_registry):
+    """A missing override keeps its own structured path and is never double-wrapped."""
+
+    class _NoFactoryHarness(SyncAdapterHarness):
+        adapter_name = MOCK_SYNC_ADAPTER_NAME
+        command_class = MockSyncConformanceCommands
+        connect_dsn = MockSyncConformanceHarness.connect_dsn
+
+    _register_mock_sync()
+    report = run_core_sync(_NoFactoryHarness())
+    named = next(failure for failure in report.failures if failure.missing_field == "create_commands")
+
+    assert named.harness_setup_failed is False
+    assert isinstance(named.cause, HarnessDefinitionError)
+    assert "harness setup failed" not in named.message
+    assert report.harness_setup_failed is False, "a missing field is a definition error, not a setup failure"
+
+
+def test_adapter_failures_are_not_relabelled_as_setup_failures(isolated_registry):
+    """A genuine behavioral failure keeps its exact shape and never claims setup broke."""
+    name = "conformance-mock-broken-rows-not-setup"
+    _register_mock_sync(name=name, commands=_BrokenRowMappingCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _BrokenRowMappingCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _BrokenRowMappingCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "rows.query-buffered")
+
+    assert not named.passed
+    assert named.harness_setup_failed is False
+    assert "harness setup failed" not in named.message
+    assert report.harness_setup_failed is False
+
+
+def test_setup_failure_survives_a_teardown_failure(isolated_registry):
+    """A later setup failure keeps its attribution when an earlier command's teardown fails."""
+    name = "conformance-mock-setup-then-teardown-boom"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    calls = []
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            calls.append(1)
+            if len(calls) > 1:
+                raise _SeedingFailure("second seed boom")
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+        def teardown_commands(self, commands):
+            raise RuntimeError("teardown boom")
+
+    def _two_commands_case(ctx):
+        ctx.create_commands()
+        ctx.create_commands()
+
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.two-commands", "d", "instrumented", _two_commands_case),),
+    )
+    report = run_core_sync(
+        _Harness(),
+        capability_catalog={AdapterCapability.TRANSACTIONS: profile},
+        case_ids=["transactions.two-commands"],
+    )
+    named = next(result for result in report.results if result.case_id == "transactions.two-commands")
+
+    assert named.harness_setup_failed is True, "merging a teardown failure must not lose the attribution"
+    assert isinstance(named.cause, _SeedingFailure)
+    assert isinstance(named.cleanup_error, RuntimeError)
+    assert report.harness_setup_failed is True
+
+
+def test_conformance_failure_error_flags_a_harness_setup_run(isolated_registry):
+    """The raised summary — what CI actually prints — says the harness never got off the ground."""
+    _register_mock_sync()
+
+    class _BrokenSeedHarness(MockSyncConformanceHarness):
+        def create_commands(self):
+            raise _SeedingFailure("seed boom")
+
+    report = run_core_sync(_BrokenSeedHarness())
+    with pytest.raises(ConformanceFailureError) as exc_info:
+        report.raise_for_failures()
+
+    summary = str(exc_info.value)
+    assert "HARNESS SETUP FAILED" in summary
+    assert f"{len(report.failures)} of {len(report.failures)} failure(s)" in summary
+    assert "fix the harness first" in summary
+
+
+def test_conformance_failure_error_omits_the_setup_banner_for_ordinary_failures():
+    """Every other failure kind keeps the pre-existing summary byte for byte."""
+    failing = CaseResult(CORE_SYNC, "scalar.value", False, message="boom")
+    report = ConformanceReport(
+        profile_id=CORE_SYNC,
+        adapter_name="mock",
+        command_class_name="Mock",
+        results=(failing,),
+    )
+
+    with pytest.raises(ConformanceFailureError) as exc_info:
+        report.raise_for_failures()
+
+    assert "HARNESS SETUP" not in str(exc_info.value)
+    assert str(exc_info.value) == (
+        "1 conformance case(s) failed for profile 'core-sync' ('mock' / Mock); first failure: 'scalar.value': boom"
+    )
+    assert report.harness_setup_failed is False

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -158,6 +158,7 @@ def test_helper_import_is_dependency_clean():
             "oracledb",
             "google",
             "sqlalchemy",
+            "typing_extensions",
         }
 
         class Guard:
@@ -374,8 +375,9 @@ def test_declared_capability_without_profile_fails_clearly(isolated_registry):
     assert named.profile_id == CORE_SYNC
 
 
-def test_synthetic_capability_profile_runs_and_satisfies_declaration(isolated_registry):
-    """A test-local synthetic profile proves extension without touching production state."""
+def test_synthetic_capability_profile_runs_but_cannot_cover_a_declaration(isolated_registry):
+    """A test-local synthetic profile runs its cases, but only the production catalog
+    can satisfy the declared-capability honesty check — injection is not a bypass."""
     name = "conformance-mock-synth-txn"
     _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
 
@@ -400,11 +402,60 @@ def test_synthetic_capability_profile_runs_and_satisfies_declaration(isolated_re
         sync_cases=(SyncCase("transactions.smoke", "synthetic transactions case", "instrumented", _txn_case),),
     )
     report = run_core_sync(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: synthetic})
-    assert report.passed, [(f.case_id, f.message) for f in report.failures]
-    assert ran == ["transactions.smoke"]
+    assert ran == ["transactions.smoke"], "the injected profile's cases must actually run"
     synthetic_results = [result for result in report.results if result.profile_id == "transactions"]
     assert [result.case_id for result in synthetic_results] == ["transactions.smoke"]
+    assert synthetic_results[0].passed
+    # the declaration honesty case still fails: the production catalog has no
+    # transactions profile, and an injected catalog can never make one appear covered
+    failed_ids = [failure.case_id for failure in report.failures]
+    assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
     assert capability_profiles() == {}, "the production catalog must stay empty until a capability ships"
+
+
+def test_option_probes_cannot_be_waived_by_declaration_alone(isolated_registry):
+    """A falsely declared capability must still fail the option-honesty probes, even
+    with an injected catalog claiming coverage (the adversarial-audit bypass)."""
+    name = "conformance-mock-false-caps"
+
+    class _FalselyDeclaringCommands(MockSyncConformanceCommands):
+        capabilities = frozenset(AdapterCapability)
+
+        @staticmethod
+        def _resolve_options(options=None):
+            # deliberately dishonest: accepts every option and applies none of them,
+            # returning the caller's instance so hook-identity checks stay quiet
+            from pydapper.command_options import CommandOptions
+
+            return options if options is not None else CommandOptions()
+
+    _register_mock_sync(name=name, commands=_FalselyDeclaringCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _FalselyDeclaringCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _FalselyDeclaringCommands(FakeSyncConnection(seeded_mini_db()))
+
+    def _noop(ctx):
+        return None
+
+    injected = {
+        member: ConformanceProfile(
+            profile_id=member.value,
+            capability=member,
+            sync_cases=(SyncCase(f"{member.value}.noop", "attacker no-op", "instrumented", _noop),),
+        )
+        for member in AdapterCapability
+    }
+    report = run_core_sync(_Harness(), capability_catalog=injected)
+    failed_ids = {failure.case_id for failure in report.failures}
+    assert "options.unsupported-raises" in failed_ids, "option probes must not be waived by declaration alone"
+    assert "options.unsupported-before-driver-work" in failed_ids
+    assert "capabilities.declared-profile-populated" in failed_ids
+    assert not report.passed
 
 
 def test_production_capability_catalog_is_empty_and_immutable():
@@ -505,6 +556,16 @@ def test_missing_adapter_name_fails_before_any_case():
     assert exc_info.value.profile_id == CORE_SYNC
 
 
+def test_missing_command_class_fails_before_any_case():
+    class _ClasslessHarness(SyncAdapterHarness):
+        adapter_name = MOCK_SYNC_ADAPTER_NAME
+
+    with pytest.raises(HarnessDefinitionError) as exc_info:
+        run_core_sync(_ClasslessHarness())
+    assert exc_info.value.missing_field == "command_class"
+    assert exc_info.value.profile_id == CORE_SYNC
+
+
 def test_sync_and_async_harnesses_do_not_require_the_opposite_mode():
     assert not hasattr(SyncAdapterHarness, "cursor_factory_style")
     sync_members = set(vars(SyncAdapterHarness))
@@ -519,6 +580,33 @@ def test_sync_and_async_harnesses_do_not_require_the_opposite_mode():
 async def test_async_runner_rejects_sync_harness():
     with pytest.raises(TypeError):
         await run_core_async(MockSyncConformanceHarness())  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_and_still_tears_down(isolated_registry):
+    """Task cancellation must abort the run promptly, not be recorded as a failed case,
+    and the active case's live resources must still be released first."""
+    import asyncio
+
+    _register_mock_async()
+    torn_down = []
+
+    class _HangingHarness(MockAsyncConformanceHarness):
+        async def create_commands(self):
+            commands = await super().create_commands()
+            await asyncio.sleep(3600)
+            return commands
+
+        async def teardown_commands(self, commands):
+            torn_down.append(commands)
+            await super().teardown_commands(commands)
+
+    task = asyncio.get_running_loop().create_task(run_core_async(_HangingHarness()))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled(), "run_core_async must not swallow cancellation into a report"
 
 
 # ------------------------------------------------------------------ isolation, cleanup, precedence
@@ -610,14 +698,9 @@ def test_adapter_code_cannot_declare_its_own_case_passed(isolated_registry):
 # ------------------------------------------------------------------ concrete first-party classes (service-free)
 
 
+# derived from the single conformance source of truth so this list cannot go stale
 _SYNC_CONCRETE_CLASSES = [
-    Sqlite3Commands,
-    Psycopg2Commands,
-    Psycopg3Commands,
-    MySqlConnectorPythonCommands,
-    PymssqlCommands,
-    OracledbCommands,
-    GoogleBigqueryClientCommands,
+    entry.command_class for entry in FIRST_PARTY_CONFORMANCE_ENTRIES.values() if entry.mode == "sync"
 ]
 
 
@@ -807,6 +890,8 @@ def test_every_conformance_entry_module_exists_and_targets_its_adapter():
         expected_runner = "run_core_sync" if mode == "sync" else "run_core_async"
         assert expected_runner in text, (name, mode)
         assert "FIRST_PARTY_CONFORMANCE_ENTRIES" in text, (name, mode)
+        assert re.search(r"^def test_|^async def test_", text, re.MULTILINE), (name, mode)
+        assert "raise_for_failures" in text, (name, mode)
 
 
 def test_every_declared_first_party_capability_has_a_populated_profile(isolated_registry):
@@ -825,6 +910,14 @@ def test_every_declared_first_party_capability_has_a_populated_profile(isolated_
 # ------------------------------------------------------------------ built artifacts carry the helper
 
 
+def _expected_helper_members():
+    """Derive the shipped helper file list from the source tree, so a renamed or new
+    module is covered automatically instead of silently dropping out of the check."""
+    members = {str(path.relative_to(REPO_ROOT)) for path in (REPO_ROOT / "pydapper" / "testing").rglob("*.py")}
+    assert len(members) >= 11, members
+    return members
+
+
 def test_built_wheel_and_sdist_ship_the_conformance_helper(tmp_path):
     import shutil
 
@@ -838,27 +931,46 @@ def test_built_wheel_and_sdist_ship_the_conformance_helper(tmp_path):
     )
     assert completed.returncode == 0, f"poetry build failed:\n{completed.stdout}\n{completed.stderr}"
 
+    expected = _expected_helper_members()
+
     [wheel_path] = tmp_path.glob("pydapper-*.whl")
+    wheel_extract = tmp_path / "wheel-extract"
     with zipfile.ZipFile(wheel_path) as wheel:
         names = set(wheel.namelist())
-    for member in (
-        "pydapper/testing/__init__.py",
-        "pydapper/testing/adapter_conformance/__init__.py",
-        "pydapper/testing/adapter_conformance/_runner.py",
-        "pydapper/testing/adapter_conformance/_cases_sync.py",
-        "pydapper/testing/adapter_conformance/_cases_async.py",
-    ):
-        assert member in names, f"wheel is missing {member}"
+        wheel.extractall(wheel_extract)
+    missing = expected - names
+    assert not missing, f"wheel is missing helper files: {sorted(missing)}"
 
     [sdist_path] = tmp_path.glob("pydapper-*.tar.gz")
+    sdist_extract = tmp_path / "sdist-extract"
     with tarfile.open(sdist_path) as sdist:
         sdist_names = {"/".join(name.split("/")[1:]) for name in sdist.getnames()}
-    for member in (
-        "pydapper/testing/__init__.py",
-        "pydapper/testing/adapter_conformance/__init__.py",
-        "pydapper/testing/adapter_conformance/_runner.py",
-    ):
-        assert member in sdist_names, f"sdist is missing {member}"
+        sdist.extractall(sdist_extract)
+    missing = expected - sdist_names
+    assert not missing, f"sdist is missing helper files: {sorted(missing)}"
+
+    # the packaged helper must IMPORT from each built artifact, not just be listed in
+    # it: run a hermetic interpreter whose sys.path is only the extracted artifact
+    [sdist_root] = sdist_extract.glob("pydapper-*")
+    for artifact_root in (wheel_extract, sdist_root):
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                "-c",
+                "import sys; sys.path.insert(0, sys.argv[1]); "
+                "import pydapper.testing.adapter_conformance as helper; "
+                "assert helper.CORE_SYNC == 'core-sync' and helper.CORE_ASYNC == 'core-async'; "
+                "assert callable(helper.run_core_sync) and callable(helper.run_core_async); "
+                "print('ARTIFACT-IMPORT-OK')",
+                str(artifact_root),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, f"import from {artifact_root} failed:\n{completed.stderr}"
+        assert "ARTIFACT-IMPORT-OK" in completed.stdout
 
 
 # ------------------------------------------------------------------ documented examples actually run

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -38,9 +38,11 @@ from pydapper.sqlite import Sqlite3Commands
 from pydapper.testing.adapter_conformance import CORE_ASYNC
 from pydapper.testing.adapter_conformance import CORE_SYNC
 from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import AsyncCase
 from pydapper.testing.adapter_conformance import CaseResult
 from pydapper.testing.adapter_conformance import ConformanceFailureError
 from pydapper.testing.adapter_conformance import ConformanceProfile
+from pydapper.testing.adapter_conformance import ConformanceReport
 from pydapper.testing.adapter_conformance import HarnessDefinitionError
 from pydapper.testing.adapter_conformance import ProfileDefinitionError
 from pydapper.testing.adapter_conformance import SyncAdapterHarness
@@ -50,11 +52,15 @@ from pydapper.testing.adapter_conformance import core_async_profile
 from pydapper.testing.adapter_conformance import core_sync_profile
 from pydapper.testing.adapter_conformance import run_core_async
 from pydapper.testing.adapter_conformance import run_core_sync
+from pydapper.testing.adapter_conformance._checks import SyncCaseContext
 from pydapper.testing.adapter_conformance._instrumentation import CursorScript
 from pydapper.testing.adapter_conformance._instrumentation import RecordingAsyncConnection
 from pydapper.testing.adapter_conformance._instrumentation import RecordingConnection
 from pydapper.testing.adapter_conformance._instrumentation import SynchronousCursorRecordingAsyncConnection
 from pydapper.testing.adapter_conformance._profiles import validate_capability_catalog
+from pydapper.testing.adapter_conformance._results import CaseCheckError
+from pydapper.testing.adapter_conformance._sqlspec import render_statement
+from pydapper.testing.adapter_conformance._sqlspec import statement_ids
 from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
 from tests.conformance_support import MOCK_ASYNC_ADAPTER_NAME
 from tests.conformance_support import MOCK_SYNC_ADAPTER_NAME
@@ -986,3 +992,677 @@ def test_documented_third_party_examples_run_as_shown(example):
     completed = subprocess.run([sys.executable, str(path)], cwd=REPO_ROOT, capture_output=True, text=True)
     assert completed.returncode == 0, f"{example} failed:\n{completed.stdout}\n{completed.stderr}"
     assert "import pytest" not in path.read_text(), "documented examples must not require pytest"
+
+
+# ------------------------------------------------------------------ statement catalog
+
+
+def _noop_case(ctx):
+    return None
+
+
+def test_statement_catalog_exposes_ids_and_rejects_unknown_statements():
+    ids = statement_ids()
+    assert ids == tuple(sorted(ids)), "statement ids must be reported in a stable sorted order"
+    assert {"select_all", "insert_row", "update_label"} <= set(ids)
+    assert render_statement("select_all", "t") == "SELECT id, label, score, note FROM t ORDER BY id"
+    assert render_statement("select_all", "t", {"select_all": "SELECT 1 FROM {table}"}) == "SELECT 1 FROM t"
+    with pytest.raises(KeyError) as exc_info:
+        render_statement("no_such_statement", "t")
+    assert "no_such_statement" in str(exc_info.value)
+
+
+# ------------------------------------------------------------------ profile definition validation
+
+
+def test_invalid_case_kind_is_rejected():
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        ConformanceProfile(
+            profile_id=CORE_SYNC,
+            capability=None,
+            sync_cases=(SyncCase("bad.kind", "d", "made-up-kind", _noop_case),),
+        )
+    assert "invalid kind" in str(exc_info.value)
+
+
+def test_empty_profile_id_is_rejected():
+    with pytest.raises(ProfileDefinitionError):
+        ConformanceProfile(
+            profile_id="",
+            capability=None,
+            sync_cases=(SyncCase("x.y", "d", "instrumented", _noop_case),),
+        )
+
+
+def test_non_enum_profile_capability_is_rejected():
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        ConformanceProfile(
+            profile_id="transactions",
+            capability="transactions",  # type: ignore[arg-type]
+            sync_cases=(SyncCase("x.y", "d", "instrumented", _noop_case),),
+        )
+    assert "AdapterCapability" in str(exc_info.value)
+
+
+def test_non_enum_capability_catalog_key_is_rejected():
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.smoke", "d", "instrumented", _noop_case),),
+    )
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        validate_capability_catalog({"transactions": profile})  # type: ignore[dict-item]
+    assert "AdapterCapability member" in str(exc_info.value)
+
+
+# ------------------------------------------------------------------ framework assertion helpers
+
+
+def test_check_event_order_helper_reports_the_observed_order(isolated_registry):
+    _register_mock_sync()
+    ctx = SyncCaseContext(MockSyncConformanceHarness(), CORE_SYNC, "helper.check-order", {})
+    connection = RecordingConnection()
+    commands = ctx.instrumented_commands(connection)
+    commands.query("SELECT id, label FROM t")
+
+    observed = connection.log.kinds()
+    ctx.check_event_order(connection.log, observed)
+
+    with pytest.raises(CaseCheckError) as exc_info:
+        ctx.check_event_order(connection.log, ("execute",))
+    assert "expected driver interaction order" in str(exc_info.value)
+
+
+def test_conformance_failure_error_tolerates_a_report_without_failures():
+    report = ConformanceReport(
+        profile_id=CORE_SYNC,
+        adapter_name="mock",
+        command_class_name="Mock",
+        results=(CaseResult(CORE_SYNC, "some.case", True),),
+    )
+    error = ConformanceFailureError(report)
+    assert error.failures == ()
+    assert "0 conformance case(s) failed" in str(error)
+
+
+# ------------------------------------------------------------------ instrumentation internals
+
+
+def test_recording_cursor_records_executemany_through_the_command_class(isolated_registry):
+    connection = RecordingConnection(CursorScript())
+    commands = MockSyncConformanceCommands(connection)
+    affected = commands.execute(
+        "INSERT INTO t (id, label) VALUES (?id?, ?label?)",
+        params=[{"id": 1, "label": "a"}, {"id": 2, "label": "b"}],
+    )
+    event = connection.log.first("executemany")
+    assert event is not None
+    assert event.params == [(1, "a"), (2, "b")], "the driver must observe one bound tuple per record"
+    assert affected == 2, "the default script derives the rowcount from the executemany length"
+
+
+def test_recording_cursor_can_script_a_fixed_executemany_rowcount(isolated_registry):
+    connection = RecordingConnection(CursorScript(rowcount_from_executemany_length=False, rowcount=7))
+    commands = MockSyncConformanceCommands(connection)
+    affected = commands.execute("INSERT INTO t (id, label) VALUES (?id?, ?label?)", params=[{"id": 1, "label": "a"}])
+    assert affected == 7
+
+
+def test_recording_cursor_injects_scripted_interaction_failures():
+    boom = RuntimeError("scripted failure")
+    connection = RecordingConnection(
+        CursorScript(executemany_error=boom, fetchone_error=boom, fetchmany_error=boom),
+        cursor_style="plain",
+    )
+    cursor = connection.cursor()
+    with pytest.raises(RuntimeError):
+        cursor.executemany("INSERT INTO t (id) VALUES (%s)", [(1,)])
+    with pytest.raises(RuntimeError):
+        cursor.fetchone()
+    with pytest.raises(RuntimeError):
+        cursor.fetchmany(2)
+
+
+@pytest.mark.asyncio
+async def test_recording_async_cursor_records_executemany_through_the_command_class():
+    connection = RecordingAsyncConnection(CursorScript())
+    commands = MockAsyncConformanceCommands(connection)
+    affected = await commands.execute_async(
+        "INSERT INTO t (id, label) VALUES (?id?, ?label?)",
+        params=[{"id": 1, "label": "a"}, {"id": 2, "label": "b"}],
+    )
+    event = connection.log.first("executemany")
+    assert event is not None
+    assert event.params == [(1, "a"), (2, "b")]
+    assert affected == 2
+
+
+def test_recording_connections_accept_a_sequence_of_scripts():
+    """A per-cursor script sequence lets one case drive differently-behaving cursors."""
+    scripts = [CursorScript(rowcount=1), CursorScript(rowcount=2)]
+
+    connection = RecordingConnection(scripts)
+    connection.cursor()
+    connection.cursor()
+    assert [recorder.script.rowcount for recorder in connection.recorders] == [1, 2]
+
+    async_connection = RecordingAsyncConnection(scripts)
+    assert async_connection.cursor_calls == 0
+
+
+# ------------------------------------------------------------------ connect() cleanup tolerance
+
+
+class _CloselessFakeConnection(FakeSyncConnection):
+    """Exposes no callable ``close``, like a pooled/managed connection handle."""
+
+    close = None  # type: ignore[assignment]
+
+
+class _RaisingCloseFakeConnection(FakeSyncConnection):
+    def close(self):
+        raise RuntimeError("close boom")
+
+
+class _CloselessConnectCommands(MockSyncConformanceCommands):
+    @classmethod
+    def connect(cls, parsed_dsn, **connect_kwargs):
+        return cls(_CloselessFakeConnection(seeded_mini_db()))
+
+
+class _RaisingCloseConnectCommands(MockSyncConformanceCommands):
+    @classmethod
+    def connect(cls, parsed_dsn, **connect_kwargs):
+        return cls(_RaisingCloseFakeConnection(seeded_mini_db()))
+
+
+@pytest.mark.parametrize(
+    "commands_class",
+    [_CloselessConnectCommands, _RaisingCloseConnectCommands],
+    ids=["no-close", "close-raises"],
+)
+def test_dsn_connect_case_tolerates_unclosable_connections(isolated_registry, commands_class):
+    """The connect() case verifies the adapter, never the connection's close behavior."""
+    name = f"conformance-mock-{commands_class.__name__.strip(chr(95)).lower()}"
+    _register_mock_sync(name=name, commands=commands_class)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = commands_class
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return commands_class(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "registration.dsn-connect")
+    assert named.passed, named.message
+
+
+class _CloselessFakeAsyncConnection(FakeAsyncConnection):
+    close = None  # type: ignore[assignment]
+
+
+class _RaisingCloseFakeAsyncConnection(FakeAsyncConnection):
+    def close(self):
+        raise RuntimeError("close boom")
+
+
+class _CloselessConnectAsyncCommands(MockAsyncConformanceCommands):
+    @classmethod
+    async def connect_async(cls, parsed_dsn, **connect_kwargs):
+        return cls(_CloselessFakeAsyncConnection(seeded_mini_db()))
+
+
+class _RaisingCloseConnectAsyncCommands(MockAsyncConformanceCommands):
+    @classmethod
+    async def connect_async(cls, parsed_dsn, **connect_kwargs):
+        return cls(_RaisingCloseFakeAsyncConnection(seeded_mini_db()))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "commands_class",
+    [_CloselessConnectAsyncCommands, _RaisingCloseConnectAsyncCommands],
+    ids=["no-close", "close-raises"],
+)
+async def test_async_dsn_connect_case_tolerates_unclosable_connections(isolated_registry, commands_class):
+    name = f"conformance-mock-{commands_class.__name__.strip(chr(95)).lower()}"
+    _register_mock_async(name=name, async_commands=commands_class)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = commands_class
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return commands_class(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    named = next(result for result in report.results if result.case_id == "registration.dsn-connect")
+    assert named.passed, named.message
+
+
+# ------------------------------------------------------------------ adapters that skip the driver
+
+
+class _NoDriverWorkCommands(MockSyncConformanceCommands):
+    """Returns plausible results without ever reaching the driver."""
+
+    def query(self, *args, **kwargs):
+        return []
+
+    def execute(self, *args, **kwargs):
+        return 0
+
+
+class _NoDriverWorkAsyncCommands(MockAsyncConformanceCommands):
+    async def query_async(self, *args, **kwargs):
+        return []
+
+    async def execute_async(self, *args, **kwargs):
+        return 0
+
+
+def test_adapter_that_never_reaches_the_driver_fails_the_binding_cases(isolated_registry):
+    """Binding cases assert on observed driver traffic, so a no-op adapter cannot pass them."""
+    name = "conformance-mock-no-driver-work"
+    _register_mock_sync(name=name, commands=_NoDriverWorkCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _NoDriverWorkCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _NoDriverWorkCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    for case_id in ("params.repeated-placeholders-binding", "execute.nested-list-single-value"):
+        assert case_id in failures, sorted(failures)
+        assert "execute must reach the driver" in failures[case_id]
+
+
+@pytest.mark.asyncio
+async def test_async_adapter_that_never_reaches_the_driver_fails_the_binding_cases(isolated_registry):
+    name = "conformance-mock-no-driver-work-async"
+    _register_mock_async(name=name, async_commands=_NoDriverWorkAsyncCommands)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _NoDriverWorkAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _NoDriverWorkAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    for case_id in ("params.repeated-placeholders-binding", "execute.nested-list-single-value"):
+        assert case_id in failures, sorted(failures)
+        assert "execute must reach the driver" in failures[case_id]
+
+
+# ------------------------------------------------------------------ capability declaration honesty
+
+
+class _NonEnumMemberCommands(MockSyncConformanceCommands):
+    capabilities = frozenset({"transactions"})  # type: ignore[assignment]  # right container, wrong members
+
+
+class _NonEnumMemberAsyncCommands(MockAsyncConformanceCommands):
+    capabilities = frozenset({"transactions"})  # type: ignore[assignment]
+
+
+class _InvalidCapabilityAsyncCommands(MockAsyncConformanceCommands):
+    capabilities = {"transactions"}  # type: ignore[assignment]  # not even a frozenset
+
+
+def test_non_enum_capability_members_fail_both_declaration_cases(isolated_registry):
+    """register_adapter() rejects this declaration outright, so the conformance cases are
+    the backstop for a class that was never registered through the public path."""
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = "conformance-mock-non-enum-caps"
+        command_class = _NonEnumMemberCommands
+
+        def create_commands(self):
+            return _NonEnumMemberCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    assert "non-AdapterCapability member" in failures["capabilities.declaration-valid"]
+    assert "non-enum member" in failures["capabilities.declared-profile-populated"]
+
+
+@pytest.mark.asyncio
+async def test_async_non_enum_capability_members_fail_both_declaration_cases(isolated_registry):
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = "conformance-mock-non-enum-caps-async"
+        command_class = _NonEnumMemberAsyncCommands
+
+        async def create_commands(self):
+            return _NonEnumMemberAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    assert "non-AdapterCapability member" in failures["capabilities.declaration-valid"]
+    assert "non-enum member" in failures["capabilities.declared-profile-populated"]
+
+
+@pytest.mark.asyncio
+async def test_async_invalid_capability_declaration_fails_clearly(isolated_registry):
+    """A non-frozenset declaration fails loudly and is ignored by the option probes."""
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = "conformance-mock-invalid-caps-async"
+        command_class = _InvalidCapabilityAsyncCommands
+
+        async def create_commands(self):
+            return _InvalidCapabilityAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    assert "frozenset" in failures["capabilities.declaration-valid"]
+    assert "invalid declaration" in failures["capabilities.declared-profile-populated"]
+    # an unreadable declaration waives nothing: the option probes still ran and passed
+    assert "options.unsupported-raises" not in failures
+    assert "options.unsupported-before-driver-work" not in failures
+
+
+# ------------------------------------------------------------------ a shipped capability waives its probe
+
+
+class _DeclaredTimeoutCommands(MockSyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.COMMAND_TIMEOUT})
+
+
+class _DeclaredTimeoutAsyncCommands(MockAsyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.COMMAND_TIMEOUT})
+
+
+class _DeclaredTransactionsAsyncCommands(MockAsyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+
+def _profile_for(capability, *, sync=True, async_=True):
+    return ConformanceProfile(
+        profile_id=capability.value,
+        capability=capability,
+        sync_cases=(SyncCase(f"{capability.value}.smoke", "d", "instrumented", _noop_case),) if sync else (),
+        async_cases=(AsyncCase(f"{capability.value}.smoke", "d", "instrumented", _async_noop_case),) if async_ else (),
+    )
+
+
+async def _async_noop_case(ctx):
+    return None
+
+
+def test_a_shipped_capability_profile_waives_its_option_probe(isolated_registry, monkeypatch):
+    """Once a capability ships a real production profile, its option probe is waived —
+    the adapter is expected to implement the option rather than reject it."""
+    from pydapper.testing.adapter_conformance import _cases_sync
+
+    name = "conformance-mock-shipped-timeout"
+    _register_mock_sync(name=name, commands=_DeclaredTimeoutCommands)
+    shipped = {AdapterCapability.COMMAND_TIMEOUT: _profile_for(AdapterCapability.COMMAND_TIMEOUT)}
+    monkeypatch.setattr(_cases_sync, "capability_profiles", lambda: shipped)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTimeoutCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTimeoutCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+
+
+@pytest.mark.asyncio
+async def test_async_shipped_capability_profile_waives_its_option_probe(isolated_registry, monkeypatch):
+    from pydapper.testing.adapter_conformance import _cases_async
+
+    name = "conformance-mock-shipped-timeout-async"
+    _register_mock_async(name=name, async_commands=_DeclaredTimeoutAsyncCommands)
+    shipped = {AdapterCapability.COMMAND_TIMEOUT: _profile_for(AdapterCapability.COMMAND_TIMEOUT)}
+    monkeypatch.setattr(_cases_async, "capability_profiles", lambda: shipped)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTimeoutAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _DeclaredTimeoutAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+
+
+def test_capability_profile_without_sync_cases_fails_the_sync_declaration(isolated_registry, monkeypatch):
+    """A capability covered only in the other mode does not cover this one."""
+    from pydapper.testing.adapter_conformance import _cases_sync
+
+    name = "conformance-mock-async-only-profile"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    catalog = {AdapterCapability.TRANSACTIONS: _profile_for(AdapterCapability.TRANSACTIONS, sync=False)}
+    monkeypatch.setattr(_cases_sync, "capability_profiles", lambda: catalog)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    assert "no sync conformance cases" in failures["capabilities.declared-profile-populated"]
+
+
+@pytest.mark.asyncio
+async def test_capability_profile_without_async_cases_fails_the_async_declaration(isolated_registry, monkeypatch):
+    from pydapper.testing.adapter_conformance import _cases_async
+
+    name = "conformance-mock-sync-only-profile"
+    _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
+    catalog = {AdapterCapability.TRANSACTIONS: _profile_for(AdapterCapability.TRANSACTIONS, async_=False)}
+    monkeypatch.setattr(_cases_async, "capability_profiles", lambda: catalog)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _DeclaredTransactionsAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failures = {failure.case_id: failure.message for failure in report.failures}
+    assert "no async conformance cases" in failures["capabilities.declared-profile-populated"]
+
+
+@pytest.mark.asyncio
+async def test_async_empty_string_fallback_value_round_trips(isolated_registry):
+    """supports_empty_strings=False swaps in the documented fallback label in async mode too."""
+    _register_mock_async()
+
+    class _Harness(MockAsyncConformanceHarness):
+        supports_empty_strings = False
+
+        async def create_commands(self):
+            return MockAsyncConformanceCommands(FakeAsyncConnection(seeded_mini_db(supports_empty_strings=False)))
+
+    report = await run_core_async(_Harness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+
+
+# ------------------------------------------------------------------ runner shutdown and teardown paths
+
+
+def test_sync_runner_propagates_base_exceptions_after_releasing_resources(isolated_registry):
+    """A KeyboardInterrupt/shutdown is never recorded as a failed case, and the active
+    case's resources are still released before it propagates."""
+    name = "conformance-mock-sync-shutdown"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    torn_down = []
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+        def teardown_commands(self, commands):
+            torn_down.append(commands)
+            super().teardown_commands(commands)
+
+    def _shutdown_case(ctx):
+        ctx.create_commands()
+        raise KeyboardInterrupt("shutdown")
+
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.shutdown", "d", "instrumented", _shutdown_case),),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        run_core_sync(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: profile})
+    assert torn_down, "the interrupted case's live resources must still be released"
+
+
+def test_teardown_reports_the_first_error_across_several_commands(isolated_registry):
+    """When one case builds several commands and every teardown fails, the first failure
+    is the reported one and the remaining commands are still torn down."""
+    name = "conformance-mock-multi-teardown"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    attempts = []
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+        def teardown_commands(self, commands):
+            attempts.append(commands)
+            raise RuntimeError(f"teardown boom {len(attempts)}")
+
+    created = []
+
+    def _two_commands_case(ctx):
+        created.append(ctx.create_commands())
+        created.append(ctx.create_commands())
+
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.two-commands", "d", "instrumented", _two_commands_case),),
+    )
+    report = run_core_sync(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: profile})
+    named = next(result for result in report.results if result.case_id == "transactions.two-commands")
+    assert not named.passed
+    assert len(created) == 2
+    torn_down = [command for command in created if any(command is attempt for attempt in attempts)]
+    assert len(torn_down) == 2, "every created command must be torn down even after the first failure"
+    assert str(named.cause) == f"teardown boom {attempts.index(created[0]) + 1}", "the first failure is reported"
+
+
+@pytest.mark.asyncio
+async def test_async_teardown_failure_fails_a_passing_case(isolated_registry):
+    _register_mock_async()
+
+    class _FailingTeardownHarness(MockAsyncConformanceHarness):
+        async def teardown_commands(self, commands):
+            raise RuntimeError("async teardown boom")
+
+    report = await run_core_async(_FailingTeardownHarness())
+    named = next(result for result in report.results if result.case_id == "params.params-keyword")
+    assert not named.passed
+    assert isinstance(named.cause, RuntimeError)
+    assert "teardown" in named.message
+
+
+def test_capability_catalog_value_must_be_a_profile():
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        validate_capability_catalog({AdapterCapability.TRANSACTIONS: object()})  # type: ignore[dict-item]
+    assert "must be a ConformanceProfile" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_async_declared_capability_without_profile_fails_clearly(isolated_registry):
+    """The async twin of the sync declaration-honesty check, against the real catalog."""
+    name = "conformance-mock-declared-txn-async"
+    _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _DeclaredTransactionsAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failed_ids = [failure.case_id for failure in report.failures]
+    assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
+    assert "has no production conformance profile" in report.failures[0].message
+    assert report.failures[0].profile_id == CORE_ASYNC
+
+
+@pytest.mark.asyncio
+async def test_async_relaxed_rowcounts_still_require_integer_results(isolated_registry):
+    """strict_rowcounts=False relaxes only exact-count equality; the cases still run."""
+    _register_mock_async()
+
+    class _Harness(MockAsyncConformanceHarness):
+        strict_rowcounts = False
+
+    report = await run_core_async(_Harness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+
+
+@pytest.mark.asyncio
+async def test_async_teardown_reports_the_first_error_across_several_commands(isolated_registry):
+    name = "conformance-mock-multi-teardown-async"
+    _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
+    attempts = []
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _DeclaredTransactionsAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+        async def teardown_commands(self, commands):
+            attempts.append(commands)
+            raise RuntimeError(f"async teardown boom {len(attempts)}")
+
+    created = []
+
+    async def _two_commands_case(ctx):
+        created.append(await ctx.create_commands())
+        created.append(await ctx.create_commands())
+
+    profile = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        async_cases=(AsyncCase("transactions.two-commands", "d", "instrumented", _two_commands_case),),
+    )
+    report = await run_core_async(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: profile})
+    named = next(result for result in report.results if result.case_id == "transactions.two-commands")
+    assert not named.passed
+    assert len(created) == 2
+    torn_down = [command for command in created if any(command is attempt for attempt in attempts)]
+    assert len(torn_down) == 2, "every created command must be torn down even after the first failure"

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -1,0 +1,876 @@
+"""Framework self-tests for the reusable adapter conformance suite.
+
+Pytest is allowed here (repository tests), never in the shipped helper. Coverage in
+this module is service-free: mock harnesses over a pure-Python fake driver, a real
+in-memory SQLite harness, instrumented concrete first-party classes, negative
+broken-adapter tests, packaging/drift invariants, and import hygiene.
+"""
+
+import dataclasses
+import importlib.metadata
+import re
+import subprocess
+import sys
+import tarfile
+import textwrap
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import pydapper
+from pydapper import _adapter_discovery
+from pydapper import main
+from pydapper._context import _AwaitableAsyncContextManager as _RealAwaitableAsyncContextManager
+from pydapper.bigquery import GoogleBigqueryClientCommands
+from pydapper.capabilities import AdapterCapability
+from pydapper.commands import Commands
+from pydapper.exceptions import MoreThanOneResultException
+from pydapper.mssql import PymssqlCommands
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.oracle import OracledbCommands
+from pydapper.postgresql import AiopgCommands
+from pydapper.postgresql import Psycopg2Commands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.sqlite import Sqlite3Commands
+from pydapper.testing.adapter_conformance import CORE_ASYNC
+from pydapper.testing.adapter_conformance import CORE_SYNC
+from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import CaseResult
+from pydapper.testing.adapter_conformance import ConformanceFailureError
+from pydapper.testing.adapter_conformance import ConformanceProfile
+from pydapper.testing.adapter_conformance import HarnessDefinitionError
+from pydapper.testing.adapter_conformance import ProfileDefinitionError
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import SyncCase
+from pydapper.testing.adapter_conformance import capability_profiles
+from pydapper.testing.adapter_conformance import core_async_profile
+from pydapper.testing.adapter_conformance import core_sync_profile
+from pydapper.testing.adapter_conformance import run_core_async
+from pydapper.testing.adapter_conformance import run_core_sync
+from pydapper.testing.adapter_conformance._instrumentation import CursorScript
+from pydapper.testing.adapter_conformance._instrumentation import RecordingAsyncConnection
+from pydapper.testing.adapter_conformance._instrumentation import RecordingConnection
+from pydapper.testing.adapter_conformance._instrumentation import SynchronousCursorRecordingAsyncConnection
+from pydapper.testing.adapter_conformance._profiles import validate_capability_catalog
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import MOCK_ASYNC_ADAPTER_NAME
+from tests.conformance_support import MOCK_SYNC_ADAPTER_NAME
+from tests.conformance_support import FakeAsyncConnection
+from tests.conformance_support import FakeSyncConnection
+from tests.conformance_support import MockAsyncConformanceCommands
+from tests.conformance_support import MockAsyncConformanceHarness
+from tests.conformance_support import MockSyncConformanceCommands
+from tests.conformance_support import MockSyncConformanceHarness
+from tests.conformance_support import Sqlite3ConformanceHarness
+from tests.conformance_support import seeded_mini_db
+
+pytestmark = pytest.mark.core
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GROUP = "pydapper.adapters"
+
+
+def _canonicalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Snapshot-and-restore isolation for the global adapter registry state."""
+    registry = main._adapter_registry.copy()
+    monkeypatch.setattr(main, "_adapter_registry", registry)
+    monkeypatch.setattr(_adapter_discovery, "_catalog", None)
+    monkeypatch.setattr(main, "_loaded_provider_registrations", {})
+    yield registry
+
+
+def _register_mock_sync(name=MOCK_SYNC_ADAPTER_NAME, commands=MockSyncConformanceCommands):
+    pydapper.register_adapter(
+        name,
+        commands=commands,
+        using_connection_predicate=lambda connection: isinstance(connection, FakeSyncConnection),
+    )
+
+
+def _register_mock_async(name=MOCK_ASYNC_ADAPTER_NAME, async_commands=MockAsyncConformanceCommands):
+    pydapper.register_adapter(
+        name,
+        async_commands=async_commands,
+        using_connection_predicate=lambda connection: isinstance(connection, FakeAsyncConnection),
+    )
+
+
+# ------------------------------------------------------------------ import surface
+
+
+def test_documented_helper_imports():
+    import pydapper.testing.adapter_conformance as helper
+
+    for symbol in helper.__all__:
+        assert getattr(helper, symbol, None) is not None, symbol
+    assert helper.CORE_SYNC == "core-sync"
+    assert helper.CORE_ASYNC == "core-async"
+
+
+def test_no_conformance_symbol_on_package_root():
+    for name in (
+        "run_core_sync",
+        "run_core_async",
+        "SyncAdapterHarness",
+        "AsyncAdapterHarness",
+        "ConformanceReport",
+        "ConformanceError",
+        "adapter_conformance",
+    ):
+        assert name not in vars(pydapper), f"package root must not re-export {name}"
+
+    script = textwrap.dedent("""
+        import pydapper
+        import sys
+        assert "pydapper.testing" not in sys.modules, "plain import pydapper must not import pydapper.testing"
+        assert not hasattr(pydapper, "run_core_sync")
+        print("OK")
+        """)
+    completed = subprocess.run([sys.executable, "-c", script], cwd=REPO_ROOT, capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    assert "OK" in completed.stdout
+
+
+def test_helper_import_is_dependency_clean():
+    """Importing the shipped helper must not load pytest, tests, testcontainers, or drivers."""
+    script = textwrap.dedent("""
+        import sys
+
+        BANNED = {
+            "pytest",
+            "_pytest",
+            "tests",
+            "testcontainers",
+            "faker",
+            "psycopg2",
+            "psycopg",
+            "aiopg",
+            "mysql",
+            "pymssql",
+            "oracledb",
+            "google",
+            "sqlalchemy",
+        }
+
+        class Guard:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.split(".")[0] in BANNED:
+                    raise ImportError(f"forbidden import during conformance-helper import: {fullname}")
+                return None
+
+        sys.meta_path.insert(0, Guard())
+        import pydapper.testing.adapter_conformance  # noqa: F401
+
+        loaded = sorted(name for name in sys.modules if name.split(".")[0] in BANNED)
+        assert not loaded, f"banned modules loaded: {loaded}"
+        print("OK")
+        """)
+    completed = subprocess.run([sys.executable, "-c", script], cwd=REPO_ROOT, capture_output=True, text=True)
+    assert completed.returncode == 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "OK" in completed.stdout
+
+
+# ------------------------------------------------------------------ passing harnesses
+
+
+def test_mock_sync_harness_passes(isolated_registry):
+    _register_mock_sync()
+    report = run_core_sync(MockSyncConformanceHarness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert report.profile_id == CORE_SYNC
+    assert report.adapter_name == MOCK_SYNC_ADAPTER_NAME
+    assert len(report.results) == len(core_sync_profile().sync_cases)
+
+
+@pytest.mark.asyncio
+async def test_mock_async_harness_passes(isolated_registry):
+    _register_mock_async()
+    report = await run_core_async(MockAsyncConformanceHarness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert report.profile_id == CORE_ASYNC
+    assert len(report.results) == len(core_async_profile().async_cases)
+
+
+def test_sqlite_in_memory_core_sync_harness_passes(isolated_registry, tmp_path):
+    report = run_core_sync(Sqlite3ConformanceHarness(tmp_path))
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert report.adapter_name == "sqlite3"
+    assert report.command_class_name.endswith("Sqlite3Commands")
+
+
+def test_pass_fail_ordering_is_deterministic(isolated_registry):
+    _register_mock_sync()
+    first = run_core_sync(MockSyncConformanceHarness())
+    second = run_core_sync(MockSyncConformanceHarness())
+    declared_order = [case.case_id for case in core_sync_profile().sync_cases]
+    assert [result.case_id for result in first.results] == declared_order
+    assert [result.case_id for result in second.results] == declared_order
+
+
+def test_raise_for_failures_raises_structured_error(isolated_registry):
+    class _NoFactoryHarness(SyncAdapterHarness):
+        adapter_name = MOCK_SYNC_ADAPTER_NAME
+        command_class = MockSyncConformanceCommands
+        connect_dsn = MockSyncConformanceHarness.connect_dsn
+
+    _register_mock_sync()
+    report = run_core_sync(_NoFactoryHarness())
+    with pytest.raises(ConformanceFailureError) as exc_info:
+        report.raise_for_failures()
+    assert exc_info.value.report is report
+    assert exc_info.value.failures == report.failures
+    assert exc_info.value.failures
+
+
+# ------------------------------------------------------------------ broken adapters fail named cases
+
+
+class _BrokenRowMappingCommands(MockSyncConformanceCommands):
+    """Deliberately corrupts row mapping while keeping row counts intact."""
+
+    def query(self, sql, *args, **kwargs):
+        result = super().query(sql, *args, **kwargs)
+        if isinstance(result, list):
+            return [{"broken": index} for index, _ in enumerate(result)]
+        return result
+
+
+def test_broken_row_mapper_fails_named_case(isolated_registry):
+    name = "conformance-mock-broken-rows"
+    _register_mock_sync(name=name, commands=_BrokenRowMappingCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _BrokenRowMappingCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _BrokenRowMappingCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    failed_ids = {failure.case_id for failure in report.failures}
+    assert "rows.query-buffered" in failed_ids
+    assert not report.passed
+    passed_ids = {result.case_id for result in report.results if result.passed}
+    assert "execute.rowcount" in passed_ids, "unrelated cases must still pass so failures stay named and narrow"
+    named = next(failure for failure in report.failures if failure.case_id == "rows.query-buffered")
+    assert named.profile_id == CORE_SYNC
+    assert named.message
+
+
+class _LeakingCursorCommands(MockSyncConformanceCommands):
+    """Deliberately leaks every command-owned cursor."""
+
+    @contextmanager
+    def _cursor_context_proxy(self):
+        cursor = self.cursor()
+        enter = getattr(type(cursor), "__enter__", None)
+        if callable(enter):
+            yield enter(cursor)
+        else:
+            yield cursor
+        # no close, no __exit__: the cursor leaks
+
+
+def test_leaking_cursor_fails_named_lifecycle_case(isolated_registry):
+    name = "conformance-mock-leaky"
+    _register_mock_sync(name=name, commands=_LeakingCursorCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _LeakingCursorCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _LeakingCursorCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "lifecycle.context-cursor-success")
+    assert not named.passed
+    assert "cleanup" in named.message
+
+
+class _CleanupMask(Exception):
+    pass
+
+
+class _MaskingCleanupCommands(MockSyncConformanceCommands):
+    """Deliberately replaces an active command error with a cleanup failure."""
+
+    @contextmanager
+    def _cursor_context_proxy(self):
+        with super()._cursor_context_proxy() as cursor:
+            try:
+                yield cursor
+            except Exception:
+                raise _CleanupMask("cleanup failure replaced the active error") from None
+
+
+def test_error_masking_adapter_fails_named_case(isolated_registry):
+    name = "conformance-mock-masking"
+    _register_mock_sync(name=name, commands=_MaskingCleanupCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _MaskingCleanupCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _MaskingCleanupCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "lifecycle.active-error-precedence")
+    assert not named.passed
+    assert isinstance(named.cause, _CleanupMask)
+
+
+class _InvalidCapabilityCommands(MockSyncConformanceCommands):
+    capabilities = {"transactions"}  # type: ignore[assignment]  # deliberately wrong: set of str
+
+
+def test_invalid_capability_declaration_fails_clearly(isolated_registry):
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = "conformance-mock-invalid-caps"
+        command_class = _InvalidCapabilityCommands
+
+        def create_commands(self):
+            return _InvalidCapabilityCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "capabilities.declaration-valid")
+    assert not named.passed
+    assert "frozenset" in named.message
+
+
+class _DeclaredTransactionsCommands(MockSyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+
+def test_declared_capability_without_profile_fails_clearly(isolated_registry):
+    name = "conformance-mock-declared-txn"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+    report = run_core_sync(_Harness())
+    failed_ids = [failure.case_id for failure in report.failures]
+    assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
+    named = report.failures[0]
+    assert "transactions" in named.message
+    assert named.profile_id == CORE_SYNC
+
+
+def test_synthetic_capability_profile_runs_and_satisfies_declaration(isolated_registry):
+    """A test-local synthetic profile proves extension without touching production state."""
+    name = "conformance-mock-synth-txn"
+    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredTransactionsCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+
+    ran = []
+
+    def _txn_case(ctx):
+        ran.append(ctx.case_id)
+        commands = ctx.command_class(FakeSyncConnection())
+        ctx.check(commands.supports(AdapterCapability.TRANSACTIONS), "declared capability must be supported")
+
+    synthetic = ConformanceProfile(
+        profile_id="transactions",
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=(SyncCase("transactions.smoke", "synthetic transactions case", "instrumented", _txn_case),),
+    )
+    report = run_core_sync(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: synthetic})
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert ran == ["transactions.smoke"]
+    synthetic_results = [result for result in report.results if result.profile_id == "transactions"]
+    assert [result.case_id for result in synthetic_results] == ["transactions.smoke"]
+    assert capability_profiles() == {}, "the production catalog must stay empty until a capability ships"
+
+
+def test_production_capability_catalog_is_empty_and_immutable():
+    catalog = capability_profiles()
+    assert dict(catalog) == {}
+    with pytest.raises(TypeError):
+        catalog[AdapterCapability.TRANSACTIONS] = None  # type: ignore[index]
+
+
+def test_zero_case_profile_is_rejected():
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        ConformanceProfile(profile_id="transactions", capability=AdapterCapability.TRANSACTIONS)
+    assert exc_info.value.profile_id == "transactions"
+
+
+def test_duplicate_case_ids_are_rejected():
+    def _noop(ctx):
+        return None
+
+    cases = (
+        SyncCase("dup.case", "first", "instrumented", _noop),
+        SyncCase("dup.case", "second", "instrumented", _noop),
+    )
+    with pytest.raises(ProfileDefinitionError):
+        ConformanceProfile(profile_id="core-sync", capability=None, sync_cases=cases)
+
+
+def test_mismatched_capability_catalog_key_is_rejected(isolated_registry):
+    _register_mock_sync()
+
+    def _noop(ctx):
+        return None
+
+    profile = ConformanceProfile(
+        profile_id="raw-reader",
+        capability=AdapterCapability.RAW_READER,
+        sync_cases=(SyncCase("raw.smoke", "d", "instrumented", _noop),),
+    )
+    with pytest.raises(ProfileDefinitionError):
+        validate_capability_catalog({AdapterCapability.TRANSACTIONS: profile})
+    with pytest.raises(ProfileDefinitionError):
+        run_core_sync(MockSyncConformanceHarness(), capability_catalog={AdapterCapability.TRANSACTIONS: profile})
+
+
+# ------------------------------------------------------------------ harness validation
+
+
+def test_missing_factory_reports_profile_case_and_field(isolated_registry):
+    class _NoFactoryHarness(SyncAdapterHarness):
+        adapter_name = MOCK_SYNC_ADAPTER_NAME
+        command_class = MockSyncConformanceCommands
+        connect_dsn = MockSyncConformanceHarness.connect_dsn
+
+    _register_mock_sync()
+    report = run_core_sync(_NoFactoryHarness())
+    factory_failures = [failure for failure in report.failures if failure.missing_field == "create_commands"]
+    assert factory_failures, "live cases must fail with the missing harness field"
+    sample = factory_failures[0]
+    assert sample.profile_id == CORE_SYNC
+    assert sample.case_id
+    assert "create_commands" in sample.message
+    for failure in factory_failures:
+        assert failure.missing_field == "create_commands"
+
+
+def test_missing_teardown_reports_missing_field(isolated_registry):
+    class _NoTeardownHarness(SyncAdapterHarness):
+        adapter_name = MOCK_SYNC_ADAPTER_NAME
+        command_class = MockSyncConformanceCommands
+        connect_dsn = MockSyncConformanceHarness.connect_dsn
+
+        def create_commands(self):
+            return MockSyncConformanceCommands(FakeSyncConnection(seeded_mini_db()))
+
+    _register_mock_sync()
+    report = run_core_sync(_NoTeardownHarness())
+    assert any(failure.missing_field == "teardown_commands" for failure in report.failures)
+
+
+def test_missing_connect_dsn_reports_missing_field(isolated_registry):
+    class _NoDsnHarness(MockSyncConformanceHarness):
+        connect_dsn = None
+
+    _register_mock_sync()
+    report = run_core_sync(_NoDsnHarness())
+    named = next(result for result in report.results if result.case_id == "registration.dsn-connect")
+    assert not named.passed
+    assert named.missing_field == "connect_dsn"
+
+
+def test_missing_adapter_name_fails_before_any_case():
+    class _AnonymousHarness(SyncAdapterHarness):
+        command_class = MockSyncConformanceCommands
+
+    with pytest.raises(HarnessDefinitionError) as exc_info:
+        run_core_sync(_AnonymousHarness())
+    assert exc_info.value.missing_field == "adapter_name"
+    assert exc_info.value.profile_id == CORE_SYNC
+
+
+def test_sync_and_async_harnesses_do_not_require_the_opposite_mode():
+    assert not hasattr(SyncAdapterHarness, "cursor_factory_style")
+    sync_members = set(vars(SyncAdapterHarness))
+    assert "create_commands" in sync_members and "teardown_commands" in sync_members
+    # the mock sync harness defines no async member and still passes (see above); the
+    # runners also reject a harness of the opposite mode outright:
+    with pytest.raises(TypeError):
+        run_core_sync(MockAsyncConformanceHarness())  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_async_runner_rejects_sync_harness():
+    with pytest.raises(TypeError):
+        await run_core_async(MockSyncConformanceHarness())  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------------ isolation, cleanup, precedence
+
+
+class _TrackingHarness(MockSyncConformanceHarness):
+    def __init__(self):
+        self.created = []
+        self.torn_down = []
+
+    def create_commands(self):
+        commands = super().create_commands()
+        self.created.append(commands)
+        return commands
+
+    def teardown_commands(self, commands):
+        self.torn_down.append(commands)
+        super().teardown_commands(commands)
+
+
+def test_fresh_case_isolation_and_teardown_after_success(isolated_registry):
+    _register_mock_sync()
+    harness = _TrackingHarness()
+    report = run_core_sync(harness)
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert harness.created, "live cases must create commands"
+    assert len(set(map(id, harness.created))) == len(harness.created), "every case must get a fresh command"
+    assert sorted(map(id, harness.torn_down)) == sorted(map(id, harness.created)), "every created command is torn down"
+    # every live case except registration.dsn-connect (which exercises connect() instead
+    # of the factory) creates at least one fresh command instance
+    live_case_count = sum(1 for case in core_sync_profile().sync_cases if case.kind == "live")
+    assert len(harness.created) >= live_case_count - 1
+
+
+def test_teardown_failure_fails_a_passing_case(isolated_registry):
+    class _FailingTeardownHarness(MockSyncConformanceHarness):
+        def teardown_commands(self, commands):
+            raise RuntimeError("teardown boom")
+
+    _register_mock_sync()
+    report = run_core_sync(_FailingTeardownHarness())
+    named = next(result for result in report.results if result.case_id == "params.params-keyword")
+    assert not named.passed
+    assert isinstance(named.cause, RuntimeError)
+    assert "teardown" in named.message
+
+
+def test_case_failure_takes_precedence_over_teardown_failure(isolated_registry):
+    name = "conformance-mock-broken-and-leaky-teardown"
+    _register_mock_sync(name=name, commands=_BrokenRowMappingCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _BrokenRowMappingCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _BrokenRowMappingCommands(FakeSyncConnection(seeded_mini_db()))
+
+        def teardown_commands(self, commands):
+            raise RuntimeError("teardown boom")
+
+    report = run_core_sync(_Harness())
+    named = next(result for result in report.results if result.case_id == "rows.query-buffered")
+    assert not named.passed
+    assert "teardown" not in named.message, "the active case failure must be preserved"
+    assert isinstance(named.cleanup_error, RuntimeError), "the teardown failure is retained as structured info"
+
+
+def test_adapter_code_cannot_declare_its_own_case_passed(isolated_registry):
+    from pydapper.testing.adapter_conformance._results import CaseCheckError
+
+    class _SelfPassingHarness(MockSyncConformanceHarness):
+        def create_commands(self):
+            raise CaseCheckError("adapter pretends everything is fine")
+
+    _register_mock_sync()
+    report = run_core_sync(_SelfPassingHarness())
+    live_case_ids = {case.case_id for case in core_sync_profile().sync_cases if case.kind == "live"}
+    live_case_ids.discard("registration.dsn-connect")  # exercises connect(), not the factory
+    live_results = [result for result in report.results if result.case_id in live_case_ids]
+    assert live_results
+    assert all(not result.passed for result in live_results), "raising framework errors must never mark a case passed"
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.results[0].passed = True  # type: ignore[misc]
+
+
+# ------------------------------------------------------------------ concrete first-party classes (service-free)
+
+
+_SYNC_CONCRETE_CLASSES = [
+    Sqlite3Commands,
+    Psycopg2Commands,
+    Psycopg3Commands,
+    MySqlConnectorPythonCommands,
+    PymssqlCommands,
+    OracledbCommands,
+    GoogleBigqueryClientCommands,
+]
+
+
+@pytest.mark.parametrize("command_class", _SYNC_CONCRETE_CLASSES, ids=lambda cls: cls.__name__)
+def test_concrete_sync_class_lifecycle_over_instrumented_connection(command_class):
+    connection = RecordingConnection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = command_class(connection)
+    rows = commands.query("SELECT id, label FROM t")
+    assert rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}]
+    assert connection.cursor_calls == 1
+    recorder = connection.recorders[0]
+    assert recorder.exit_calls + recorder.close_calls == 1
+
+    fault = RuntimeError("boom")
+    failing = RecordingConnection(CursorScript(execute_error=fault, exit_error=ValueError("cleanup")))
+    commands = command_class(failing)
+    with pytest.raises(RuntimeError) as exc_info:
+        commands.query("SELECT id, label FROM t")
+    assert exc_info.value is fault
+    assert failing.recorders[0].exit_calls == 1
+
+
+def test_mysql_query_first_lifecycle_is_exercised_not_bypassed():
+    """The MySQL override must keep its documented drain inside the shared lifecycle."""
+    connection = RecordingConnection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = MySqlConnectorPythonCommands(connection)
+    row = commands.query_first("SELECT id, label FROM t")
+    assert row == {"id": 1, "label": "alpha"}
+    kinds = connection.log.kinds()
+    assert kinds == ("cursor", "enter", "execute", "fetchone", "fetchall", "exit"), kinds
+
+    fault = RuntimeError("execute boom")
+    failing = RecordingConnection(CursorScript(execute_error=fault, exit_error=ValueError("cleanup")))
+    commands = MySqlConnectorPythonCommands(failing)
+    with pytest.raises(RuntimeError) as exc_info:
+        commands.query_first("SELECT id, label FROM t")
+    assert exc_info.value is fault, "the MySQL override must preserve active-error precedence"
+    exit_event = failing.log.first("exit")
+    assert exit_event is not None and exit_event.exc_value is fault
+
+
+class _MySqlUnreadResultCursor:
+    """Plain cursor emulating mysql-connector's unread-result surface."""
+
+    def __init__(self):
+        self.rows = [(1, "a"), (2, "b"), (3, "c")]
+        self.unread_result = True
+        self.drained = False
+        self.reset_calls = []
+        self.rowcount = -1
+        self.closed = 0
+
+    @property
+    def description(self):
+        return (("id", None, None, None, None, None, None), ("label", None, None, None, None, None, None))
+
+    def execute(self, sql, parameters=None):
+        return None
+
+    def executemany(self, sql, seq_of_parameters=None):
+        return None
+
+    def reset(self, free=False):
+        self.reset_calls.append(free)
+        raise TypeError("emulates drivers whose reset() takes no arguments on retry")
+
+    def fetchmany(self, size=1):
+        taken = self.rows[:size]
+        del self.rows[:size]
+        return taken
+
+    def fetchone(self):
+        if not self.rows:
+            return None
+        return self.rows.pop(0)
+
+    def fetchall(self):
+        self.drained = True
+        self.unread_result = False
+        remaining = self.rows
+        self.rows = []
+        return remaining
+
+    def close(self):
+        self.closed += 1
+
+
+def test_mysql_query_single_drains_unread_results_before_raising():
+    cursor = _MySqlUnreadResultCursor()
+
+    class _Connection:
+        def cursor(self, *args, **kwargs):
+            return cursor
+
+    commands = MySqlConnectorPythonCommands(_Connection())
+    with pytest.raises(MoreThanOneResultException):
+        commands.query_single("SELECT id, label FROM t")
+    assert cursor.drained, "the documented unread-result drain must run before the cardinality error"
+    assert cursor.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_psycopg3_async_cursor_normalization_over_instrumented_connection():
+    connection = SynchronousCursorRecordingAsyncConnection(CursorScript(rows=((1, "alpha"),)))
+    commands = Psycopg3CommandsAsync(connection)
+    wrapper = commands.cursor()
+    assert isinstance(wrapper, _RealAwaitableAsyncContextManager)
+    cursor = await wrapper
+    assert cursor is connection.cursors[0]
+
+    connection = SynchronousCursorRecordingAsyncConnection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = Psycopg3CommandsAsync(connection)
+    rows = await commands.query_async("SELECT id, label FROM t")
+    assert rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}]
+    assert connection.recorders[0].exit_calls == 1
+
+    fault = RuntimeError("boom")
+    failing = SynchronousCursorRecordingAsyncConnection(CursorScript(execute_error=fault, exit_error=ValueError("x")))
+    commands = Psycopg3CommandsAsync(failing)
+    with pytest.raises(RuntimeError) as exc_info:
+        await commands.query_async("SELECT id, label FROM t")
+    assert exc_info.value is fault
+
+
+@pytest.mark.asyncio
+async def test_aiopg_commands_over_instrumented_connection():
+    connection = RecordingAsyncConnection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = AiopgCommands(connection)
+    rows = await commands.query_async("SELECT id, label FROM t")
+    assert rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}]
+    assert connection.recorders[0].exit_calls == 1
+
+    # aiopg emulates executemany by looping execute and summing rowcounts
+    connection = RecordingAsyncConnection(CursorScript(rowcount=1))
+    commands = AiopgCommands(connection)
+    count = await commands.execute_async(
+        "INSERT INTO t (id) VALUES (?id?)",
+        params=[{"id": 1}, {"id": 2}],
+    )
+    assert count == 2
+    assert connection.log.count("execute") == 2
+    assert connection.log.count("executemany") == 0
+
+
+# ------------------------------------------------------------------ first-party drift invariants
+
+
+def _installed_first_party_registrations(isolated_registry):
+    entry_points = [
+        entry_point
+        for entry_point in importlib.metadata.entry_points(group=GROUP)
+        if entry_point.dist is not None and _canonicalize(entry_point.dist.name) == "pydapper"
+    ]
+    assert entry_points, "the pydapper distribution must declare installed adapter entry points"
+    for entry_point in entry_points:
+        callback = entry_point.load()
+        callback()
+    registrations = {}
+    for entry_point in entry_points:
+        record = isolated_registry[entry_point.name]
+        if record.commands is not None:
+            registrations[(entry_point.name, "sync")] = record.commands
+        if record.async_commands is not None:
+            registrations[(entry_point.name, "async")] = record.async_commands
+    return registrations
+
+
+def test_every_installed_first_party_mode_has_a_conformance_entry(isolated_registry):
+    installed = _installed_first_party_registrations(isolated_registry)
+    assert set(installed) == set(FIRST_PARTY_CONFORMANCE_ENTRIES), (
+        "every installed first-party adapter mode must have exactly one conformance entry; "
+        f"installed={sorted(installed)}, entries={sorted(FIRST_PARTY_CONFORMANCE_ENTRIES)}"
+    )
+    for key, command_class in installed.items():
+        entry = FIRST_PARTY_CONFORMANCE_ENTRIES[key]
+        assert entry.command_class is command_class, key
+        assert entry.adapter_name == key[0]
+        assert entry.mode == key[1]
+
+
+def test_every_conformance_entry_module_exists_and_targets_its_adapter():
+    for (name, mode), entry in FIRST_PARTY_CONFORMANCE_ENTRIES.items():
+        module_path = REPO_ROOT / entry.test_module
+        assert module_path.is_file(), f"missing conformance entry module {entry.test_module}"
+        text = module_path.read_text()
+        assert f'"{name}"' in text, (name, mode)
+        expected_runner = "run_core_sync" if mode == "sync" else "run_core_async"
+        assert expected_runner in text, (name, mode)
+        assert "FIRST_PARTY_CONFORMANCE_ENTRIES" in text, (name, mode)
+
+
+def test_every_declared_first_party_capability_has_a_populated_profile(isolated_registry):
+    installed = _installed_first_party_registrations(isolated_registry)
+    catalog = capability_profiles()
+    for (name, mode), command_class in installed.items():
+        declared = command_class.capabilities
+        assert isinstance(declared, frozenset), (name, mode)
+        for member in declared:
+            assert member in catalog, f"{name}/{mode} declares {member.value!r} without a conformance profile"
+            profile = catalog[member]
+            cases = profile.sync_cases if mode == "sync" else profile.async_cases
+            assert cases, f"{name}/{mode} declares {member.value!r} but its profile has no {mode} cases"
+
+
+# ------------------------------------------------------------------ built artifacts carry the helper
+
+
+def test_built_wheel_and_sdist_ship_the_conformance_helper(tmp_path):
+    import shutil
+
+    poetry = shutil.which("poetry")
+    assert poetry is not None, "the poetry executable is required to build the artifacts under test"
+    completed = subprocess.run(
+        [poetry, "build", "--output", str(tmp_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, f"poetry build failed:\n{completed.stdout}\n{completed.stderr}"
+
+    [wheel_path] = tmp_path.glob("pydapper-*.whl")
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+    for member in (
+        "pydapper/testing/__init__.py",
+        "pydapper/testing/adapter_conformance/__init__.py",
+        "pydapper/testing/adapter_conformance/_runner.py",
+        "pydapper/testing/adapter_conformance/_cases_sync.py",
+        "pydapper/testing/adapter_conformance/_cases_async.py",
+    ):
+        assert member in names, f"wheel is missing {member}"
+
+    [sdist_path] = tmp_path.glob("pydapper-*.tar.gz")
+    with tarfile.open(sdist_path) as sdist:
+        sdist_names = {"/".join(name.split("/")[1:]) for name in sdist.getnames()}
+    for member in (
+        "pydapper/testing/__init__.py",
+        "pydapper/testing/adapter_conformance/__init__.py",
+        "pydapper/testing/adapter_conformance/_runner.py",
+    ):
+        assert member in sdist_names, f"sdist is missing {member}"
+
+
+# ------------------------------------------------------------------ documented examples actually run
+
+
+@pytest.mark.parametrize(
+    "example",
+    ["docs_src/adapter_conformance/sync_example.py", "docs_src/adapter_conformance/async_example.py"],
+)
+def test_documented_third_party_examples_run_as_shown(example):
+    path = REPO_ROOT / example
+    assert path.is_file(), f"documented example {example} is missing"
+    completed = subprocess.run([sys.executable, str(path)], cwd=REPO_ROOT, capture_output=True, text=True)
+    assert completed.returncode == 0, f"{example} failed:\n{completed.stdout}\n{completed.stderr}"
+    assert "import pytest" not in path.read_text(), "documented examples must not require pytest"

--- a/tests/test_bigquery/test_conformance.py
+++ b/tests/test_bigquery/test_conformance.py
@@ -27,13 +27,13 @@ class _BigQueryConformanceHarness(SyncAdapterHarness):
 
     def __init__(self, client):
         self._client = client
-        self.connect_kwargs = {"client": client}  # type: ignore[misc]
+        self.connect_kwargs = {"client": client}
 
     def create_commands(self) -> Commands:
         from google.cloud.bigquery.dbapi import connect
 
         # a unique fully-qualified table per case keeps emulator state isolated
-        self.table_name = f"pydapper.pydapper.conformance_{uuid4().hex}"  # type: ignore[misc]
+        self.table_name = f"pydapper.pydapper.conformance_{uuid4().hex}"
         commands = GoogleBigqueryClientCommands(connect(client=self._client))
         commands.execute(f"CREATE TABLE `{self.table_name}` (id INT64, label STRING, score INT64, note STRING)")
         self._seed(commands)

--- a/tests/test_bigquery/test_conformance.py
+++ b/tests/test_bigquery/test_conformance.py
@@ -1,0 +1,46 @@
+from uuid import uuid4
+
+import pytest
+
+from pydapper.bigquery import GoogleBigqueryClientCommands
+from pydapper.commands import Commands
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import seed_through_adapter
+
+pytestmark = pytest.mark.bigquery
+
+
+class _BigQueryConformanceHarness(SyncAdapterHarness):
+    adapter_name = "google"
+    command_class = GoogleBigqueryClientCommands
+    # the goccy bigquery-emulator reports unreliable DML rowcounts, so exact-count
+    # equality is relaxed; the rowcount cases still run and must return ints
+    strict_rowcounts = False
+    connect_dsn = "bigquery:////"
+
+    def __init__(self, client):
+        self._client = client
+        self.connect_kwargs = {"client": client}  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        from google.cloud.bigquery.dbapi import connect
+
+        # a unique fully-qualified table per case keeps emulator state isolated
+        self.table_name = f"pydapper.pydapper.conformance_{uuid4().hex}"  # type: ignore[misc]
+        commands = GoogleBigqueryClientCommands(connect(client=self._client))
+        commands.execute(f"CREATE TABLE `{self.table_name}` (id INT64, label STRING, score INT64, note STRING)")
+        seed_through_adapter(commands, self.table_name)
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        commands.connection.close()
+
+
+def test_google_core_sync_conformance(client):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("google", "sync")]
+    harness = _BigQueryConformanceHarness(client)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()

--- a/tests/test_bigquery/test_conformance.py
+++ b/tests/test_bigquery/test_conformance.py
@@ -7,9 +7,14 @@ from pydapper.commands import Commands
 from pydapper.testing.adapter_conformance import SyncAdapterHarness
 from pydapper.testing.adapter_conformance import run_core_sync
 from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
-from tests.conformance_support import seed_through_adapter
+from tests.conformance_support import SEED_INSERT
+from tests.conformance_support import seed_records
 
 pytestmark = pytest.mark.bigquery
+
+#: Stand-in bound for the canonical dataset's SQL NULL note while seeding; see
+#: :meth:`_BigQueryConformanceHarness._seed`.
+_NULL_SENTINEL = "__pydapper_null__"
 
 
 class _BigQueryConformanceHarness(SyncAdapterHarness):
@@ -31,8 +36,25 @@ class _BigQueryConformanceHarness(SyncAdapterHarness):
         self.table_name = f"pydapper.pydapper.conformance_{uuid4().hex}"  # type: ignore[misc]
         commands = GoogleBigqueryClientCommands(connect(client=self._client))
         commands.execute(f"CREATE TABLE `{self.table_name}` (id INT64, label STRING, score INT64, note STRING)")
-        seed_through_adapter(commands, self.table_name)
+        self._seed(commands)
         return commands
+
+    def _seed(self, commands: Commands) -> None:
+        """Seed the canonical dataset, working around untyped NULL parameters.
+
+        The BigQuery DBAPI derives each parameter's type from its Python value and
+        rejects an untyped ``None``, so the canonical NULL note is bound as a sentinel
+        and then replaced with a real SQL NULL. The stored dataset is identical to the
+        one every other backend seeds.
+        """
+        records = seed_records()
+        null_ids = [record["id"] for record in records if record["note"] is None]
+        for record in records:
+            if record["note"] is None:
+                record["note"] = _NULL_SENTINEL
+        commands.execute(SEED_INSERT.format(table=self.table_name), params=records)
+        for row_id in null_ids:
+            commands.execute(f"UPDATE {self.table_name} SET note = NULL WHERE id = ?id?", params={"id": row_id})
 
     def teardown_commands(self, commands: Commands) -> None:
         commands.connection.close()

--- a/tests/test_bigquery/testcontainer.py
+++ b/tests/test_bigquery/testcontainer.py
@@ -3,11 +3,16 @@ from testcontainers.core.generic import DockerContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready
 from urllib3.exceptions import ConnectionError
 
+#: Pinned so an upstream release cannot change what CI runs without a commit here.
+#: The other backends inherit their images from the testcontainers classes, which pin
+#: their own defaults; this is the only image the repo names itself.
+BIGQUERY_EMULATOR_IMAGE = "ghcr.io/goccy/bigquery-emulator:0.8.1"
+
 
 class BigQueryEmulatorContainer(DockerContainer):
     def __init__(
         self,
-        image: str = "ghcr.io/goccy/bigquery-emulator:latest",
+        image: str = BIGQUERY_EMULATOR_IMAGE,
         project: str = "default",
         dataset: str = "default",
         **kwargs,

--- a/tests/test_mssql/test_conformance.py
+++ b/tests/test_mssql/test_conformance.py
@@ -27,7 +27,7 @@ class _PymssqlConformanceHarness(SyncAdapterHarness):
             "password": "pydapper!PYDAPPER",
             "database": database_name,
         }
-        self.connect_dsn = f"mssql://sa:pydapper!PYDAPPER@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"mssql://sa:pydapper!PYDAPPER@{server}:{db_port}/{database_name}"
 
     def create_commands(self) -> Commands:
         from pymssql import _pymssql

--- a/tests/test_mssql/test_conformance.py
+++ b/tests/test_mssql/test_conformance.py
@@ -1,0 +1,55 @@
+from contextlib import suppress
+
+import pytest
+
+from pydapper.commands import Commands
+from pydapper.mssql import PymssqlCommands
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import seed_through_adapter
+
+pytestmark = pytest.mark.mssql
+
+_DROP = "DROP TABLE IF EXISTS pydapper_conformance"
+_CREATE = "CREATE TABLE pydapper_conformance (id INT PRIMARY KEY, label NVARCHAR(64), score INT, note NVARCHAR(64))"
+
+
+class _PymssqlConformanceHarness(SyncAdapterHarness):
+    adapter_name = "pymssql"
+    command_class = PymssqlCommands
+
+    def __init__(self, server, db_port, database_name):
+        self._connect_kwargs = {
+            "server": server,
+            "port": db_port,
+            "user": "sa",
+            "password": "pydapper!PYDAPPER",
+            "database": database_name,
+        }
+        self.connect_dsn = f"mssql://sa:pydapper!PYDAPPER@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        from pymssql import _pymssql
+
+        commands = PymssqlCommands(_pymssql.connect(**self._connect_kwargs))
+        commands.execute(_DROP)
+        commands.execute(_CREATE)
+        seed_through_adapter(commands, self.table_name)
+        commands.connection.commit()
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        with suppress(Exception):
+            commands.connection.rollback()
+            commands.execute(_DROP)
+            commands.connection.commit()
+        commands.connection.close()
+
+
+def test_pymssql_core_sync_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("pymssql", "sync")]
+    harness = _PymssqlConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()

--- a/tests/test_mysql/test_conformance.py
+++ b/tests/test_mysql/test_conformance.py
@@ -29,7 +29,7 @@ class _MySqlConformanceHarness(SyncAdapterHarness):
             "password": "pydapper",
             "database": database_name,
         }
-        self.connect_dsn = f"mysql://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"mysql://pydapper:pydapper@{server}:{db_port}/{database_name}"
 
     def create_commands(self) -> Commands:
         import mysql.connector

--- a/tests/test_mysql/test_conformance.py
+++ b/tests/test_mysql/test_conformance.py
@@ -1,0 +1,55 @@
+from contextlib import suppress
+
+import pytest
+
+from pydapper.commands import Commands
+from pydapper.mysql import MySqlConnectorPythonCommands
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import seed_through_adapter
+
+pytestmark = pytest.mark.mysql
+
+_TABLE = "pydapper.pydapper_conformance"
+_DROP = f"DROP TABLE IF EXISTS {_TABLE}"
+_CREATE = f"CREATE TABLE {_TABLE} (id INT PRIMARY KEY, label VARCHAR(64), score INT, note VARCHAR(64))"
+
+
+class _MySqlConformanceHarness(SyncAdapterHarness):
+    adapter_name = "mysql"
+    command_class = MySqlConnectorPythonCommands
+    table_name = _TABLE
+
+    def __init__(self, server, db_port, database_name):
+        self._connect_kwargs = {
+            "host": server,
+            "port": db_port,
+            "user": "pydapper",
+            "password": "pydapper",
+            "database": database_name,
+        }
+        self.connect_dsn = f"mysql://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        import mysql.connector
+
+        commands = MySqlConnectorPythonCommands(mysql.connector.connect(**self._connect_kwargs))
+        commands.execute(_DROP)
+        commands.execute(_CREATE)
+        seed_through_adapter(commands, self.table_name)
+        commands.connection.commit()
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        with suppress(Exception):
+            commands.execute(_DROP)
+        commands.connection.close()
+
+
+def test_mysql_core_sync_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("mysql", "sync")]
+    harness = _MySqlConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()

--- a/tests/test_oracle/test_conformance.py
+++ b/tests/test_oracle/test_conformance.py
@@ -29,7 +29,7 @@ class _OracledbConformanceHarness(SyncAdapterHarness):
 
     def __init__(self, server, db_port, database_name):
         self._oracle_dsn = f"{server}:{db_port}/{database_name}"
-        self.connect_dsn = f"oracle://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"oracle://pydapper:pydapper@{server}:{db_port}/{database_name}"
 
     def create_commands(self) -> Commands:
         import oracledb

--- a/tests/test_oracle/test_conformance.py
+++ b/tests/test_oracle/test_conformance.py
@@ -1,0 +1,56 @@
+from contextlib import suppress
+
+import pytest
+
+from pydapper.commands import Commands
+from pydapper.oracle import OracledbCommands
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import seed_through_adapter
+
+pytestmark = pytest.mark.oracle
+
+_DROP = "BEGIN EXECUTE IMMEDIATE 'DROP TABLE pydapper_conformance'; EXCEPTION WHEN OTHERS THEN NULL; END;"
+_CREATE = (
+    "CREATE TABLE pydapper_conformance "
+    "(id NUMBER(10) PRIMARY KEY, label VARCHAR2(64), score NUMBER(10), note VARCHAR2(64))"
+)
+
+
+class _OracledbConformanceHarness(SyncAdapterHarness):
+    adapter_name = "oracledb"
+    command_class = OracledbCommands
+    # unquoted Oracle identifiers fold to uppercase, and Oracle stores '' as NULL —
+    # both are documented, narrow dialect knobs rather than case opt-outs
+    column_case = "upper"
+    supports_empty_strings = False
+    sql_overrides = {"select_literal": "SELECT 1 FROM dual"}
+
+    def __init__(self, server, db_port, database_name):
+        self._oracle_dsn = f"{server}:{db_port}/{database_name}"
+        self.connect_dsn = f"oracle://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        import oracledb
+
+        commands = OracledbCommands(oracledb.connect(password="pydapper", user="pydapper", dsn=self._oracle_dsn))
+        commands.execute(_DROP)
+        commands.execute(_CREATE)
+        seed_through_adapter(commands, self.table_name, supports_empty_strings=False)
+        commands.connection.commit()
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        with suppress(Exception):
+            commands.connection.rollback()
+            commands.execute(_DROP)
+        commands.connection.close()
+
+
+def test_oracledb_core_sync_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("oracledb", "sync")]
+    harness = _OracledbConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()

--- a/tests/test_postgresql/test_conformance.py
+++ b/tests/test_postgresql/test_conformance.py
@@ -1,0 +1,162 @@
+import inspect
+from contextlib import suppress
+
+import pytest
+import pytest_asyncio  # noqa: F401  (documents the async fixture plugin this module relies on)
+
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+from pydapper.postgresql import AiopgCommands
+from pydapper.postgresql import Psycopg2Commands
+from pydapper.postgresql import Psycopg3Commands
+from pydapper.postgresql import Psycopg3CommandsAsync
+from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import run_core_async
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import seed_through_adapter
+from tests.conformance_support import seed_through_adapter_async
+
+pytestmark = pytest.mark.postgresql
+
+_DROP = "DROP TABLE IF EXISTS pydapper_conformance"
+_CREATE = "CREATE TABLE pydapper_conformance (id INTEGER PRIMARY KEY, label TEXT, score INTEGER, note TEXT)"
+
+
+class _Psycopg2ConformanceHarness(SyncAdapterHarness):
+    adapter_name = "psycopg2"
+    command_class = Psycopg2Commands
+
+    def __init__(self, server, db_port, database_name):
+        self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
+        self.connect_dsn = self._url  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        import psycopg2
+
+        commands = Psycopg2Commands(psycopg2.connect(self._url))
+        commands.execute(_DROP)
+        commands.execute(_CREATE)
+        seed_through_adapter(commands, self.table_name)
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        try:
+            commands.connection.rollback()
+        finally:
+            commands.connection.close()
+
+
+class _Psycopg3SyncConformanceHarness(SyncAdapterHarness):
+    adapter_name = "psycopg"
+    command_class = Psycopg3Commands
+
+    def __init__(self, server, db_port, database_name):
+        self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
+        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    def create_commands(self) -> Commands:
+        import psycopg
+
+        commands = Psycopg3Commands(psycopg.connect(self._url))
+        commands.execute(_DROP)
+        commands.execute(_CREATE)
+        seed_through_adapter(commands, self.table_name)
+        return commands
+
+    def teardown_commands(self, commands: Commands) -> None:
+        try:
+            commands.connection.rollback()
+        finally:
+            commands.connection.close()
+
+
+class _Psycopg3AsyncConformanceHarness(AsyncAdapterHarness):
+    adapter_name = "psycopg"
+    command_class = Psycopg3CommandsAsync
+    # psycopg3's AsyncConnection.cursor() returns the cursor synchronously; the command
+    # class normalizes it, so the instrumented connection must use the same shape
+    cursor_factory_style = "synchronous"
+
+    def __init__(self, server, db_port, database_name):
+        self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
+        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    async def create_commands(self) -> CommandsAsync:
+        import psycopg
+
+        connection = await psycopg.AsyncConnection.connect(self._url)
+        commands = Psycopg3CommandsAsync(connection)
+        await commands.execute_async(_DROP)
+        await commands.execute_async(_CREATE)
+        await seed_through_adapter_async(commands, self.table_name)
+        return commands
+
+    async def teardown_commands(self, commands: CommandsAsync) -> None:
+        try:
+            await commands.connection.rollback()
+        finally:
+            await commands.connection.close()
+
+
+class _AiopgConformanceHarness(AsyncAdapterHarness):
+    adapter_name = "aiopg"
+    command_class = AiopgCommands
+
+    def __init__(self, server, db_port, database_name):
+        self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
+        self.connect_dsn = f"postgresql+aiopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+
+    async def create_commands(self) -> CommandsAsync:
+        import aiopg
+
+        commands = AiopgCommands(await aiopg.connect(self._url))
+        # aiopg is autocommit-only, so drop/create/seed take effect immediately
+        await commands.execute_async(_DROP)
+        await commands.execute_async(_CREATE)
+        await seed_through_adapter_async(commands, self.table_name)
+        return commands
+
+    async def teardown_commands(self, commands: CommandsAsync) -> None:
+        with suppress(Exception):
+            await commands.execute_async(_DROP)
+        result = commands.connection.close()
+        if inspect.isawaitable(result):
+            await result
+
+
+def test_psycopg2_core_sync_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("psycopg2", "sync")]
+    harness = _Psycopg2ConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()
+
+
+def test_psycopg3_core_sync_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("psycopg", "sync")]
+    harness = _Psycopg3SyncConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()
+
+
+@pytest.mark.asyncio
+async def test_psycopg3_core_async_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("psycopg", "async")]
+    harness = _Psycopg3AsyncConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    report = await run_core_async(harness)
+    report.raise_for_failures()
+
+
+@pytest.mark.asyncio
+async def test_aiopg_core_async_conformance(server, db_port, database_name):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("aiopg", "async")]
+    harness = _AiopgConformanceHarness(server, db_port, database_name)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    report = await run_core_async(harness)
+    report.raise_for_failures()

--- a/tests/test_postgresql/test_conformance.py
+++ b/tests/test_postgresql/test_conformance.py
@@ -30,7 +30,7 @@ class _Psycopg2ConformanceHarness(SyncAdapterHarness):
 
     def __init__(self, server, db_port, database_name):
         self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
-        self.connect_dsn = self._url  # type: ignore[misc]
+        self.connect_dsn = self._url
 
     def create_commands(self) -> Commands:
         import psycopg2
@@ -54,7 +54,7 @@ class _Psycopg3SyncConformanceHarness(SyncAdapterHarness):
 
     def __init__(self, server, db_port, database_name):
         self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
-        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"
 
     def create_commands(self) -> Commands:
         import psycopg
@@ -81,7 +81,7 @@ class _Psycopg3AsyncConformanceHarness(AsyncAdapterHarness):
 
     def __init__(self, server, db_port, database_name):
         self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
-        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"postgresql+psycopg://pydapper:pydapper@{server}:{db_port}/{database_name}"
 
     async def create_commands(self) -> CommandsAsync:
         import psycopg
@@ -106,7 +106,7 @@ class _AiopgConformanceHarness(AsyncAdapterHarness):
 
     def __init__(self, server, db_port, database_name):
         self._url = f"postgresql://pydapper:pydapper@{server}:{db_port}/{database_name}"
-        self.connect_dsn = f"postgresql+aiopg://pydapper:pydapper@{server}:{db_port}/{database_name}"  # type: ignore[misc]
+        self.connect_dsn = f"postgresql+aiopg://pydapper:pydapper@{server}:{db_port}/{database_name}"
 
     async def create_commands(self) -> CommandsAsync:
         import aiopg

--- a/tests/test_sqlite/test_conformance.py
+++ b/tests/test_sqlite/test_conformance.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pydapper.testing.adapter_conformance import run_core_sync
+from tests.conformance_support import FIRST_PARTY_CONFORMANCE_ENTRIES
+from tests.conformance_support import Sqlite3ConformanceHarness
+
+pytestmark = pytest.mark.sqlite
+
+
+def test_core_sync_conformance(tmp_path):
+    entry = FIRST_PARTY_CONFORMANCE_ENTRIES[("sqlite3", "sync")]
+    harness = Sqlite3ConformanceHarness(tmp_path)
+    assert harness.adapter_name == entry.adapter_name
+    assert harness.command_class is entry.command_class
+    run_core_sync(harness).raise_for_failures()

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -38,6 +38,7 @@ from pydapper.testing import adapter_conformance
 from pydapper.testing.adapter_conformance import AsyncAdapterHarness
 from pydapper.testing.adapter_conformance import AsyncCase
 from pydapper.testing.adapter_conformance import CaseResult
+from pydapper.testing.adapter_conformance import CaseSelectionError
 from pydapper.testing.adapter_conformance import ConformanceError
 from pydapper.testing.adapter_conformance import ConformanceFailureError
 from pydapper.testing.adapter_conformance import ConformanceProfile
@@ -804,6 +805,43 @@ class CommandsAsync:
             )
 
 
+class _RuntimeSyncHarness(SyncAdapterHarness):
+    """Regression guard: sync harness knobs are instance-assignable, not ``ClassVar``.
+
+    A real harness only learns its DSN once a test container is up, so assigning any
+    configuration field on ``self`` must type check without a ``type: ignore``.
+    """
+
+    adapter_name = "sqlite3"
+    command_class = Sqlite3Commands
+
+    def __init__(self, dsn: str) -> None:
+        self.connect_dsn = dsn
+        self.connect_kwargs = {"timeout": 5}
+        self.table_name = "runtime_conformance"
+        self.column_case = "upper"
+        self.supports_empty_strings = False
+        self.strict_rowcounts = False
+        self.sql_overrides = {"select_literal": "SELECT 1"}
+
+
+class _RuntimeAsyncHarness(AsyncAdapterHarness):
+    """Regression guard: async harness knobs are instance-assignable, not ``ClassVar``."""
+
+    adapter_name = "psycopg"
+    command_class = Psycopg3CommandsAsync
+
+    def __init__(self, dsn: str) -> None:
+        self.connect_dsn = dsn
+        self.connect_kwargs = {"autocommit": True}
+        self.table_name = "runtime_conformance"
+        self.column_case = "lower"
+        self.supports_empty_strings = True
+        self.strict_rowcounts = True
+        self.sql_overrides = {"select_literal": "SELECT 1"}
+        self.cursor_factory_style = "synchronous"
+
+
 def adapter_conformance_types() -> None:
     assert_type(adapter_conformance.CORE_SYNC, str)
     assert_type(adapter_conformance.CORE_ASYNC, str)
@@ -828,6 +866,23 @@ def adapter_conformance_types() -> None:
     assert_type(async_harness.adapter_name, Optional[str])
     assert_type(async_harness.command_class, Optional[Type[PydapperCommandsAsync]])
     assert_type(async_harness.table_name, str)
+    assert_type(async_harness.cursor_factory_style, Literal["awaitable", "synchronous"])
+
+    # harnesses that compute configuration at runtime keep the base annotations, and
+    # the fields they do not override still resolve to the base defaults
+    runtime_sync = _RuntimeSyncHarness("sqlite:///conformance.db")
+    assert_type(runtime_sync.connect_dsn, Optional[str])
+    assert_type(runtime_sync.connect_kwargs, Mapping[str, Any])
+    assert_type(runtime_sync.table_name, str)
+    assert_type(runtime_sync.column_case, Literal["lower", "upper"])
+    assert_type(runtime_sync.supports_empty_strings, bool)
+    assert_type(runtime_sync.strict_rowcounts, bool)
+    assert_type(runtime_sync.sql_overrides, Mapping[str, str])
+
+    runtime_async = _RuntimeAsyncHarness("postgresql+psycopg://localhost/conformance")
+    assert_type(runtime_async.connect_dsn, Optional[str])
+    assert_type(runtime_async.cursor_factory_style, Literal["awaitable", "synchronous"])
+    assert_type(runtime_async.sql_overrides, Mapping[str, str])
 
     report = run_core_sync(sync_harness)
     assert_type(report, ConformanceReport)
@@ -837,7 +892,12 @@ def adapter_conformance_types() -> None:
     assert_type(report.results, Tuple[CaseResult, ...])
     assert_type(report.failures, Tuple[CaseResult, ...])
     assert_type(report.passed, bool)
+    assert_type(report.covers_full_inventory, bool)
+    assert_type(report.harness_setup_failed, bool)
     assert_type(report.raise_for_failures(), None)
+
+    # the debugging-only case_ids filter keeps the report type
+    assert_type(run_core_sync(sync_harness, case_ids=["rows.query-buffered"]), ConformanceReport)
 
     result = cast(CaseResult, object())
     assert_type(result.profile_id, str)
@@ -847,11 +907,32 @@ def adapter_conformance_types() -> None:
     assert_type(result.cause, Optional[BaseException])
     assert_type(result.missing_field, Optional[str])
     assert_type(result.cleanup_error, Optional[BaseException])
+    assert_type(result.harness_setup_failed, bool)
+
+    # harness setup attribution is optional at construction, so results built without it
+    # keep their existing shape
+    assert_type(CaseResult(adapter_conformance.CORE_SYNC, "scalar.null-returns-none", False).harness_setup_failed, bool)
+    assert_type(
+        CaseResult(
+            adapter_conformance.CORE_SYNC, "scalar.null-returns-none", False, harness_setup_failed=True
+        ).harness_setup_failed,
+        bool,
+    )
+    assert_type(
+        ConformanceReport(adapter_conformance.CORE_SYNC, "sqlite3", "Sqlite3Commands", (result,)).harness_setup_failed,
+        bool,
+    )
 
     harness_error = cast(HarnessDefinitionError, object())
     assert_type(harness_error.profile_id, str)
     assert_type(harness_error.case_id, str)
     assert_type(harness_error.missing_field, str)
+
+    selection_error = cast(CaseSelectionError, object())
+    assert_type(selection_error.profile_id, str)
+    assert_type(selection_error.requested_case_ids, Tuple[str, ...])
+    assert_type(selection_error.unknown_case_ids, Tuple[str, ...])
+    selection_conformance_error: ConformanceError = selection_error
 
     failure_error = cast(ConformanceFailureError, object())
     assert_type(failure_error.report, ConformanceReport)
@@ -881,6 +962,7 @@ def adapter_conformance_types() -> None:
 async def adapter_conformance_async_types() -> None:
     async_harness = cast(AsyncAdapterHarness, object())
     assert_type(await run_core_async(async_harness), ConformanceReport)
+    assert_type(await run_core_async(async_harness, case_ids=["rows.query-buffered"]), ConformanceReport)
     assert_type(await async_harness.create_commands(), PydapperCommandsAsync)
     assert_type(await async_harness.teardown_commands(cast(PydapperCommandsAsync, object())), None)
 

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -7,7 +7,10 @@ from typing import Dict
 from typing import Generator
 from typing import List
 from typing import Literal
+from typing import Mapping
+from typing import Optional
 from typing import Tuple
+from typing import Type
 from typing import Union
 from typing import cast
 
@@ -15,6 +18,7 @@ import pytest
 from typing_extensions import assert_type
 
 import pydapper
+from pydapper._context import _AwaitableAsyncContextManager
 from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands as PydapperCommands
 from pydapper.commands import CommandsAsync as PydapperCommandsAsync
@@ -30,6 +34,23 @@ from pydapper.exceptions import RowMappingException
 from pydapper.exceptions import UnsupportedFeatureError
 from pydapper.postgresql import Psycopg3CommandsAsync
 from pydapper.sqlite import Sqlite3Commands
+from pydapper.testing import adapter_conformance
+from pydapper.testing.adapter_conformance import AsyncAdapterHarness
+from pydapper.testing.adapter_conformance import AsyncCase
+from pydapper.testing.adapter_conformance import CaseResult
+from pydapper.testing.adapter_conformance import ConformanceError
+from pydapper.testing.adapter_conformance import ConformanceFailureError
+from pydapper.testing.adapter_conformance import ConformanceProfile
+from pydapper.testing.adapter_conformance import ConformanceReport
+from pydapper.testing.adapter_conformance import HarnessDefinitionError
+from pydapper.testing.adapter_conformance import ProfileDefinitionError
+from pydapper.testing.adapter_conformance import SyncAdapterHarness
+from pydapper.testing.adapter_conformance import SyncCase
+from pydapper.testing.adapter_conformance import capability_profiles
+from pydapper.testing.adapter_conformance import core_async_profile
+from pydapper.testing.adapter_conformance import core_sync_profile
+from pydapper.testing.adapter_conformance import run_core_async
+from pydapper.testing.adapter_conformance import run_core_sync
 from pydapper.types import AsyncConnectionType
 from pydapper.types import AsyncCursorType
 from pydapper.types import ConnectionType
@@ -781,3 +802,89 @@ class CommandsAsync:
                 await commands.query_single_or_default_async(query, "hello", mapper=to_task, options=options),
                 Union[str, Task],
             )
+
+
+def adapter_conformance_types() -> None:
+    assert_type(adapter_conformance.CORE_SYNC, str)
+    assert_type(adapter_conformance.CORE_ASYNC, str)
+    assert_type(adapter_conformance.CONFORMANCE_COLUMNS, Tuple[str, ...])
+    assert_type(adapter_conformance.CONFORMANCE_ROWS, Tuple[Tuple[Any, ...], ...])
+    assert_type(adapter_conformance.seed_rows(True), Tuple[Tuple[Any, ...], ...])
+
+    sync_harness = cast(SyncAdapterHarness, object())
+    assert_type(sync_harness.adapter_name, Optional[str])
+    assert_type(sync_harness.command_class, Optional[Type[PydapperCommands]])
+    assert_type(sync_harness.connect_dsn, Optional[str])
+    assert_type(sync_harness.connect_kwargs, Mapping[str, Any])
+    assert_type(sync_harness.table_name, str)
+    assert_type(sync_harness.supports_empty_strings, bool)
+    assert_type(sync_harness.strict_rowcounts, bool)
+    assert_type(sync_harness.sql_overrides, Mapping[str, str])
+    assert_type(sync_harness.create_commands(), PydapperCommands)
+    assert_type(sync_harness.teardown_commands(cast(PydapperCommands, object())), None)
+    assert_type(sync_harness.recover_after_error(cast(PydapperCommands, object())), None)
+
+    async_harness = cast(AsyncAdapterHarness, object())
+    assert_type(async_harness.adapter_name, Optional[str])
+    assert_type(async_harness.command_class, Optional[Type[PydapperCommandsAsync]])
+    assert_type(async_harness.table_name, str)
+
+    report = run_core_sync(sync_harness)
+    assert_type(report, ConformanceReport)
+    assert_type(report.profile_id, str)
+    assert_type(report.adapter_name, str)
+    assert_type(report.command_class_name, str)
+    assert_type(report.results, Tuple[CaseResult, ...])
+    assert_type(report.failures, Tuple[CaseResult, ...])
+    assert_type(report.passed, bool)
+    assert_type(report.raise_for_failures(), None)
+
+    result = cast(CaseResult, object())
+    assert_type(result.profile_id, str)
+    assert_type(result.case_id, str)
+    assert_type(result.passed, bool)
+    assert_type(result.message, str)
+    assert_type(result.cause, Optional[BaseException])
+    assert_type(result.missing_field, Optional[str])
+    assert_type(result.cleanup_error, Optional[BaseException])
+
+    harness_error = cast(HarnessDefinitionError, object())
+    assert_type(harness_error.profile_id, str)
+    assert_type(harness_error.case_id, str)
+    assert_type(harness_error.missing_field, str)
+
+    failure_error = cast(ConformanceFailureError, object())
+    assert_type(failure_error.report, ConformanceReport)
+    assert_type(failure_error.failures, Tuple[CaseResult, ...])
+
+    profile_error = cast(ProfileDefinitionError, object())
+    assert_type(profile_error.profile_id, str)
+    conformance_error: ConformanceError = failure_error
+
+    catalog = capability_profiles()
+    assert_type(catalog, Mapping[pydapper.AdapterCapability, ConformanceProfile])
+
+    profile = core_sync_profile()
+    assert_type(profile, ConformanceProfile)
+    assert_type(core_async_profile(), ConformanceProfile)
+    assert_type(profile.profile_id, str)
+    assert_type(profile.capability, Optional[pydapper.AdapterCapability])
+    assert_type(profile.sync_cases, Tuple[SyncCase, ...])
+    assert_type(profile.async_cases, Tuple[AsyncCase, ...])
+
+    sync_case = cast(SyncCase, object())
+    assert_type(sync_case.case_id, str)
+    assert_type(sync_case.description, str)
+    assert_type(sync_case.kind, str)
+
+
+async def adapter_conformance_async_types() -> None:
+    async_harness = cast(AsyncAdapterHarness, object())
+    assert_type(await run_core_async(async_harness), ConformanceReport)
+    assert_type(await async_harness.create_commands(), PydapperCommandsAsync)
+    assert_type(await async_harness.teardown_commands(cast(PydapperCommandsAsync, object())), None)
+
+
+def psycopg3_async_cursor_normalization_types() -> None:
+    async_commands = cast(Psycopg3CommandsAsync, object())
+    assert_type(async_commands.cursor(), _AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType])


### PR DESCRIPTION
Implements #499: a reusable, typed, pytest-free adapter conformance suite shipped in the installed distribution, with mandatory per-mode core profiles, an extensible (and deliberately empty) capability-profile catalog, first-party adoption for every installed adapter mode, and honest, separated evidence.

## Design and supported API

Everything ships under `pydapper.testing.adapter_conformance` (nothing is re-exported from the package root; `import pydapper` does not import `pydapper.testing`). The helper uses only the standard library and pydapper core — importing it loads no pytest, tests, testcontainers, faker, typing_extensions, or optional driver modules, enforced by a subprocess meta-path-guard test.

Public surface (one documented way to run the suite):

- `CORE_SYNC = "core-sync"` / `CORE_ASYNC = "core-async"` — the stable mandatory profile ids. They are per registered *mode*, independent, and are not `AdapterCapability` flags; a dual-mode adapter must pass both.
- `SyncAdapterHarness` / `AsyncAdapterHarness` — typed harness bases. Required fields: `adapter_name`, `command_class`, `connect_dsn`, `create_commands()` (fresh connection + freshly seeded canonical dataset per case), `teardown_commands()`. Narrow documented dialect knobs: `table_name`, `column_case` (Oracle uppercase folding), `supports_empty_strings` (Oracle `''`→NULL), `strict_rowcounts` (BigQuery-emulator rowcounts), `sql_overrides`, `connect_kwargs`, `recover_after_error()`, and async-only `cursor_factory_style` (`"awaitable"` per the `CommandsAsync` base contract vs `"synchronous"` for psycopg3-style factories). Sync-only harnesses have no async members and vice versa. Missing required fields fail with structured `HarnessDefinitionError(profile_id, case_id, missing_field)`.
- `run_core_sync(harness)` / `await run_core_async(harness)` — the async runner is a plain awaitable, never calls `asyncio.run()`, and propagates `asyncio.CancelledError` after releasing the active case's resources.
- `ConformanceReport` / `CaseResult` — deterministic declared-order results carrying `profile_id`, `case_id`, `passed`, `message`, `cause`, `missing_field`, and `cleanup_error`; `report.raise_for_failures()` raises `ConformanceFailureError`. No prose parsing needed.
- `ConformanceProfile` / `SyncCase` / `AsyncCase` / `capability_profiles()` — the capability-profile model. The production catalog is empty (no optional capability is implemented) and immutable; zero-case profiles and duplicate case ids are rejected at construction. The runner's `capability_catalog` parameter only selects which profiles *additionally run*: the capability-honesty core cases always consult the production catalog, so injection can never make an unimplemented capability appear covered (this was hardened after the adversarial audit — see below).
- Framework-owned instrumentation (recording/fault-injecting connections and cursors, context-manager and plain shapes, sync/awaitable close, truthy/raising exits, scripted results, entered-cursor identity objects) is internal; interaction-level cases instantiate the harness's **real concrete command class** around it. The harness has no API to declare a case passed; every assertion lives in the runner.

The runner executes 54 named cases per mode (29 live + 25 instrumented for sync; the async inventory mirrors it, adding awaitable-close and `aclose()` shapes). The framework owns all query/DML SQL in portable `?name?` placeholders; the harness owns only DDL/seeding of the canonical dataset (`CONFORMANCE_COLUMNS`/`CONFORMANCE_ROWS`/`seed_rows()`).

## Behavior implemented (traceability)

Every #499 core bullet maps to named cases (identical ids in both modes unless noted):

| #499 requirement | Case id(s) |
|---|---|
| Explicit adapter selection returns declared class | `registration.explicit-adapter-selection` |
| Supplied connection via documented path | `registration.supplied-connection` |
| Documented DSN connect path | `registration.dsn-connect` |
| #541 acquisition/preparation/execution/fetch/cleanup | `lifecycle.context-cursor-success`, `lifecycle.hook-order` |
| Cleanup after success and active failure | `lifecycle.context-cursor-success`, `lifecycle.cleanup-after-failure` |
| Active error not replaced by cleanup failure | `lifecycle.active-error-precedence`, `lifecycle.fetch-error-precedence`, `lifecycle.cleanup-error-after-success` |
| Truthy exit cannot suppress / fabricate results | `lifecycle.truthy-exit-not-suppressing` |
| Plain-close and native-CM cursors (both modes) | `lifecycle.plain-cursor-close` (async sweeps sync+awaitable `close()`), `lifecycle.context-cursor-success` |
| Unbuffered exhaustion + explicit close/aclose | `lifecycle.unbuffered-exhaustion-cleanup`, `lifecycle.unbuffered-explicit-close` / `-aclose` |
| `params=` / `param=` / both rejected pre-driver | `params.params-keyword`, `params.param-alias`, `params.both-rejected-before-driver-work` |
| Repeated placeholders order + reuse | `params.repeated-placeholders`, `params.repeated-placeholders-binding` |
| Missing / invalid parameter shapes | `params.missing-raises`, `params.invalid-shape-raises` |
| Record representations (mapping/attr/dataclass) | `params.record-representations` |
| `execute()`/`execute_async()` rowcounts | `execute.rowcount`, `execute.executemany-rowcount` |
| Empty executemany no-op without cursor | `execute.executemany-empty-noop` |
| Mixed executemany representations | `execute.executemany-mixed-records` |
| Nested list stays one bound value (instrumented binding) | `execute.nested-list-single-value` |
| Buffered/unbuffered query, ordered dict rows | `rows.query-buffered` (key-order assertion), `rows.query-unbuffered` |
| `mapper=` receives `RawRow`; model/mapper exclusive | `rows.mapper-receives-raw-row`, `rows.model-mapper-exclusive` |
| `DuplicateColumnException` structured attrs; mapper receives duplicates | `rows.duplicate-columns-raise`, `rows.mapper-receives-duplicates` |
| Mapper/model errors propagate + cursor cleaned | `lifecycle.mapper-error-cleanup`, `lifecycle.model-error-cleanup` |
| Zero/one/many for first/single/or-default | `cardinality.first-returns-first`, `.first-zero-raises`, `.first-or-default`, `.single-one`, `.single-zero-raises`, `.single-many-raises`, `.single-or-default` |
| Single-row methods consume at most two rows | `cardinality.single-bounded-fetch` (fetchmany(2) and fetchone-fallback branches; post-decision drain tolerated for MySQL) |
| Scalar no-row vs SQL NULL; falsey preserved | `scalar.no-row-raises`, `scalar.null-returns-none`, `scalar.value`, `scalar.falsey-preserved`, `cardinality.falsey-row-is-result` |
| Options default equivalence / unsupported-before-driver-work / invalid | `options.default-equivalence`, `options.unsupported-raises`, `options.unsupported-before-driver-work` (probes cover the full non-default `CommandOptions` surface incl. `readonly=False`), `options.invalid-rejected` |
| `supports()` matches declaration; invalid declarations fail; declared-without-profile fails | `capabilities.supports-matches-declaration`, `capabilities.declaration-valid`, `capabilities.declared-profile-populated` |
| Hooks run in #467 order with normalized options | `lifecycle.hook-order` |

Every required framework test from #499 maps to `tests/test_adapter_conformance.py` (48 tests, all `core`-marked): documented import + no-root-export + import hygiene; mock sync/async harnesses pass (pure-Python fake DBAPI, no sqlite); real in-memory SQLite `core-sync` passes; broken row mapper fails `rows.query-buffered` by name while unrelated cases still pass; leaked cursor fails `lifecycle.context-cursor-success`; cleanup-masking adapter fails `lifecycle.active-error-precedence` with the masking exception as `cause`; invalid capability declaration fails `capabilities.declaration-valid`; declared-capability-without-profile fails exactly `capabilities.declared-profile-populated`; a synthetic injected profile runs its cases but cannot cover a declaration; a falsely-declaring adapter with an injected all-green catalog still fails the option probes; zero-case profiles and duplicate ids rejected; missing `create_commands`/`teardown_commands`/`connect_dsn`/`adapter_name`/`command_class` report profile/case/missing field; sync-only and async-only harnesses independent (runners reject the opposite mode); fresh-case isolation (every created command distinct and torn down); teardown-failure precedence both directions; deterministic ordering; adapter-raised framework errors never mark a case passed and `CaseResult` is frozen; concrete-class instrumented coverage for all 7 sync classes + `AiopgCommands` (executemany emulation observed) + `Psycopg3CommandsAsync` (synchronous-cursor normalization observed at runtime); MySQL `query_first` drain order (`cursor/enter/execute/fetchone/fetchall/exit`) and `query_single` unread-result drain before `MoreThanOneResultException`; task cancellation propagates with teardown; entry-point drift invariants; built wheel+sdist member lists derived from the source tree plus hermetic `python -I -S` imports from both extracted artifacts; both documented examples execute.

## First-party adoption

One live core-profile entry per installed mode, under existing markers and service fixtures, all keyed to the single `tests/conformance_support.FIRST_PARTY_CONFORMANCE_ENTRIES` registry (uniqueness-guarded); the drift test derives the expected registry from the installed `pydapper.adapters` entry points, so a new/renamed/mode-changed first-party adapter fails loudly:

| Adapter | Mode | Class | Entry |
|---|---|---|---|
| sqlite3 | sync | `Sqlite3Commands` | `tests/test_sqlite/test_conformance.py` |
| psycopg2 | sync | `Psycopg2Commands` | `tests/test_postgresql/test_conformance.py` |
| psycopg | sync | `Psycopg3Commands` | `tests/test_postgresql/test_conformance.py` |
| psycopg | async | `Psycopg3CommandsAsync` (`cursor_factory_style="synchronous"`) | `tests/test_postgresql/test_conformance.py` |
| aiopg | async | `AiopgCommands` (autocommit-aware teardown) | `tests/test_postgresql/test_conformance.py` |
| mysql | sync | `MySqlConnectorPythonCommands` | `tests/test_mysql/test_conformance.py` |
| pymssql | sync | `PymssqlCommands` | `tests/test_mssql/test_conformance.py` |
| oracledb | sync | `OracledbCommands` (`column_case="upper"`, `supports_empty_strings=False`, `SELECT 1 FROM dual` override) | `tests/test_oracle/test_conformance.py` |
| google | sync | `GoogleBigqueryClientCommands` (per-case uuid tables, `strict_rowcounts=False`, sentinel + literal `UPDATE` to seed the canonical SQL `NULL`) | `tests/test_bigquery/test_conformance.py` |

## Narrow concrete fix

`Psycopg3CommandsAsync.cursor()` had no return annotation, so its documented sync-cursor-factory normalization was untyped. It now carries the base `CommandsAsync.cursor` annotation (`_AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType]`); body unchanged; regression coverage in `tests/type_tests.py` and a runtime normalization test. No other concrete defect surfaced — the M1-era MySQL/psycopg3 lifecycle issues were already fixed by #541 and are now locked in by conformance cases.

## Adversarial audit and hardening

A six-dimension adversarial audit (traceability, dependency boundary, false positives, concrete-class bypass, diff hygiene, lifecycle semantics) with an independent refute-or-confirm pass produced three confirmed majors, all fixed in the final commit:

1. **`run_core_async` swallowed `asyncio.CancelledError`** (recorded it as a failed case and kept running). Both runners now propagate cancellation/shutdown after releasing the active case's resources; regression test added.
2. **Capability-declaration + injected-catalog bypass**: an adapter falsely declaring capabilities, combined with a caller-supplied catalog of no-op profiles, could pass while silently ignoring options. The option-honesty probes and `capabilities.declared-profile-populated` now consult the *production* catalog exclusively; the exact PoC is now a regression test (`test_option_probes_cannot_be_waived_by_declaration_alone`).
3. **Packaging test gaps**: only 5 of 11 shipped files were asserted and nothing imported from a built artifact. The test now derives the expected member list from the source tree for both artifacts and imports the helper hermetically (`python -I -S`) from the extracted wheel and sdist.

A fourth major (unvalidated `sql_overrides` as a tautology vector) was **refuted**: the harness is already a trusted surface with equivalent power through `table_name` and seeding; documented as a knob, not a defect. Confirmed minors also fixed: `cleanup_error` now populated when teardown fails after a passing case; `readonly=False` probe added; case inventories frozen at import; the instrumented concrete-class list and drift checks lost their second hand-maintained lists; `typing_extensions` added to the import-hygiene denylist.

## BigQuery portability, emulator pin, and coverage (follow-up commits)

Three issues surfaced once the suite ran against real services and the repo's 100% coverage gate:

1. **The core profile could not run on BigQuery at all.** The canonical dataset seeds a SQL `NULL` note, and the BigQuery DBAPI derives each parameter's type from its Python value — it raises `ProgrammingError` for an untyped `None`. Every live `core-sync` case died inside `create_commands()` while seeding (28 of 54 failed; the 26 instrumented cases still passed). Two changes fix it, and the stored dataset is byte-identical to every other backend's:
   * the framework no longer binds `None` as a parameter value — the two `executemany` cases that carried `note: None` now bind real notes, since they cover rowcounts and mixed record representations, not NULL binding; and
   * the BigQuery harness seeds the canonical `NULL` by binding a sentinel and clearing it with a literal `UPDATE ... SET note = NULL`.

   `scalar.null-returns-none` still asserts a stored SQL `NULL` reads back as `None` on every backend, including BigQuery. Documented in the conformance page's dataset section and driver matrix.

2. **The emulator image is now pinned** to `ghcr.io/goccy/bigquery-emulator:0.8.1` (was `:latest`). It is the only container image this repo names itself — the other backends inherit pinned defaults from their testcontainers classes — so an upstream release could previously change what CI runs with no commit here.

3. **100% coverage restored.** The conformance helper ships inside `pydapper/`, so its untested lines counted against the repo's 100% gate: 66 missed lines and 42 partial branches, all in `pydapper/testing/adapter_conformance/` (every other module was already at 100%). `tests/test_adapter_conformance.py` grew from 48 to 81 tests covering statement-catalog rejection, profile-definition validation, instrumentation internals (executemany recording, scripted fetch faults, per-cursor script sequences), `connect()` tolerance of unclosable connections, an adapter that never reaches the driver, the full capability-honesty matrix in both modes, and the runner's shutdown/teardown paths. Eight `Optional`-narrowing guards are marked `# pragma: no cover` with the reason inline — the preparation-hook guards are unreachable because the event-order assertion above them already proves the hook fired with framework-recorded detail, and the `DuplicateColumnException` guard is unreachable because `expect_raises()` captures only the expected type.

## Commands run and results

Run on a machine with **every optional driver installed and Docker running**, so all backend suites executed live:

| Command | Result |
|---|---|
| `poetry run pytest --cov=. --cov-branch` (entire suite, all backends live) | **1588 passed, 100% coverage** (0 missed lines, 0 partial branches) |
| `poetry run pytest -m "core"` | 1371 passed, 217 deselected |
| `poetry run pytest -m "sqlite"` | 30 passed |
| `poetry run pytest -m "postgresql"` | 91 passed |
| `poetry run pytest -m "mysql"` | 23 passed |
| `poetry run pytest -m "mssql"` | 27 passed |
| `poetry run pytest -m "oracle"` | 23 passed |
| `poetry run pytest -m "bigquery"` | 23 passed |
| `poetry run pytest tests/test_adapter_conformance.py` | 81 passed |
| `poetry run pytest tests/test_commands_interface.py -m "core"` | 435 passed |
| `poetry run pytest tests/test_adapter_units.py -m "core"` | 41 passed |
| `poetry run mypy pydapper` | Success: no issues found in 39 source files |
| `poetry run mypy tests/type_tests.py` | Success: no issues found in 1 source file |
| `poetry run black --check .` | clean |
| `poetry run isort --check .` | clean |
| `poetry run mkdocs build --strict` | built cleanly |
| `git diff --check` | clean |
| `poetry run python docs_src/adapter_conformance/sync_example.py` | exit 0 (54 cases, passed=True) |
| `poetry run python docs_src/adapter_conformance/async_example.py` | exit 0 (54 cases, passed=True) |

The only warnings are the pre-existing testcontainers `@wait_container_is_ready` deprecation and google-api-core/bigquery-storage notices. No dependency changes; `poetry.lock` untouched.

## Wheel and sdist proof

`test_built_wheel_and_sdist_ship_the_conformance_helper` builds both artifacts on every run, derives the expected member list from the source tree (so a new or renamed shipped file cannot be missed), and imports the helper hermetically (`python -I -S`) from both extracted artifacts. It asserts a meta-path guard forbidding pytest/tests/testcontainers/faker/drivers/sqlalchemy during import, that the documented sync and async imports resolve from the installed package rather than the checkout, and that zero banned modules land in `sys.modules`. Artifact hashes are deliberately not quoted here — they change with every build; the test is the standing proof.

## Backend verification matrix

Every first-party adapter mode now has a live conformance entry that has actually executed:

| Backend | Conformance entry | Live result | Notes |
|---|---|---|---|
| SQLite | `Sqlite3Commands` | **live, passed** | stdlib; also runs service-free inside `-m core` |
| PostgreSQL | `Psycopg2Commands`, `Psycopg3Commands`, `Psycopg3CommandsAsync`, `AiopgCommands` | **live, passed** | all four modes, testcontainers |
| MySQL | `MySqlConnectorPythonCommands` | **live, passed** | unread-result drain exercised live and instrumented |
| SQL Server | `PymssqlCommands` | **live, passed** | testcontainers |
| Oracle | `OracledbCommands` | **live, passed** | `column_case="upper"`, `supports_empty_strings=False`, `SELECT 1 FROM dual` override |
| BigQuery | `GoogleBigqueryClientCommands` | **live, passed** | goccy emulator 0.8.1; sentinel + literal `UPDATE` seeds the canonical `NULL` |

Service-free coverage (mock sync/async harnesses over a pure-Python fake driver, the in-memory SQLite harness, and instrumented runs of every concrete command class) still runs in `-m core` on machines without Docker, and is never reported as a live pass.

## Docs

New nav page **Adapter conformance** (`docs/adapter_conformance.md`): profile semantics and independence, harness API and knobs, canonical dataset, isolation/cleanup/failure semantics, how to run one adapter, how to report unavailable service-backed suites, why native DB support never justifies a capability declaration, why unsupported features fail loudly, the driver conformance matrix (per command class, honest verification wording), and the maintenance rule for future capability PRs (enum → real production profile → supported+unsupported adapter tests → declaration → docs → type tests). Runnable third-party examples (`docs_src/adapter_conformance/sync_example.py` + `async_example.py`, no pytest) are included on the page and executed by the self-tests. Release-note entry added under `## Latest Changes`; `tests/type_tests.py` covers the documented API and the psycopg3 annotation.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

