### PR TITLE
feat: add sync commit, rollback, and transaction APIs

### DIFF
--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -34,19 +34,13 @@ recording and fault-injection connections, so cursor counts, call order, excepti
 
 ## Optional capability profiles
 
-!!! warning "Provisional API — no capability profiles ship yet"
-    `capability_profiles()` returns an **empty** catalog, and `ConformanceProfile`, `SyncCase`, and `AsyncCase`
-    exist only so the first capability feature has somewhere to land. There is nothing for an adapter author to
-    write against yet: no `AdapterCapability` member has a profile, and no adapter can usefully declare one. This
-    part of the public API is **provisional and may change** when the first real capability profile is added; the
-    mandatory `core-sync` / `core-async` surface described above is not. See
-    [Extending the suite in future capability work](#extending-the-suite-in-future-capability-work) for what that
-    first change must carry.
-
 Optional behaviors are independent profiles keyed to `pydapper.AdapterCapability` members — there is no linear
 "better adapter" tier, and no adapter is required to support any optional capability. The production catalog is
-returned by `capability_profiles()` and is **currently empty**, because no optional capability is implemented
-yet. The framework enforces honesty in both directions:
+returned by `capability_profiles()` and currently ships one profile: `transactions`, covering the sync
+[transaction APIs](transactions.md). The runners automatically append the profile cases for every capability the
+command class under test declares, so a declaring adapter is exercised against its capability profiles in the
+same `run_core_sync()` / `run_core_async()` call as the core inventory — there is no separate capability runner
+to invoke. The framework enforces honesty in both directions:
 
 * A command class that declares a valid capability with no populated profile for its mode **fails** conformance
   (`capabilities.declared-profile-populated`). An unimplemented capability can never appear covered; zero-case
@@ -60,6 +54,26 @@ yet. The framework enforces honesty in both directions:
 Native database support alone is never enough to declare a capability: a capability describes behavior the
 command class actually implements, tests through its conformance profile, and documents. Until then, the
 feature must fail loudly rather than silently execute as if supported.
+
+### The `transactions` profile
+
+Nine sync cases pin the sync `commit()` / `rollback()` / `transaction()` contract for every declaring adapter.
+Every live case first commits the harness baseline (`create_commands()` then `commit()`), so scenarios start
+from a durable, transaction-free state even when a harness seeds inside an open transaction. The profile has no
+async cases yet — the async transaction APIs are a separate feature — so an async command class may not declare
+`TRANSACTIONS` until they land.
+
+| Case id | Kind | Pins |
+|---|---|---|
+| `transactions.commit-persists` | live | `commit()` makes a write durable; a later `rollback()` cannot remove it |
+| `transactions.rollback-discards` | live | `rollback()` discards uncommitted work, committed rows stay intact |
+| `transactions.context-commits-on-exit` | live | a `transaction()` block commits on clean exit |
+| `transactions.context-rolls-back-on-error` | live | a raising block rolls back and re-raises the same exception object |
+| `transactions.commit-delegates-once` | instrumented | one connection `commit`, no cursor acquired, returns `None` |
+| `transactions.rollback-delegates-once` | instrumented | one connection `rollback`, no cursor acquired, returns `None` |
+| `transactions.context-lifecycle-order` | instrumented | the block's commit comes after the command's full cursor lifecycle |
+| `transactions.context-error-precedence` | instrumented | rollback on error, and the block's error wins over a rollback failure |
+| `transactions.commit-failure-propagates` | instrumented | a failed exit commit propagates unchanged with no rollback attempt |
 
 ## The harness API
 
@@ -284,15 +298,15 @@ service or emulator is available.
 
 | Adapter name | Command class | Mode | Declared capabilities | Conformance entry | Verification | Driver limits |
 |---|---|---|---|---|---|---|
-| `sqlite3` | `Sqlite3Commands` | sync | *(none)* | `tests/test_sqlite/test_conformance.py` | live, service-free (runs in the core and sqlite suites) | [SQLite](database_support/sqlite.md) |
-| `psycopg2` | `Psycopg2Commands` | sync | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
-| `psycopg` | `Psycopg3Commands` | sync | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `sqlite3` | `Sqlite3Commands` | sync | `transactions` | `tests/test_sqlite/test_conformance.py` | live, service-free (runs in the core and sqlite suites) | [SQLite](database_support/sqlite.md) |
+| `psycopg2` | `Psycopg2Commands` | sync | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `psycopg` | `Psycopg3Commands` | sync | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
 | `psycopg` | `Psycopg3CommandsAsync` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage (including its synchronous cursor-factory normalization); live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
-| `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute` |
-| `mysql` | `MySqlConnectorPythonCommands` | sync | *(none)* | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes |
-| `pymssql` | `PymssqlCommands` | sync | *(none)* | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md) |
-| `oracledb` | `OracledbCommands` | sync | *(none)* | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`) |
-| `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`), and the DBAPI cannot bind an untyped `None`, so the harness seeds the canonical SQL `NULL` note through a sentinel and a literal `UPDATE` |
+| `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute`; its connection-level commit/rollback raise, so `transactions` is not declared (the async transaction APIs are a separate feature) |
+| `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes |
+| `pymssql` | `PymssqlCommands` | sync | `transactions` | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md) |
+| `oracledb` | `OracledbCommands` | sync | `transactions` | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`) |
+| `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`), and the DBAPI cannot bind an untyped `None`, so the harness seeds the canonical SQL `NULL` note through a sentinel and a literal `UPDATE`; the DBAPI's `commit()` is a no-op and there is no `rollback()`, so `transactions` is not declared |
 
 ## Extending the suite in future capability work
 

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -69,8 +69,8 @@ async cases yet — the async transaction APIs are a separate feature — so an 
 | `transactions.rollback-discards` | live | `rollback()` discards uncommitted work, committed rows stay intact |
 | `transactions.context-commits-on-exit` | live | a `transaction()` block commits on clean exit |
 | `transactions.context-rolls-back-on-error` | live | a raising block rolls back and re-raises the same exception object |
-| `transactions.commit-delegates-once` | instrumented | one connection `commit`, no cursor acquired, returns `None` |
-| `transactions.rollback-delegates-once` | instrumented | one connection `rollback`, no cursor acquired, returns `None` |
+| `transactions.commit-delegates-once` | instrumented | one connection `commit`, no cursor acquired, returns `None`, failures propagate unchanged |
+| `transactions.rollback-delegates-once` | instrumented | one connection `rollback`, no cursor acquired, returns `None`, failures propagate unchanged |
 | `transactions.context-lifecycle-order` | instrumented | the block's commit comes after the command's full cursor lifecycle |
 | `transactions.context-error-precedence` | instrumented | rollback on error, and the block's error wins over a rollback failure |
 | `transactions.commit-failure-propagates` | instrumented | a failed exit commit propagates unchanged with no rollback attempt |

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -260,15 +260,16 @@ unrelated objects are all invalid. Arbitrary strings are not an extension mechan
 the enum by pydapper when the corresponding feature ships.
 
 Declare a capability only when the command class actually implements and tests the behavior. Native driver
-potential is not sufficient. All first-party declarations are currently empty because no optional capability is
-implemented yet; the feature tickets that implement transactions, timeouts, and the other optional behaviors own
-enabling their flags.
+potential is not sufficient. The first implemented capability is `TRANSACTIONS` — the sync
+[transaction APIs](transactions.md) — declared by every first-party sync adapter except BigQuery, whose DBAPI
+cannot support it. The feature tickets that implement the remaining optional behaviors (async transactions,
+timeouts, and so on) own enabling their flags.
 
 Users inspect a selected command object with `supports()`:
 
 ```python
 commands = pydapper.using(connection)
-commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # False for every first-party adapter today
+commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # True for e.g. Sqlite3Commands
 commands.supports("transactions")  # TypeError: not an AdapterCapability
 ```
 
@@ -281,18 +282,20 @@ registrations.
 
 | Registration name | Command class | Mode | Declared optional capabilities |
 |---|---|---|---|
-| `sqlite3` | `Sqlite3Commands` | sync | *(empty)* |
-| `psycopg2` | `Psycopg2Commands` | sync | *(empty)* |
-| `psycopg` | `Psycopg3Commands` | sync | *(empty)* |
+| `sqlite3` | `Sqlite3Commands` | sync | `transactions` |
+| `psycopg2` | `Psycopg2Commands` | sync | `transactions` |
+| `psycopg` | `Psycopg3Commands` | sync | `transactions` |
 | `psycopg` | `Psycopg3CommandsAsync` | async | *(empty)* |
 | `aiopg` | `AiopgCommands` | async | *(empty)* |
-| `mysql` | `MySqlConnectorPythonCommands` | sync | *(empty)* |
-| `pymssql` | `PymssqlCommands` | sync | *(empty)* |
-| `oracledb` | `OracledbCommands` | sync | *(empty)* |
+| `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` |
+| `pymssql` | `PymssqlCommands` | sync | `transactions` |
+| `oracledb` | `OracledbCommands` | sync | `transactions` |
 | `google` | `GoogleBigqueryClientCommands` | sync | *(empty)* |
 
-Empty sets are honest: they mean no optional capability is implemented yet, not that the underlying database lacks
-the feature.
+Empty sets are honest: they mean the class does not implement the optional capability, not necessarily that the
+underlying database lacks the feature. `GoogleBigqueryClientCommands` stays empty because the BigQuery DBAPI's
+`commit()` is a no-op and it has no `rollback()` at all; the async classes stay empty because the async
+transaction APIs have not landed yet.
 
 Adapters prove these contracts — the mandatory per-mode core behavior and, once implemented, each declared
 capability — with the reusable conformance suite; see [Adapter conformance](adapter_conformance.md).

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,19 @@
 ## Latest Changes
 
+* v1: synchronous commands now expose explicit transaction APIs — `commit()`, `rollback()`, and a
+  `transaction()` context manager that commits on clean exit and rolls back (then re-raises) on any exception,
+  including `KeyboardInterrupt`. The block's error always wins over a rollback failure, a failed exit commit
+  propagates unchanged with no rollback attempt, entering a block emits no SQL (the DBAPI's implicit
+  transaction start is the contract), and nested blocks on the same `Commands` instance raise `RuntimeError`.
+  All three methods are gated behind `AdapterCapability.TRANSACTIONS`: an adapter that does not declare it
+  raises `UnsupportedFeatureError` before the connection is touched. Every first-party sync adapter declares
+  the capability except BigQuery, whose DBAPI has no connection-level transactions (`commit()` is a no-op and
+  there is no `rollback()`); async command classes stay undeclared until the async transaction APIs land. This
+  is also the first shipped conformance capability profile: `capability_profiles()` now carries `transactions`
+  (nine sync cases — durability, rollback, context-manager lifecycle, delegation, and error precedence), the
+  runners automatically exercise it for every declaring adapter, and the previously provisional capability
+  surface (`ConformanceProfile`, `SyncCase`, `AsyncCase`, `capability_profiles()`) is now stable. See
+  [Transactions](transactions.md).
 * feat: add reusable adapter conformance suite and capability profiles. PR [#565](https://github.com/zschumacher/pydapper/pull/565) by [@zschumacher](https://github.com/zschumacher).
 * v1: a reusable adapter conformance suite now ships in the installed distribution at
   `pydapper.testing.adapter_conformance`. Adapter authors implement a typed `SyncAdapterHarness` /

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,0 +1,61 @@
+pydapper's synchronous command classes expose explicit transaction handling: `commit()`, `rollback()`, and a
+`transaction()` context manager. Transactions are deliberately boring — pydapper never hides an autocommit
+behind your back, never emits `BEGIN` for you, and delegates directly to the DBAPI connection.
+
+All three methods are gated behind `AdapterCapability.TRANSACTIONS`. An adapter that does not declare the
+capability raises `UnsupportedFeatureError` immediately, before the connection is touched:
+
+```python
+import pydapper
+from pydapper.exceptions import UnsupportedFeatureError
+
+with pydapper.connect("sqlite://pydapper.db") as commands:
+    commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # True
+```
+
+Every first-party sync adapter except BigQuery declares the capability — see the
+[first-party adapter table](adapter_registration.md#first-party-adapters). BigQuery does not, because its DBAPI
+has no connection-level transactions (`commit()` is a no-op and there is no `rollback()`). The async transaction
+APIs are a separate upcoming feature; async command classes do not declare the capability yet.
+
+## `commit()` and `rollback()`
+
+`commit()` and `rollback()` delegate to the driver connection's `commit()` / `rollback()`. Per the DBAPI
+contract, a transaction starts implicitly with your first statement — there is no `begin()`.
+
+```python
+{!docs/../docs_src/transactions/commit_rollback.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+## `transaction()`
+
+`transaction()` returns a context manager that commits on clean exit and rolls back on any exception
+(including `KeyboardInterrupt`) before re-raising it:
+
+```python
+{!docs/../docs_src/transactions/transaction_context.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+The exact semantics:
+
+* **Entering the block emits no SQL.** The DBAPI's implicit transaction start is the contract; work done before
+  the block on the same connection belongs to the same connection-level transaction.
+* **Clean exit commits.** If the commit itself fails, the error propagates unchanged and no rollback is
+  attempted — connection state after a failed commit is driver-defined.
+* **An exception rolls back and re-raises.** The original exception always wins: if the rollback also fails,
+  the rollback failure is suppressed and the block's exception propagates.
+* **Blocks cannot be nested.** Opening a `transaction()` block inside an active one raises `RuntimeError`.
+  There is only one connection-level transaction; savepoint-based nesting may arrive later as a separate,
+  adapter-gated feature.
+* **Explicit `commit()` / `rollback()` inside a block is allowed.** They operate on the same single
+  connection-level transaction: an inner `commit()` makes the work so far durable, and the block's exit commit
+  covers the remainder.
+
+## Driver notes
+
+Transaction behavior is pinned for every declaring adapter by the
+[`transactions` conformance profile](adapter_conformance.md#the-transactions-profile). Driver-specific
+documentation of transaction defaults (for example MySQL's `autocommit` connect kwarg and SQLite's
+`isolation_level` modes) lives with each driver's page under [Database Support](database_support/intro.md).

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,13 +1,14 @@
+# Transactions
+
 pydapper's synchronous command classes expose explicit transaction handling: `commit()`, `rollback()`, and a
-`transaction()` context manager. Transactions are deliberately boring — pydapper never hides an autocommit
-behind your back, never emits `BEGIN` for you, and delegates directly to the DBAPI connection.
+`transaction()` context manager. Transactions are deliberately boring — pydapper never emits `BEGIN` for you,
+never toggles autocommit itself, and delegates directly to the DBAPI connection.
 
 All three methods are gated behind `AdapterCapability.TRANSACTIONS`. An adapter that does not declare the
 capability raises `UnsupportedFeatureError` immediately, before the connection is touched:
 
 ```python
 import pydapper
-from pydapper.exceptions import UnsupportedFeatureError
 
 with pydapper.connect("sqlite://pydapper.db") as commands:
     commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # True
@@ -17,6 +18,12 @@ Every first-party sync adapter except BigQuery declares the capability — see t
 [first-party adapter table](adapter_registration.md#first-party-adapters). BigQuery does not, because its DBAPI
 has no connection-level transactions (`commit()` is a no-op and there is no `rollback()`). The async transaction
 APIs are a separate upcoming feature; async command classes do not declare the capability yet.
+
+!!! note "`with pydapper.connect(...)` delegates exit behavior to the driver"
+    `Commands.__enter__`/`__exit__` delegate to the driver connection's own context manager. Some drivers'
+    connection context managers commit on clean exit (for example `sqlite3` and `psycopg2`), so leaving the
+    `with connect(...)` block can itself commit outstanding work. The transaction APIs below operate on the
+    same single connection-level transaction that behavior applies to.
 
 ## `commit()` and `rollback()`
 
@@ -46,9 +53,12 @@ The exact semantics:
   attempted — connection state after a failed commit is driver-defined.
 * **An exception rolls back and re-raises.** The original exception always wins: if the rollback also fails,
   the rollback failure is suppressed and the block's exception propagates.
-* **Blocks cannot be nested.** Opening a `transaction()` block inside an active one raises `RuntimeError`.
-  There is only one connection-level transaction; savepoint-based nesting may arrive later as a separate,
-  adapter-gated feature.
+* **Blocks cannot be nested on the same `Commands` instance.** Re-entry raises `RuntimeError`. The guard is
+  per instance, not per connection: a second `Commands` object over the same connection (for example from a
+  second `using()` call) shares the same single connection-level transaction, and a `transaction()` block on
+  one instance is not protected against `commit()`/`rollback()`/`transaction()` calls made through another.
+  Use one `Commands` instance per connection when working with transactions. Savepoint-based nesting may
+  arrive later as a separate, adapter-gated feature.
 * **Explicit `commit()` / `rollback()` inside a block is allowed.** They operate on the same single
   connection-level transaction: an inner `commit()` makes the work so far durable, and the block's exit commit
   covers the remainder.
@@ -56,6 +66,11 @@ The exact semantics:
 ## Driver notes
 
 Transaction behavior is pinned for every declaring adapter by the
-[`transactions` conformance profile](adapter_conformance.md#the-transactions-profile). Driver-specific
-documentation of transaction defaults (for example MySQL's `autocommit` connect kwarg and SQLite's
-`isolation_level` modes) lives with each driver's page under [Database Support](database_support/intro.md).
+[`transactions` conformance profile](adapter_conformance.md#the-transactions-profile), and per-driver limits
+are recorded in the driver-limits column of the
+[first-party conformance matrix](adapter_conformance.md#first-party-driver-conformance-matrix). Driver-level
+transaction defaults still apply beneath these APIs — for example `mysql-connector-python` connects with
+`autocommit=False` (so no DML is durable until you commit, though MySQL still implicitly commits every DDL
+statement), and `sqlite3`'s legacy `isolation_level` mode
+opens implicit transactions for DML but not DDL, which means a rolled-back block can leave a `CREATE TABLE`
+behind. Consult your driver's own documentation for its autocommit and isolation semantics.

--- a/docs_src/connections/mysql_connector_python_connect.py
+++ b/docs_src/connections/mysql_connector_python_connect.py
@@ -13,4 +13,4 @@ with pydapper.connect("mysql+mysql://root:pydapper@localhost:3307/pydapper", aut
         # <class 'mysql.connector.cursor_cext.CMySQLCursor'>
 
     # you could alternatively commit your transaction all together at the end of the block
-    commands.connection.commit()
+    commands.commit()

--- a/docs_src/connections/mysql_connector_python_connect.py
+++ b/docs_src/connections/mysql_connector_python_connect.py
@@ -1,7 +1,8 @@
 import pydapper
 
-# NOTE: setting autocommit to True will cause the transaction to commit immediately
-with pydapper.connect("mysql+mysql://root:pydapper@localhost:3307/pydapper", autocommit=True) as commands:
+# mysql-connector-python defaults to autocommit=False, so no DML is durable until you
+# commit; alternatively pass autocommit=True to connect to commit each statement immediately
+with pydapper.connect("mysql+mysql://root:pydapper@localhost:3307/pydapper") as commands:
     print(type(commands))
     # <class 'pydapper.mysql.mysql_connector_python.MySqlConnectorPythonCommands'>
 
@@ -12,5 +13,5 @@ with pydapper.connect("mysql+mysql://root:pydapper@localhost:3307/pydapper", aut
         print(type(raw_cursor))
         # <class 'mysql.connector.cursor_cext.CMySQLCursor'>
 
-    # you could alternatively commit your transaction all together at the end of the block
+    # commit any outstanding work all together at the end of the block
     commands.commit()

--- a/docs_src/transactions/commit_rollback.py
+++ b/docs_src/transactions/commit_rollback.py
@@ -1,0 +1,18 @@
+import datetime
+
+from pydapper import connect
+
+with connect() as commands:
+    commands.execute(
+        "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+        params={"description": "A rollback example", "due_date": datetime.date.today(), "owner_id": 1},
+    )
+    # discard the uncommitted insert
+    commands.rollback()
+
+    commands.execute(
+        "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+        params={"description": "A commit example", "due_date": datetime.date.today(), "owner_id": 1},
+    )
+    # make the insert durable
+    commands.commit()

--- a/docs_src/transactions/transaction_context.py
+++ b/docs_src/transactions/transaction_context.py
@@ -1,0 +1,15 @@
+import datetime
+
+from pydapper import connect
+
+with connect() as commands:
+    with commands.transaction():
+        commands.execute(
+            "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+            params={"description": "A transaction example", "due_date": datetime.date.today(), "owner_id": 1},
+        )
+        commands.execute(
+            "update task set description = ?description? where id = ?id?",
+            params={"id": 1, "description": "Updated in the same transaction"},
+        )
+    # the block exited cleanly, so both statements are committed together

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Overview: index.md
   - Compatibility Policy: compatibility.md
   - Command options: command_options.md
+  - Transactions: transactions.md
   - Adapter registration: adapter_registration.md
   - Adapter conformance: adapter_conformance.md
   - Database Support:

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -12,6 +12,7 @@ from typing import Any
 from typing import AsyncGenerator
 from typing import Callable
 from typing import ClassVar
+from typing import ContextManager
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
     from .types import CursorType
     from .types import ListParamType
     from .types import ParamType
+    from .types import TransactionalConnectionType
 
     _T = TypeVar("_T")
     _Default = TypeVar("_Default")
@@ -350,6 +352,7 @@ class BaseCommands(ABC):
 class Commands(BaseCommands, ABC):
     def __init__(self, connection: "ConnectionType"):
         self.connection = connection
+        self._in_transaction = False
 
     def __enter__(self) -> "Commands":
         if hasattr(self.connection, "__enter__"):
@@ -363,6 +366,64 @@ class Commands(BaseCommands, ABC):
     @classmethod
     @abstractmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands": ...
+
+    def commit(self) -> None:
+        """Commit the connection's current transaction.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` before the connection is touched. May be called inside an open
+        ``transaction()`` block: there is only the single connection-level PEP 249 transaction, so
+        this commits the work so far and the block's exit commit covers the remainder.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        cast("TransactionalConnectionType", self.connection).commit()
+
+    def rollback(self) -> None:
+        """Roll back the connection's current transaction.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` before the connection is touched.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        cast("TransactionalConnectionType", self.connection).rollback()
+
+    def transaction(self) -> ContextManager[None]:
+        """Return a context manager that commits on normal exit and rolls back on exception.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` at call time, before the returned context manager is entered.
+        Entering the block emits no SQL — the DBAPI's implicit transaction start is the contract.
+        On a clean exit the block commits; on any exception (``BaseException`` included) it rolls
+        back and re-raises, with a rollback failure losing to the active exception. A commit
+        failure on clean exit propagates unchanged and no rollback is attempted, because
+        connection state after a failed commit is driver-defined. Blocks cannot be nested on the
+        same instance; re-entry raises ``RuntimeError``.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        return self._transaction_proxy()
+
+    @contextmanager
+    def _transaction_proxy(self) -> Generator[None, None, None]:
+        if self._in_transaction:
+            raise RuntimeError(
+                "transaction() blocks cannot be nested; a transaction block is already active on this "
+                "Commands instance"
+            )
+        self._in_transaction = True
+        try:
+            try:
+                yield
+            except BaseException:
+                # the active error wins over a rollback failure (same precedence as _cursor_context_proxy)
+                try:
+                    self.rollback()
+                except BaseException:
+                    pass
+                raise
+            else:
+                self.commit()
+        finally:
+            self._in_transaction = False
 
     @contextmanager
     def _cursor_context_proxy(self):

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -350,9 +350,12 @@ class BaseCommands(ABC):
 
 
 class Commands(BaseCommands, ABC):
+    # class-level default so a subclass that overrides __init__ without calling super() still
+    # gets a working transaction guard; entering a block shadows it per instance
+    _in_transaction: bool = False
+
     def __init__(self, connection: "ConnectionType"):
         self.connection = connection
-        self._in_transaction = False
 
     def __enter__(self) -> "Commands":
         if hasattr(self.connection, "__enter__"):
@@ -397,7 +400,11 @@ class Commands(BaseCommands, ABC):
         back and re-raises, with a rollback failure losing to the active exception. A commit
         failure on clean exit propagates unchanged and no rollback is attempted, because
         connection state after a failed commit is driver-defined. Blocks cannot be nested on the
-        same instance; re-entry raises ``RuntimeError``.
+        same instance; re-entry raises ``RuntimeError``. The guard is per ``Commands`` instance:
+        a second instance over the same connection (for example from a second ``using()`` call)
+        shares the same single connection-level transaction and is not guarded against. Entering
+        the returned context manager manually without exiting it leaves the rollback to generator
+        finalization at a nondeterministic time; always use ``with``.
         """
         self._require_capability(AdapterCapability.TRANSACTIONS)
         return self._transaction_proxy()

--- a/pydapper/mssql/pymssql.py
+++ b/pydapper/mssql/pymssql.py
@@ -16,7 +16,7 @@ _PARAM_TYPE_LOOKUP = {float: "%d", int: "%d", str: "%s", Decimal: "%d"}
 
 
 class PymssqlCommands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -55,7 +55,7 @@ def _discard_unread_result(cursor: "CursorType") -> None:
 
 
 class MySqlConnectorPythonCommands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/oracle/oracledb.py
+++ b/pydapper/oracle/oracledb.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class OracledbCommands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/pydapper/postgresql/psycopg2.py
+++ b/pydapper/postgresql/psycopg2.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class Psycopg2Commands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class Psycopg3Commands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":

--- a/pydapper/sqlite/sqlite3.py
+++ b/pydapper/sqlite/sqlite3.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class Sqlite3Commands(Commands):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     class SqlParamHandler(BaseSqlParamHandler):
         def get_param_placeholder(self, param_name) -> str:

--- a/pydapper/testing/adapter_conformance/__init__.py
+++ b/pydapper/testing/adapter_conformance/__init__.py
@@ -12,13 +12,11 @@ mandatory per-mode core profiles::
 ``core-sync`` and ``core-async`` are independent mandatory profiles; a dual-mode
 adapter must pass both. Optional capabilities are covered by independent capability
 profiles keyed to :class:`pydapper.AdapterCapability`; see :func:`capability_profiles`.
-
-The capability surface — :class:`ConformanceProfile`, :class:`SyncCase`,
-:class:`AsyncCase`, and :func:`capability_profiles` — is **provisional**: no capability
-profile ships yet, so there is nothing for an adapter author to write against, and this
-part of the API may change when the first one lands. The mandatory core surface is not
-provisional. See the "Extending the suite in future capability work" section of the
-adapter conformance documentation.
+The runners automatically append the profile cases for every capability the command
+class declares, so a declaring adapter is exercised against its capability profiles
+in the same run as the core inventory. The first shipped capability profile is
+``transactions``. See the "Extending the suite in future capability work" section of
+the adapter conformance documentation.
 
 This package uses only the standard library and pydapper core: it never imports
 pytest, optional database drivers, or any test-service tooling, and importing it
@@ -29,12 +27,14 @@ from ._harness import AsyncAdapterHarness
 from ._harness import SyncAdapterHarness
 from ._profiles import CORE_ASYNC
 from ._profiles import CORE_SYNC
+from ._profiles import TRANSACTIONS_PROFILE
 from ._profiles import AsyncCase
 from ._profiles import ConformanceProfile
 from ._profiles import SyncCase
 from ._profiles import capability_profiles
 from ._profiles import core_async_profile
 from ._profiles import core_sync_profile
+from ._profiles import transactions_profile
 from ._results import CaseResult
 from ._results import CaseSelectionError
 from ._results import ConformanceError
@@ -53,6 +53,7 @@ __all__ = [
     "CORE_SYNC",
     "CONFORMANCE_COLUMNS",
     "CONFORMANCE_ROWS",
+    "TRANSACTIONS_PROFILE",
     "AsyncAdapterHarness",
     "AsyncCase",
     "CaseResult",
@@ -71,4 +72,5 @@ __all__ = [
     "run_core_async",
     "run_core_sync",
     "seed_rows",
+    "transactions_profile",
 ]

--- a/pydapper/testing/adapter_conformance/_cases_transactions.py
+++ b/pydapper/testing/adapter_conformance/_cases_transactions.py
@@ -121,16 +121,17 @@ def _transactions_context_rolls_back(ctx: SyncCaseContext) -> None:
             commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
             raise fault
     ctx.check(caught.exception is fault, "the block's exception must propagate as the same exception object")
-    ctx.recover(commands)
     ctx.check(
         _row_count(ctx, commands, _TX_ROW["id"]) == 0,
         "a transaction() block that raised must roll its insert back",
     )
+    # recover runs last so a harness recovery step can never repair the state under test
+    ctx.recover(commands)
 
 
 @_case(
     "transactions.commit-delegates-once",
-    "commit() delegates to the connection exactly once and acquires no cursor",
+    "commit() delegates to the connection exactly once, acquires no cursor, and its failure propagates",
     "instrumented",
 )
 def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
@@ -144,10 +145,19 @@ def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
     ctx.check(connection.cursor_calls == 0, "commit() must not acquire a cursor")
     ctx.check_event_order(connection.log, ("commit",))
 
+    fault = _InjectedTransactionCleanupFault("commit")
+    failing = ctx.recording_connection(commit_error=fault)
+    commands = ctx.instrumented_commands(failing)
+    with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
+        commands.commit()
+    ctx.check(caught.exception is fault, "a connection commit failure must propagate from commit() unchanged")
+    ctx.check(failing.commit_calls == 1, f"expected exactly one commit attempt, saw {failing.commit_calls}")
+    ctx.check(failing.rollback_calls == 0, "a failed commit() must not trigger a rollback")
+
 
 @_case(
     "transactions.rollback-delegates-once",
-    "rollback() delegates to the connection exactly once and acquires no cursor",
+    "rollback() delegates to the connection exactly once, acquires no cursor, and its failure propagates",
     "instrumented",
 )
 def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
@@ -162,6 +172,15 @@ def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
     ctx.check(connection.commit_calls == 0, "rollback() must not commit")
     ctx.check(connection.cursor_calls == 0, "rollback() must not acquire a cursor")
     ctx.check_event_order(connection.log, ("rollback",))
+
+    fault = _InjectedTransactionCleanupFault("rollback")
+    failing = ctx.recording_connection(rollback_error=fault)
+    commands = ctx.instrumented_commands(failing)
+    with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
+        commands.rollback()
+    ctx.check(caught.exception is fault, "a connection rollback failure must propagate from rollback() unchanged")
+    ctx.check(failing.rollback_calls == 1, f"expected exactly one rollback attempt, saw {failing.rollback_calls}")
+    ctx.check(failing.commit_calls == 0, "a failed rollback() must not trigger a commit")
 
 
 @_case(

--- a/pydapper/testing/adapter_conformance/_cases_transactions.py
+++ b/pydapper/testing/adapter_conformance/_cases_transactions.py
@@ -1,0 +1,229 @@
+"""The ``transactions`` capability profile's sync case inventory.
+
+These cases run only for command classes that declare
+:attr:`~pydapper.capabilities.AdapterCapability.TRANSACTIONS`. Every ``live`` case
+first commits the harness baseline (``create_commands()`` then ``commit()``) so the
+scenario starts from a durable, transaction-free state regardless of whether the
+harness seeded inside an open transaction. ``instrumented`` cases observe delegation,
+ordering, and error precedence directly through recording connections.
+
+The async inventory ships with the async transaction APIs (#464).
+"""
+
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from pydapper.commands import Commands
+
+from ._checks import SyncCaseContext
+from ._profiles import SyncCase
+
+_CASES: List[SyncCase] = []
+
+
+def _case(case_id: str, description: str, kind: str) -> Callable[[Callable[[SyncCaseContext], None]], Callable]:
+    def register(fn: Callable[[SyncCaseContext], None]) -> Callable[[SyncCaseContext], None]:
+        _CASES.append(SyncCase(case_id=case_id, description=description, kind=kind, run=fn))
+        return fn
+
+    return register
+
+
+def transactions_sync_cases() -> Tuple[SyncCase, ...]:
+    """Return the full, ordered, immutable ``transactions`` sync case inventory."""
+    return _FROZEN_CASES
+
+
+class _InjectedTransactionFault(Exception):
+    """Framework-injected failure raised inside a transaction block."""
+
+
+class _InjectedTransactionCleanupFault(Exception):
+    """Framework-injected connection commit/rollback failure."""
+
+
+_TX_ROW: Dict[str, Any] = {"id": 100, "label": "tx", "score": 7, "note": "tx-note"}
+
+
+def _row_count(ctx: SyncCaseContext, commands: Commands, row_id: int) -> int:
+    return len(commands.query(ctx.sql("select_by_id"), params={"id": row_id}))
+
+
+@_case(
+    "transactions.commit-persists",
+    "commit() makes a write durable: a later rollback() cannot remove it",
+    "live",
+)
+def _transactions_commit_persists(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    commands.commit()
+    commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    commands.commit()
+    commands.rollback()
+    ctx.check(
+        _row_count(ctx, commands, _TX_ROW["id"]) == 1,
+        "a committed insert must survive a subsequent rollback()",
+    )
+
+
+@_case(
+    "transactions.rollback-discards",
+    "rollback() discards uncommitted work and leaves committed rows intact",
+    "live",
+)
+def _transactions_rollback_discards(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    commands.commit()
+    commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    commands.rollback()
+    ctx.check(
+        _row_count(ctx, commands, _TX_ROW["id"]) == 0,
+        "rollback() must discard the uncommitted insert",
+    )
+    rows = commands.query(ctx.sql("select_all"))
+    ctx.check(
+        len(rows) == len(ctx.seeded_rows()),
+        f"rollback() must leave the {len(ctx.seeded_rows())} committed baseline rows intact, saw {len(rows)}",
+    )
+
+
+@_case(
+    "transactions.context-commits-on-exit",
+    "A transaction() block commits on clean exit",
+    "live",
+)
+def _transactions_context_commits(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    commands.commit()
+    with commands.transaction():
+        commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    commands.rollback()
+    ctx.check(
+        _row_count(ctx, commands, _TX_ROW["id"]) == 1,
+        "a clean transaction() exit must commit; a later rollback() cannot remove the insert",
+    )
+
+
+@_case(
+    "transactions.context-rolls-back-on-error",
+    "A transaction() block rolls back on exception and re-raises the same exception",
+    "live",
+)
+def _transactions_context_rolls_back(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    commands.commit()
+    fault = _InjectedTransactionFault("boom")
+    with ctx.expect_raises(_InjectedTransactionFault) as caught:
+        with commands.transaction():
+            commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
+            raise fault
+    ctx.check(caught.exception is fault, "the block's exception must propagate as the same exception object")
+    ctx.recover(commands)
+    ctx.check(
+        _row_count(ctx, commands, _TX_ROW["id"]) == 0,
+        "a transaction() block that raised must roll its insert back",
+    )
+
+
+@_case(
+    "transactions.commit-delegates-once",
+    "commit() delegates to the connection exactly once and acquires no cursor",
+    "instrumented",
+)
+def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    # a third-party override may return a value; the contract pins None
+    result = commands.commit()  # type: ignore[func-returns-value]
+    ctx.check(result is None, f"commit() must return None, got {result!r}")
+    ctx.check(connection.commit_calls == 1, f"expected exactly one connection commit, saw {connection.commit_calls}")
+    ctx.check(connection.rollback_calls == 0, "commit() must not roll back")
+    ctx.check(connection.cursor_calls == 0, "commit() must not acquire a cursor")
+    ctx.check_event_order(connection.log, ("commit",))
+
+
+@_case(
+    "transactions.rollback-delegates-once",
+    "rollback() delegates to the connection exactly once and acquires no cursor",
+    "instrumented",
+)
+def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    # a third-party override may return a value; the contract pins None
+    result = commands.rollback()  # type: ignore[func-returns-value]
+    ctx.check(result is None, f"rollback() must return None, got {result!r}")
+    ctx.check(
+        connection.rollback_calls == 1, f"expected exactly one connection rollback, saw {connection.rollback_calls}"
+    )
+    ctx.check(connection.commit_calls == 0, "rollback() must not commit")
+    ctx.check(connection.cursor_calls == 0, "rollback() must not acquire a cursor")
+    ctx.check_event_order(connection.log, ("rollback",))
+
+
+@_case(
+    "transactions.context-lifecycle-order",
+    "A clean transaction() block commits exactly once, after the command's cursor lifecycle",
+    "instrumented",
+)
+def _transactions_context_lifecycle(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with commands.transaction():
+        commands.execute("UPDATE t SET label = 'x'")
+    ctx.check(connection.commit_calls == 1, f"expected exactly one commit, saw {connection.commit_calls}")
+    ctx.check(connection.rollback_calls == 0, "a clean transaction() block must not roll back")
+    ctx.check_event_order(connection.log, ("cursor", "enter", "execute", "exit", "commit"))
+
+
+@_case(
+    "transactions.context-error-precedence",
+    "A transaction() block rolls back on error, re-raises it, and the error wins over a rollback failure",
+    "instrumented",
+)
+def _transactions_context_error_precedence(ctx: SyncCaseContext) -> None:
+    fault = _InjectedTransactionFault("boom")
+    connection = ctx.recording_connection()
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedTransactionFault) as caught:
+        with commands.transaction():
+            raise fault
+    ctx.check(caught.exception is fault, "the block's exception must propagate as the same exception object")
+    ctx.check(
+        connection.rollback_calls == 1, f"expected exactly one connection rollback, saw {connection.rollback_calls}"
+    )
+    ctx.check(connection.commit_calls == 0, "a failed transaction() block must not commit")
+
+    rollback_fault = _InjectedTransactionCleanupFault("rollback")
+    failing = ctx.recording_connection(rollback_error=rollback_fault)
+    commands = ctx.instrumented_commands(failing)
+    with ctx.expect_raises(_InjectedTransactionFault) as caught_again:
+        with commands.transaction():
+            raise fault
+    ctx.check(caught_again.exception is fault, "the block's exception must win over a rollback failure")
+    ctx.check(failing.rollback_calls == 1, f"expected exactly one rollback attempt, saw {failing.rollback_calls}")
+
+
+@_case(
+    "transactions.commit-failure-propagates",
+    "A commit failure on clean transaction() exit propagates unchanged with no rollback attempt",
+    "instrumented",
+)
+def _transactions_commit_failure(ctx: SyncCaseContext) -> None:
+    commit_fault = _InjectedTransactionCleanupFault("commit")
+    connection = ctx.recording_connection(commit_error=commit_fault)
+    commands = ctx.instrumented_commands(connection)
+    with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
+        with commands.transaction():
+            pass
+    ctx.check(caught.exception is commit_fault, "the commit failure must propagate as the same exception object")
+    ctx.check(connection.commit_calls == 1, f"expected exactly one commit attempt, saw {connection.commit_calls}")
+    ctx.check(connection.rollback_calls == 0, "no rollback may be attempted after a failed commit")
+
+
+#: The production inventory is frozen once at import; later mutation of the private
+#: registration list cannot alter what the runner executes.
+_FROZEN_CASES: Tuple[SyncCase, ...] = tuple(_CASES)

--- a/pydapper/testing/adapter_conformance/_checks.py
+++ b/pydapper/testing/adapter_conformance/_checks.py
@@ -189,8 +189,12 @@ class SyncCaseContext(_BaseCaseContext):
         self,
         scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
         cursor_style: str = "context",
+        commit_error: Optional[BaseException] = None,
+        rollback_error: Optional[BaseException] = None,
     ) -> RecordingConnection:
-        return RecordingConnection(scripts, cursor_style=cursor_style)
+        return RecordingConnection(
+            scripts, cursor_style=cursor_style, commit_error=commit_error, rollback_error=rollback_error
+        )
 
     def instrumented_commands(self, connection: RecordingConnection) -> Commands:
         return self.command_class(cast("ConnectionType", connection))  # type: ignore[abstract]

--- a/pydapper/testing/adapter_conformance/_instrumentation.py
+++ b/pydapper/testing/adapter_conformance/_instrumentation.py
@@ -347,13 +347,16 @@ class RecordingConnection:
     ``scripts`` supplies one :class:`CursorScript` per acquired cursor; the last
     script repeats if more cursors are acquired than scripts were given.
     ``cursor_style`` selects the cursor shape: ``"context"`` (native context manager)
-    or ``"plain"`` (close-only).
+    or ``"plain"`` (close-only). ``commit_error``/``rollback_error`` inject a failure
+    at the named connection-level transaction interaction.
     """
 
     def __init__(
         self,
         scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
         cursor_style: str = "context",
+        commit_error: Optional[BaseException] = None,
+        rollback_error: Optional[BaseException] = None,
     ) -> None:
         if scripts is None:
             scripts = CursorScript()
@@ -361,10 +364,26 @@ class RecordingConnection:
             scripts = [scripts]
         self._scripts = list(scripts)
         self._cursor_style = cursor_style
+        self._commit_error = commit_error
+        self._rollback_error = rollback_error
         self.log = RecordingLog()
         self.cursor_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
         self.recorders: List[CursorRecorder] = []
         self.cursors: List[_SyncCursorFacade] = []
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+        self.log.add(RecordedEvent(kind="commit"))
+        if self._commit_error is not None:
+            raise self._commit_error
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+        self.log.add(RecordedEvent(kind="rollback"))
+        if self._rollback_error is not None:
+            raise self._rollback_error
 
     def cursor(self, *args: Any, **kwargs: Any) -> _SyncCursorFacade:
         self.cursor_calls += 1

--- a/pydapper/testing/adapter_conformance/_profiles.py
+++ b/pydapper/testing/adapter_conformance/_profiles.py
@@ -2,15 +2,14 @@
 
 ``core-sync`` and ``core-async`` are the mandatory per-mode profiles. Optional
 capability profiles are keyed to :class:`~pydapper.capabilities.AdapterCapability`
-members; each future capability feature adds its own independent profile here in the
-same change that implements the feature. The production catalog is immutable and is
-intentionally empty until the first capability feature lands — an unimplemented
-capability must never appear covered.
+members; each capability feature adds its own independent profile here in the same
+change that implements the feature — an unimplemented capability must never appear
+covered. The production catalog is immutable and currently ships the
+``transactions`` profile.
 
-Because no capability profile ships yet, the public capability surface here
-(:class:`ConformanceProfile`, :class:`SyncCase`, :class:`AsyncCase`, and
-:func:`capability_profiles`) is **provisional** and may change with the first real
-capability feature. The mandatory core profiles are not provisional.
+The capability surface (:class:`ConformanceProfile`, :class:`SyncCase`,
+:class:`AsyncCase`, and :func:`capability_profiles`) is stable alongside the
+mandatory core profiles.
 """
 
 from dataclasses import dataclass
@@ -37,6 +36,9 @@ CORE_SYNC = "core-sync"
 #: Stable identifier of the mandatory asynchronous core profile.
 CORE_ASYNC = "core-async"
 
+#: Stable identifier of the optional ``transactions`` capability profile.
+TRANSACTIONS_PROFILE = "transactions"
+
 #: Case kinds: ``"live"`` cases run through the harness's real database resources;
 #: ``"instrumented"`` cases run the real concrete command class around
 #: framework-owned recording/fault-injection connections.
@@ -47,8 +49,7 @@ CASE_KINDS = ("live", "instrumented")
 class SyncCase:
     """One named synchronous conformance case. ``run`` is framework-owned.
 
-    Provisional alongside :class:`ConformanceProfile` until the first capability
-    profile ships; adapter authors do not write cases today.
+    Adapter authors do not write cases; profiles ship with the framework.
     """
 
     case_id: str
@@ -61,7 +62,7 @@ class SyncCase:
 class AsyncCase:
     """One named asynchronous conformance case. ``run`` is framework-owned.
 
-    Provisional alongside :class:`ConformanceProfile`; see :class:`SyncCase`.
+    See :class:`SyncCase`.
     """
 
     case_id: str
@@ -83,10 +84,6 @@ def _validate_cases(profile_id: str, cases: Tuple[Any, ...], mode: str) -> None:
 @dataclass(frozen=True)
 class ConformanceProfile:
     """A named, per-mode set of conformance cases.
-
-    Provisional: outside the two mandatory core profiles, nothing constructs this yet
-    (the production capability catalog is empty), so its shape may change with the first
-    capability feature.
 
     A profile must contain at least one case; zero-case profiles are rejected so an
     empty profile can never make a capability appear covered. Case identifiers are
@@ -127,17 +124,32 @@ def core_async_profile() -> ConformanceProfile:
     return ConformanceProfile(profile_id=CORE_ASYNC, capability=None, async_cases=async_core_cases())
 
 
+def transactions_profile() -> ConformanceProfile:
+    """Build the optional ``transactions`` capability profile.
+
+    Sync cases only: the async transaction APIs are a separate feature, and the async
+    inventory ships with them. Until then an async command class may not declare
+    :attr:`AdapterCapability.TRANSACTIONS` — ``capabilities.declared-profile-populated``
+    rejects a declaration with no cases for its mode.
+    """
+    from ._cases_transactions import transactions_sync_cases
+
+    return ConformanceProfile(
+        profile_id=TRANSACTIONS_PROFILE,
+        capability=AdapterCapability.TRANSACTIONS,
+        sync_cases=transactions_sync_cases(),
+    )
+
+
 def capability_profiles() -> Mapping[AdapterCapability, ConformanceProfile]:
     """Return the production catalog of optional capability profiles.
 
-    The catalog is immutable and currently empty: no optional capability is
-    implemented yet, so no capability profile exists and there is nothing here for an
-    adapter author to act on. Future capability features register their profile here in
-    the same change that implements the capability, keyed by the owning
-    :class:`AdapterCapability` member; until the first one lands this function and the
-    profile/case types it returns are provisional and may change.
+    The catalog is immutable. Capability features register their profile here in the
+    same change that implements the capability, keyed by the owning
+    :class:`AdapterCapability` member; a capability with no profile here is not
+    implemented and may not be declared by any command class.
     """
-    return MappingProxyType({})
+    return MappingProxyType({AdapterCapability.TRANSACTIONS: transactions_profile()})
 
 
 def validate_capability_catalog(catalog: Mapping[AdapterCapability, ConformanceProfile]) -> None:

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -28,6 +28,22 @@ class ConnectionType(Protocol):
     def cursor(self, *args: Optional[Any], **kwargs: Optional[Any]) -> "CursorType": ...
 
 
+class TransactionalConnectionType(Protocol):
+    """Connections usable by the capability-gated transaction APIs.
+
+    Deliberately not part of ``ConnectionType``: PEP 249 makes ``rollback()`` optional and some
+    DBAPIs (e.g. BigQuery) omit it entirely, so requiring these members on every connection would
+    structurally break connections that cannot support transactions. Command classes gate access
+    behind ``AdapterCapability.TRANSACTIONS`` instead.
+    """
+
+    @abstractmethod
+    def commit(self) -> Any: ...
+
+    @abstractmethod
+    def rollback(self) -> Any: ...
+
+
 class AsyncConnectionType(Protocol):
     @abstractmethod
     def __await__(self): ...

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -72,6 +72,8 @@ class MockAsyncCursor:
 class MockConnection:
     def __init__(self):
         self.closed = 0
+        self.commits = 0
+        self.rollbacks = 0
 
     def __enter__(self):
         return self
@@ -83,10 +85,10 @@ class MockConnection:
         return MockCursor()
 
     def commit(self):
-        pass
+        self.commits += 1
 
     def rollback(self):
-        pass
+        self.rollbacks += 1
 
     def close(self):
         self.closed = 1
@@ -95,6 +97,8 @@ class MockConnection:
 class MockAsyncConnection:
     def __init__(self):
         self.closed = 0
+        self.commits = 0
+        self.rollbacks = 0
 
     async def __aenter__(self):
         return self
@@ -106,10 +110,10 @@ class MockAsyncConnection:
         return MockAsyncCursor()
 
     def commit(self):
-        pass
+        self.commits += 1
 
     def rollback(self):
-        pass
+        self.rollbacks += 1
 
     async def close(self):
         self.closed = 1

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -220,6 +220,17 @@ def test_sqlite_in_memory_core_sync_harness_passes(isolated_registry, tmp_path):
     assert all(result.passed for result in transaction_results)
 
 
+def test_non_declaring_adapter_is_never_run_against_the_transactions_profile(isolated_registry):
+    """The unsupported half of the capability contract: an adapter that does not declare
+    TRANSACTIONS passes core conformance without the transactions profile ever running."""
+    _register_mock_sync()
+    report = run_core_sync(MockSyncConformanceHarness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert MockSyncConformanceCommands.capabilities == frozenset()
+    assert [result for result in report.results if result.profile_id == "transactions"] == []
+    assert len(report.results) == len(core_sync_profile().sync_cases)
+
+
 def test_pass_fail_ordering_is_deterministic(isolated_registry):
     _register_mock_sync()
     first = run_core_sync(MockSyncConformanceHarness())
@@ -1498,21 +1509,25 @@ async def test_async_shipped_capability_profile_waives_its_option_probe(isolated
 
 
 def test_capability_profile_without_sync_cases_fails_the_sync_declaration(isolated_registry, monkeypatch):
-    """A capability covered only in the other mode does not cover this one."""
+    """A capability covered only in the other mode does not cover this one.
+
+    Uses RAW_READER so the runner's real production catalog plans no capability cases
+    against the fake connection — TRANSACTIONS now ships real sync cases.
+    """
     from pydapper.testing.adapter_conformance import _cases_sync
 
     name = "conformance-mock-async-only-profile"
-    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
-    catalog = {AdapterCapability.TRANSACTIONS: _profile_for(AdapterCapability.TRANSACTIONS, sync=False)}
+    _register_mock_sync(name=name, commands=_DeclaredRawReaderCommands)
+    catalog = {AdapterCapability.RAW_READER: _profile_for(AdapterCapability.RAW_READER, sync=False)}
     monkeypatch.setattr(_cases_sync, "capability_profiles", lambda: catalog)
 
     class _Harness(MockSyncConformanceHarness):
         adapter_name = name
-        command_class = _DeclaredTransactionsCommands
+        command_class = _DeclaredRawReaderCommands
         connect_dsn = f"sqlite+{name}://mock"
 
         def create_commands(self):
-            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+            return _DeclaredRawReaderCommands(FakeSyncConnection(seeded_mini_db()))
 
     report = run_core_sync(_Harness())
     failures = {failure.case_id: failure.message for failure in report.failures}
@@ -1524,17 +1539,17 @@ async def test_capability_profile_without_async_cases_fails_the_async_declaratio
     from pydapper.testing.adapter_conformance import _cases_async
 
     name = "conformance-mock-sync-only-profile"
-    _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
-    catalog = {AdapterCapability.TRANSACTIONS: _profile_for(AdapterCapability.TRANSACTIONS, async_=False)}
+    _register_mock_async(name=name, async_commands=_DeclaredRawReaderAsyncCommands)
+    catalog = {AdapterCapability.RAW_READER: _profile_for(AdapterCapability.RAW_READER, async_=False)}
     monkeypatch.setattr(_cases_async, "capability_profiles", lambda: catalog)
 
     class _Harness(MockAsyncConformanceHarness):
         adapter_name = name
-        command_class = _DeclaredTransactionsAsyncCommands
+        command_class = _DeclaredRawReaderAsyncCommands
         connect_dsn = f"sqlite+{name}://mock"
 
         async def create_commands(self):
-            return _DeclaredTransactionsAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+            return _DeclaredRawReaderAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
 
     report = await run_core_async(_Harness())
     failures = {failure.case_id: failure.message for failure in report.failures}

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -212,6 +212,12 @@ def test_sqlite_in_memory_core_sync_harness_passes(isolated_registry, tmp_path):
     assert report.passed, [(f.case_id, f.message) for f in report.failures]
     assert report.adapter_name == "sqlite3"
     assert report.command_class_name.endswith("Sqlite3Commands")
+    # Sqlite3Commands declares TRANSACTIONS, so the runner appends the production
+    # transactions profile after the core inventory — live supported-adapter coverage
+    transaction_results = [result for result in report.results if result.profile_id == "transactions"]
+    expected_ids = [case.case_id for case in capability_profiles()[AdapterCapability.TRANSACTIONS].sync_cases]
+    assert [result.case_id for result in transaction_results] == expected_ids
+    assert all(result.passed for result in transaction_results)
 
 
 def test_pass_fail_ordering_is_deterministic(isolated_registry):
@@ -362,62 +368,68 @@ class _DeclaredTransactionsCommands(MockSyncConformanceCommands):
     capabilities = frozenset({AdapterCapability.TRANSACTIONS})
 
 
+class _DeclaredRawReaderCommands(MockSyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.RAW_READER})
+
+
 def test_declared_capability_without_profile_fails_clearly(isolated_registry):
-    name = "conformance-mock-declared-txn"
-    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    name = "conformance-mock-declared-raw"
+    _register_mock_sync(name=name, commands=_DeclaredRawReaderCommands)
 
     class _Harness(MockSyncConformanceHarness):
         adapter_name = name
-        command_class = _DeclaredTransactionsCommands
+        command_class = _DeclaredRawReaderCommands
         connect_dsn = f"sqlite+{name}://mock"
 
         def create_commands(self):
-            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+            return _DeclaredRawReaderCommands(FakeSyncConnection(seeded_mini_db()))
 
     report = run_core_sync(_Harness())
     failed_ids = [failure.case_id for failure in report.failures]
     assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
     named = report.failures[0]
-    assert "transactions" in named.message
+    assert "raw_reader" in named.message
     assert named.profile_id == CORE_SYNC
 
 
 def test_synthetic_capability_profile_runs_but_cannot_cover_a_declaration(isolated_registry):
     """A test-local synthetic profile runs its cases, but only the production catalog
     can satisfy the declared-capability honesty check — injection is not a bypass."""
-    name = "conformance-mock-synth-txn"
-    _register_mock_sync(name=name, commands=_DeclaredTransactionsCommands)
+    name = "conformance-mock-synth-raw"
+    _register_mock_sync(name=name, commands=_DeclaredRawReaderCommands)
 
     class _Harness(MockSyncConformanceHarness):
         adapter_name = name
-        command_class = _DeclaredTransactionsCommands
+        command_class = _DeclaredRawReaderCommands
         connect_dsn = f"sqlite+{name}://mock"
 
         def create_commands(self):
-            return _DeclaredTransactionsCommands(FakeSyncConnection(seeded_mini_db()))
+            return _DeclaredRawReaderCommands(FakeSyncConnection(seeded_mini_db()))
 
     ran = []
 
-    def _txn_case(ctx):
+    def _raw_case(ctx):
         ran.append(ctx.case_id)
         commands = ctx.command_class(FakeSyncConnection())
-        ctx.check(commands.supports(AdapterCapability.TRANSACTIONS), "declared capability must be supported")
+        ctx.check(commands.supports(AdapterCapability.RAW_READER), "declared capability must be supported")
 
     synthetic = ConformanceProfile(
-        profile_id="transactions",
-        capability=AdapterCapability.TRANSACTIONS,
-        sync_cases=(SyncCase("transactions.smoke", "synthetic transactions case", "instrumented", _txn_case),),
+        profile_id="raw_reader",
+        capability=AdapterCapability.RAW_READER,
+        sync_cases=(SyncCase("raw_reader.smoke", "synthetic raw reader case", "instrumented", _raw_case),),
     )
-    report = run_core_sync(_Harness(), capability_catalog={AdapterCapability.TRANSACTIONS: synthetic})
-    assert ran == ["transactions.smoke"], "the injected profile's cases must actually run"
-    synthetic_results = [result for result in report.results if result.profile_id == "transactions"]
-    assert [result.case_id for result in synthetic_results] == ["transactions.smoke"]
+    report = run_core_sync(_Harness(), capability_catalog={AdapterCapability.RAW_READER: synthetic})
+    assert ran == ["raw_reader.smoke"], "the injected profile's cases must actually run"
+    synthetic_results = [result for result in report.results if result.profile_id == "raw_reader"]
+    assert [result.case_id for result in synthetic_results] == ["raw_reader.smoke"]
     assert synthetic_results[0].passed
     # the declaration honesty case still fails: the production catalog has no
-    # transactions profile, and an injected catalog can never make one appear covered
+    # raw_reader profile, and an injected catalog can never make one appear covered
     failed_ids = [failure.case_id for failure in report.failures]
     assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
-    assert capability_profiles() == {}, "the production catalog must stay empty until a capability ships"
+    assert (
+        AdapterCapability.RAW_READER not in capability_profiles()
+    ), "the production catalog must not cover a capability until its feature ships"
 
 
 def test_option_probes_cannot_be_waived_by_declaration_alone(isolated_registry):
@@ -465,9 +477,16 @@ def test_option_probes_cannot_be_waived_by_declaration_alone(isolated_registry):
     assert not report.passed
 
 
-def test_production_capability_catalog_is_empty_and_immutable():
+def test_production_capability_catalog_ships_transactions_and_is_immutable():
     catalog = capability_profiles()
-    assert dict(catalog) == {}
+    assert set(catalog) == {AdapterCapability.TRANSACTIONS}
+    profile = catalog[AdapterCapability.TRANSACTIONS]
+    assert profile.profile_id == "transactions"
+    assert profile.capability is AdapterCapability.TRANSACTIONS
+    assert profile.sync_cases, "the transactions profile must ship real sync cases"
+    # async transaction APIs have not landed; async cases arrive with that feature
+    assert profile.async_cases == ()
+    validate_capability_catalog(catalog)
     with pytest.raises(TypeError):
         catalog[AdapterCapability.TRANSACTIONS] = None  # type: ignore[index]
 
@@ -1151,6 +1170,36 @@ def test_recording_connections_accept_a_sequence_of_scripts():
     assert async_connection.cursor_calls == 0
 
 
+def test_recording_connection_records_commit_and_rollback():
+    connection = RecordingConnection()
+    assert connection.commit_calls == 0
+    assert connection.rollback_calls == 0
+
+    connection.commit()
+    connection.rollback()
+    connection.rollback()
+    assert connection.commit_calls == 1
+    assert connection.rollback_calls == 2
+    assert connection.log.kinds() == ("commit", "rollback", "rollback")
+
+
+def test_recording_connection_injects_commit_and_rollback_faults():
+    commit_fault = RuntimeError("commit boom")
+    rollback_fault = RuntimeError("rollback boom")
+    connection = RecordingConnection(commit_error=commit_fault, rollback_error=rollback_fault)
+
+    with pytest.raises(RuntimeError) as commit_info:
+        connection.commit()
+    assert commit_info.value is commit_fault
+    with pytest.raises(RuntimeError) as rollback_info:
+        connection.rollback()
+    assert rollback_info.value is rollback_fault
+    # the interaction is recorded even when it fails
+    assert connection.commit_calls == 1
+    assert connection.rollback_calls == 1
+    assert connection.log.kinds() == ("commit", "rollback")
+
+
 # ------------------------------------------------------------------ connect() cleanup tolerance
 
 
@@ -1388,6 +1437,10 @@ class _DeclaredTransactionsAsyncCommands(MockAsyncConformanceCommands):
     capabilities = frozenset({AdapterCapability.TRANSACTIONS})
 
 
+class _DeclaredRawReaderAsyncCommands(MockAsyncConformanceCommands):
+    capabilities = frozenset({AdapterCapability.RAW_READER})
+
+
 def _profile_for(capability, *, sync=True, async_=True):
     return ConformanceProfile(
         profile_id=capability.value,
@@ -1602,6 +1655,29 @@ def test_capability_catalog_value_must_be_a_profile():
 @pytest.mark.asyncio
 async def test_async_declared_capability_without_profile_fails_clearly(isolated_registry):
     """The async twin of the sync declaration-honesty check, against the real catalog."""
+    name = "conformance-mock-declared-raw-async"
+    _register_mock_async(name=name, async_commands=_DeclaredRawReaderAsyncCommands)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _DeclaredRawReaderAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _DeclaredRawReaderAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    report = await run_core_async(_Harness())
+    failed_ids = [failure.case_id for failure in report.failures]
+    assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
+    assert "has no production conformance profile" in report.failures[0].message
+    assert report.failures[0].profile_id == CORE_ASYNC
+
+
+@pytest.mark.asyncio
+async def test_async_transactions_declaration_requires_async_cases(isolated_registry):
+    """Pins the #464 sequencing contract: the production transactions profile is
+    sync-only, so an async class may not declare TRANSACTIONS before the async
+    transaction APIs land with their async case inventory."""
     name = "conformance-mock-declared-txn-async"
     _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
 
@@ -1616,7 +1692,7 @@ async def test_async_declared_capability_without_profile_fails_clearly(isolated_
     report = await run_core_async(_Harness())
     failed_ids = [failure.case_id for failure in report.failures]
     assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
-    assert "has no production conformance profile" in report.failures[0].message
+    assert "has no async conformance cases" in report.failures[0].message
     assert report.failures[0].profile_id == CORE_ASYNC
 
 

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -10,6 +10,7 @@ import pytest
 import pydapper
 from pydapper import RawRow
 from pydapper._context import _AwaitableAsyncContextManager
+from pydapper.bigquery import GoogleBigqueryClientCommands
 from pydapper.capabilities import AdapterCapability
 from pydapper.command_options import CommandKind
 from pydapper.exceptions import DuplicateColumnException
@@ -5516,6 +5517,17 @@ class TestTransactions:
         # the error comes from the bare call, before any context manager exists to enter
         with pytest.raises(UnsupportedFeatureError):
             undeclared_commands.transaction()
+
+    @pytest.mark.parametrize("method", ["commit", "rollback", "transaction"])
+    def test_bigquery_is_a_first_party_unsupported_adapter(self, connection, method):
+        # the BigQuery DBAPI has no connection-level transactions (commit() is a no-op and
+        # there is no rollback()), so its command class must reject the whole API
+        commands = GoogleBigqueryClientCommands(connection)
+        with pytest.raises(UnsupportedFeatureError) as exc_info:
+            getattr(commands, method)()
+        assert "transactions" in str(exc_info.value)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
 
     # -- commit / rollback delegation ---------------------------------------------
 

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -5480,3 +5480,139 @@ class TestAdapterCapabilities:
     def test_require_capability_rejects_non_enum_arguments(self, commands, bad):
         with pytest.raises(TypeError):
             commands._require_capability(bad)
+
+
+class _TransactionBlockError(Exception):
+    """Error raised inside a transaction block by the tests below."""
+
+
+class TestTransactions:
+    @pytest.fixture
+    def connection(self):
+        return MockConnection()
+
+    @pytest.fixture
+    def undeclared_commands(self, connection):
+        return MockCommands(connection)
+
+    @pytest.fixture
+    def commands(self, connection):
+        class TransactionalCommands(MockCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        return TransactionalCommands(connection)
+
+    # -- unsupported adapters -----------------------------------------------------
+
+    @pytest.mark.parametrize("method", ["commit", "rollback", "transaction"])
+    def test_undeclared_adapter_raises_before_touching_the_connection(self, undeclared_commands, connection, method):
+        with pytest.raises(UnsupportedFeatureError) as exc_info:
+            getattr(undeclared_commands, method)()
+        assert "transactions" in str(exc_info.value)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
+
+    def test_undeclared_adapter_transaction_raises_at_call_time_without_entering(self, undeclared_commands):
+        # the error comes from the bare call, before any context manager exists to enter
+        with pytest.raises(UnsupportedFeatureError):
+            undeclared_commands.transaction()
+
+    # -- commit / rollback delegation ---------------------------------------------
+
+    def test_commit_delegates_to_the_connection(self, commands, connection):
+        assert commands.commit() is None
+        assert connection.commits == 1
+        assert connection.rollbacks == 0
+
+    def test_rollback_delegates_to_the_connection(self, commands, connection):
+        assert commands.rollback() is None
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    # -- transaction() context manager ---------------------------------------------
+
+    def test_transaction_commits_on_clean_exit(self, commands, connection):
+        with commands.transaction():
+            pass
+        assert connection.commits == 1
+        assert connection.rollbacks == 0
+
+    def test_transaction_yields_none(self, commands):
+        with commands.transaction() as value:
+            assert value is None
+
+    def test_transaction_rolls_back_and_reraises_the_same_exception(self, commands, connection):
+        error = _TransactionBlockError("boom")
+        with pytest.raises(_TransactionBlockError) as exc_info:
+            with commands.transaction():
+                raise error
+        assert exc_info.value is error
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    def test_transaction_rolls_back_on_base_exceptions(self, commands, connection):
+        with pytest.raises(KeyboardInterrupt):
+            with commands.transaction():
+                raise KeyboardInterrupt
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    def test_block_error_wins_over_a_rollback_failure(self, connection):
+        class RollbackFailingCommands(MockCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        commands = RollbackFailingCommands(connection)
+        connection.rollback = lambda: (_ for _ in ()).throw(RuntimeError("rollback boom"))
+        error = _TransactionBlockError("boom")
+        with pytest.raises(_TransactionBlockError) as exc_info:
+            with commands.transaction():
+                raise error
+        assert exc_info.value is error
+
+    def test_commit_failure_on_clean_exit_propagates_without_rollback(self, commands, connection):
+        commit_error = RuntimeError("commit boom")
+        connection.commit = lambda: (_ for _ in ()).throw(commit_error)
+        with pytest.raises(RuntimeError) as exc_info:
+            with commands.transaction():
+                pass
+        assert exc_info.value is commit_error
+        assert connection.rollbacks == 0
+
+    def test_explicit_commit_inside_a_block_is_allowed(self, commands, connection):
+        with commands.transaction():
+            commands.commit()
+        assert connection.commits == 2
+
+    # -- nesting -------------------------------------------------------------------
+
+    def test_nested_transaction_blocks_raise(self, commands, connection):
+        with pytest.raises(RuntimeError, match="cannot be nested"):
+            with commands.transaction():
+                with commands.transaction():
+                    pass  # pragma: no cover
+        # the failed inner enter is not a block error: the outer block still rolls back
+        # because the RuntimeError propagates through it
+        assert connection.rollbacks == 1
+
+    def test_nesting_guard_resets_after_the_block_exits(self, commands, connection):
+        with commands.transaction():
+            pass
+        with commands.transaction():
+            pass
+        assert connection.commits == 2
+
+    def test_nesting_guard_resets_after_a_failed_block(self, commands, connection):
+        with pytest.raises(_TransactionBlockError):
+            with commands.transaction():
+                raise _TransactionBlockError("boom")
+        with commands.transaction():
+            pass
+        assert connection.commits == 1
+        assert connection.rollbacks == 1
+
+    def test_two_unentered_context_managers_cannot_both_enter(self, commands):
+        first = commands.transaction()
+        second = commands.transaction()
+        with first:
+            with pytest.raises(RuntimeError, match="cannot be nested"):
+                second.__enter__()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -676,28 +676,33 @@ def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
     assert "sync" in str(exc_info.value)
 
 
-FIRST_PARTY_COMMAND_CLASSES = [
-    Sqlite3Commands,
-    Psycopg2Commands,
-    Psycopg3Commands,
-    Psycopg3CommandsAsync,
-    AiopgCommands,
-    MySqlConnectorPythonCommands,
-    PymssqlCommands,
-    OracledbCommands,
-    GoogleBigqueryClientCommands,
-]
+#: The exact capability set every first-party command class must declare. Sync classes
+#: implement the transaction APIs; the async transaction feature has not landed, and
+#: BigQuery's DBAPI cannot support transactions (commit() is a no-op, rollback() is absent).
+FIRST_PARTY_CAPABILITY_DECLARATIONS = {
+    Sqlite3Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    Psycopg2Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    Psycopg3Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    Psycopg3CommandsAsync: frozenset(),
+    AiopgCommands: frozenset(),
+    MySqlConnectorPythonCommands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    PymssqlCommands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    OracledbCommands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
+    GoogleBigqueryClientCommands: frozenset(),
+}
+
+FIRST_PARTY_COMMAND_CLASSES = list(FIRST_PARTY_CAPABILITY_DECLARATIONS)
 
 
 @pytest.mark.parametrize("command_class", FIRST_PARTY_COMMAND_CLASSES, ids=lambda command_class: command_class.__name__)
-def test_first_party_command_classes_declare_explicit_empty_capability_sets(command_class):
+def test_first_party_command_classes_declare_exact_capability_sets(command_class):
     declared = vars(command_class).get("capabilities")
 
     assert declared is not None, f"{command_class.__name__} must declare capabilities directly, not inherit the default"
     assert type(declared) is frozenset
     assert all(isinstance(member, pydapper.AdapterCapability) for member in declared)
-    # no optional capability is implemented yet, so any non-empty set would be an overclaim
-    assert declared == frozenset()
+    # any drift from this table is either an overclaim or an undeclared implemented feature
+    assert declared == FIRST_PARTY_CAPABILITY_DECLARATIONS[command_class]
 
 
 FIRST_PARTY_ADAPTER_TABLE = {

--- a/tests/test_postgresql/test_conformance.py
+++ b/tests/test_postgresql/test_conformance.py
@@ -44,6 +44,10 @@ class _Psycopg2ConformanceHarness(SyncAdapterHarness):
     def teardown_commands(self, commands: Commands) -> None:
         try:
             commands.connection.rollback()
+            # transaction-profile cases commit durable state; don't leave the table behind
+            with suppress(Exception):
+                commands.execute(_DROP)
+                commands.connection.commit()
         finally:
             commands.connection.close()
 
@@ -68,6 +72,10 @@ class _Psycopg3SyncConformanceHarness(SyncAdapterHarness):
     def teardown_commands(self, commands: Commands) -> None:
         try:
             commands.connection.rollback()
+            # transaction-profile cases commit durable state; don't leave the table behind
+            with suppress(Exception):
+                commands.execute(_DROP)
+                commands.connection.commit()
         finally:
             commands.connection.close()
 

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 from typing import AsyncGenerator
+from typing import ContextManager
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -181,6 +182,15 @@ def adapter_capability_types() -> None:
     # concrete first-party declarations stay typed as frozenset[AdapterCapability]
     assert_type(Sqlite3Commands.capabilities, frozenset[pydapper.AdapterCapability])
     assert_type(Psycopg3CommandsAsync.capabilities, frozenset[pydapper.AdapterCapability])
+
+
+def transaction_api_types() -> None:
+    sync_commands = cast(PydapperCommands, object())
+    assert_type(sync_commands.commit(), None)
+    assert_type(sync_commands.rollback(), None)
+    assert_type(sync_commands.transaction(), ContextManager[None])
+    with sync_commands.transaction() as handle:
+        assert_type(handle, None)
 
 
 def preparation_hook_types() -> None:


### PR DESCRIPTION
## What changed and why

Implements #463 (milestone **v1 M3: Transactions**): explicit, capability-gated synchronous transaction handling on `Commands`, built on the M2 capability infrastructure.

- **`Commands.commit()` / `Commands.rollback()`** delegate to the DBAPI connection, gated on `AdapterCapability.TRANSACTIONS` — undeclared adapters raise `UnsupportedFeatureError` before the connection is touched.
- **`Commands.transaction()`** checks the capability at call time and returns a context manager that yields `None`, emits no SQL on enter (DBAPI implicit `BEGIN` is the contract), commits on clean exit, and rolls back + re-raises on any `BaseException`. The block's error wins over a rollback failure (same precedence idiom as `_cursor_context_proxy`); a failed exit-commit propagates unchanged with no rollback attempt. Nested blocks raise `RuntimeError` (savepoint nesting stays open as a backward-compatible future upgrade).
- **Declarations**: `Sqlite3Commands`, `Psycopg2Commands`, `Psycopg3Commands`, `MySqlConnectorPythonCommands`, `PymssqlCommands`, and `OracledbCommands` declare `TRANSACTIONS`. `GoogleBigqueryClientCommands` does not (the BigQuery DBAPI's `commit()` is a no-op and it has no `rollback()`), and the async classes do not (async APIs are #464).
- **Conformance**: the production catalog ships its first capability profile — `transactions`, nine sync cases (4 live, 5 instrumented) in a new `_cases_transactions.py`. Live cases self-commit the harness baseline so they run unchanged on harnesses that seed inside an open transaction. `RecordingConnection` gained commit/rollback recording and fault injection. Every backend's existing `test_conformance.py` picks the profile up automatically via the declared-capability runner. A new self-test pins the #464 sequencing rule: an async class may not declare `TRANSACTIONS` until the profile has async cases.
- **Typing**: new narrow `TransactionalConnectionType` protocol in `pydapper/types.py`; the public `ConnectionType` protocol is unchanged (PEP 249 makes `rollback()` optional, and widening it would structurally break connections that cannot support transactions).

## Before / after

```python
# before: driver-specific, easy to forget with e.g. mysql-connector's autocommit=False default
commands.connection.commit()

# after: explicit, portable, and honest about support
with pydapper.connect(dsn) as db:
    with db.transaction():
        db.execute(insert_sql, params=task)
        db.execute(update_sql, params=owner)   # both commit together, roll back together

db.commit() / db.rollback()                    # explicit escape hatches
# undeclared adapter (e.g. BigQuery): UnsupportedFeatureError before the connection is touched
```

## Commands run

| Command | Result |
|---|---|
| `poetry run pytest -m core` | 1412 passed |
| `poetry run pytest -m sqlite` | 30 passed |
| `poetry run pytest -m postgresql` (live testcontainers) | 91 passed |
| `poetry run pytest -m "mysql or mssql or oracle"` (live testcontainers) | 73 passed |
| `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` | clean |
| `poetry run black --check .` / `poetry run isort --check .` | clean |
| `poetry run mkdocs build --strict` | passes |

**Skipped**: `pytest -m bigquery` — the BigQuery adapter has no behavior change (it declares nothing and inherits the gate); its `UnsupportedFeatureError` path is covered by core tests and the declaration drift pin, and the emulator suite is heavyweight.

## Public API / typing / docs impact

- New public methods `Commands.commit()`, `Commands.rollback()`, `Commands.transaction()`; type-test coverage added in `tests/type_tests.py` (`transaction_api_types`).
- New conformance exports `transactions_profile` / `TRANSACTIONS_PROFILE`; the capability-profile surface (`ConformanceProfile`, `SyncCase`, `AsyncCase`, `capability_profiles`) graduates from provisional to stable now that the first profile ships.
- No new exports from the `pydapper` package root; no new dependencies or extras.
- Docs: new `docs/transactions.md` (+ mkdocs nav + runnable examples in `docs_src/transactions/`); capability matrices in `docs/adapter_registration.md` and `docs/adapter_conformance.md` updated, with BigQuery/aiopg driver-limit cells explaining their non-declaration. Per-driver transaction nuance docs remain with #465.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)