### PR TITLE
fix: verify preparation-hook ordering on the conformance query paths

### DIFF
--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -32,8 +32,9 @@ owns a cursor — `execute`, buffered `query`, unbuffered `query`, `query_first`
 and `query_multiple` — because each opens its own cursor block: `_prepare_cursor` must run exactly once per
 command-owned cursor and `_prepare_command` exactly once per executed handler, both on the *entered* cursor and
 both before that handler reaches the driver (`query_multiple` therefore prepares one cursor and N handlers).
-These cases constrain preparation, not fetching: how an adapter drains an unbuffered result set (one `fetchone`
-per row, `fetchmany` batches, a driver-side iterator) is its own choice and no hook-ordering case asserts it.
+These cases constrain preparation and how often a statement runs — every single-statement path must execute
+exactly once — but not fetching: how an adapter drains an unbuffered result set (one `fetchone` per row,
+`fetchmany` batches, a driver-side iterator) is its own choice and no hook-ordering case asserts it.
 
 Cases are either **live** (they run through your real database resources) or **instrumented** (they wrap your
 real concrete command class around framework-owned recording and fault-injection connections, so cursor counts,

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -27,10 +27,16 @@ Each profile covers registration and selection, the #541 cursor lifecycle (clean
 failure, error precedence, truthy-exit non-suppression, plain and context-manager cursors, unbuffered
 exhaustion and explicit `close()`/`aclose()`), parameter handling and execution, row mapping and `RawRow`
 mappers, zero/one/many cardinality, scalar semantics (no row vs SQL `NULL` vs falsey values), command options,
-preparation-hook ordering, and capability honesty. Cases are either **live** (they run through your real
-database resources) or **instrumented** (they wrap your real concrete command class around framework-owned
-recording and fault-injection connections, so cursor counts, call order, exception precedence, and
-"fails before driver work" guarantees are observed directly rather than inferred from return values).
+preparation-hook ordering, and capability honesty. Hook ordering is checked on every distinct command path that
+owns a cursor — `execute`, buffered `query`, unbuffered `query`, `query_first`/`query_single`/`execute_scalar`,
+and `query_multiple` — because each opens its own cursor block: `_prepare_cursor` must run exactly once per
+command-owned cursor and `_prepare_command` exactly once per executed handler, both on the *entered* cursor and
+both before that handler reaches the driver (`query_multiple` therefore prepares one cursor and N handlers).
+
+Cases are either **live** (they run through your real database resources) or **instrumented** (they wrap your
+real concrete command class around framework-owned recording and fault-injection connections, so cursor counts,
+call order, exception precedence, and "fails before driver work" guarantees are observed directly rather than
+inferred from return values).
 
 ## Optional capability profiles
 

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -32,6 +32,8 @@ owns a cursor — `execute`, buffered `query`, unbuffered `query`, `query_first`
 and `query_multiple` — because each opens its own cursor block: `_prepare_cursor` must run exactly once per
 command-owned cursor and `_prepare_command` exactly once per executed handler, both on the *entered* cursor and
 both before that handler reaches the driver (`query_multiple` therefore prepares one cursor and N handlers).
+These cases constrain preparation, not fetching: how an adapter drains an unbuffered result set (one `fetchone`
+per row, `fetchmany` batches, a driver-side iterator) is its own choice and no hook-ordering case asserts it.
 
 Cases are either **live** (they run through your real database resources) or **instrumented** (they wrap your
 real concrete command class around framework-owned recording and fault-injection connections, so cursor counts,

--- a/docs_src/adapter_conformance/async_example.py
+++ b/docs_src/adapter_conformance/async_example.py
@@ -120,4 +120,4 @@ async def main() -> None:
 
 
 asyncio.run(main())
-# core-async for 'acmeaio': 54 cases, passed=True
+# core-async for 'acmeaio': 58 cases, passed=True

--- a/docs_src/adapter_conformance/sync_example.py
+++ b/docs_src/adapter_conformance/sync_example.py
@@ -67,4 +67,4 @@ print(f"{report.profile_id} for {report.adapter_name!r}: {len(report.results)} c
 report.raise_for_failures()
 # claiming conformance takes both: every case passed *and* every planned case ran
 assert report.passed and report.covers_full_inventory
-# core-sync for 'acmedb': 54 cases, passed=True
+# core-sync for 'acmedb': 58 cases, passed=True

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -453,6 +453,22 @@ def _check_preparation_prefix(ctx: AsyncCaseContext, connection: Any, path: str)
     )
 
 
+def _check_executed_exactly_once(ctx: AsyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: a single-statement path runs that statement exactly once.
+
+    This is the constraint a path pinned by the preparation prefix would otherwise lose. A
+    path that runs prepare-command plus execute twice and then drains once keeps the prefix
+    intact, keeps one prepare-cursor call, and still pairs one prepare-command call with each
+    execution, so nothing else in the inventory can see the repeated execution. Counting
+    executions catches it without saying anything about how the rows are fetched.
+    """
+    executions = connection.log.count("execute")
+    ctx.check(
+        executions == 1,
+        f"the {path} path must execute its statement exactly once; saw {executions}",
+    )
+
+
 def _check_hooks_prepared_the_entered_cursor(ctx: AsyncCaseContext, connection: Any, path: str) -> None:
     """Framework check: one prepare-cursor call per cursor, and every hook saw the entered cursor.
 
@@ -545,12 +561,14 @@ async def _lifecycle_hook_order_unbuffered_query(ctx: AsyncCaseContext) -> None:
     )
     rows = [row async for row in generator]
     ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
-    # only the preparation prefix is pinned: how an adapter drains an unbuffered result set
-    # (one fetchone per row, fetchmany batches, a driver-side iterator) is a fetch-strategy
-    # choice this case is not about, and pinning the whole sequence would fail a conformant
-    # adapter for making a different one. The prefix still proves no row is fetched before
-    # both hooks have run, and the helpers below still bound how often each hook may run.
+    # this case pins the preparation ordering and that the statement runs exactly once; it
+    # deliberately does not pin how the rows are drained, because that (one fetchone per row,
+    # fetchmany batches, a driver-side iterator) is a fetch-strategy choice, and pinning the
+    # whole sequence would fail a conformant adapter for making a different one. The prefix
+    # still proves no row is fetched before both hooks have run, and the helpers below still
+    # bound how often each hook, and the statement itself, may run.
     _check_preparation_prefix(ctx, connection, "async unbuffered query")
+    _check_executed_exactly_once(ctx, connection, "async unbuffered query")
     _check_hooks_prepared_the_entered_cursor(ctx, connection, "async unbuffered query")
     _check_prepared_handlers_reach_the_driver(ctx, connection, "async unbuffered query")
 
@@ -563,14 +581,16 @@ async def _lifecycle_hook_order_unbuffered_query(ctx: AsyncCaseContext) -> None:
 )
 async def _lifecycle_hook_order_single_row_commands(ctx: AsyncCaseContext) -> None:
     # every single-row family owns its own cursor block, so each is a distinct preparation path;
-    # only the prefix is pinned because documented adapter-specific traffic legitimately follows
-    # the execution
+    # the fetch traffic is left unpinned because documented adapter-specific traffic legitimately
+    # follows the execution, so each leg pins the preparation prefix plus the execution count
+    # instead of the whole event sequence
     for method_name in ("query_first_async", "query_single_async", "execute_scalar_async"):
         connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
         commands = ctx.instrumented_commands(connection)
         ctx.install_hook_recorder(commands, connection.log)
         await getattr(commands, method_name)("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
         _check_preparation_prefix(ctx, connection, method_name)
+        _check_executed_exactly_once(ctx, connection, method_name)
         _check_hooks_prepared_the_entered_cursor(ctx, connection, method_name)
         _check_prepared_handlers_reach_the_driver(ctx, connection, method_name)
 

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -438,6 +438,175 @@ async def _lifecycle_hook_order(ctx: AsyncCaseContext) -> None:
     )
 
 
+#: The driver interactions every command path must perform, in order, before any SQL runs.
+#: Paths whose remaining traffic is adapter-specific (a documented extra drain, for example)
+#: are pinned by this prefix instead of a full event-order assertion.
+_PREPARATION_PREFIX: Tuple[str, ...] = ("cursor", "enter", "prepare_cursor", "prepare_command", "execute")
+
+
+def _check_preparation_prefix(ctx: AsyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: the path enters one cursor and runs both hooks, in order, before executing."""
+    ctx.check(
+        connection.log.kinds()[: len(_PREPARATION_PREFIX)] == _PREPARATION_PREFIX,
+        f"the {path} path must acquire and enter a cursor, run the preparation hooks in order, and only then "
+        f"execute; observed {connection.log.kinds()!r}",
+    )
+
+
+def _check_hooks_prepared_the_entered_cursor(ctx: AsyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: one prepare-cursor call per cursor, and every hook saw the entered cursor.
+
+    The two count assertions come first on purpose: they are what makes the cursor and
+    event lookups below safe, so this helper is self-guarding and may be called in any
+    order relative to the other checks in a case.
+    """
+    log = connection.log
+    ctx.check(
+        len(connection.cursors) == 1,
+        f"the {path} path must acquire exactly one command-owned cursor, saw {len(connection.cursors)}",
+    )
+    ctx.check(
+        log.count("prepare_cursor") == 1,
+        f"the {path} path must run the prepare-cursor hook exactly once per cursor, "
+        f"saw {log.count('prepare_cursor')}",
+    )
+    entered = getattr(connection.cursors[0], "entered_cursor", None)
+    hook_cursor, hook_options = log.of_kind("prepare_cursor")[0].detail
+    ctx.check(hook_cursor is entered, f"the {path} prepare-cursor hook must receive the entered cursor object")
+    ctx.check(
+        hook_options == CommandOptions(),
+        f"the {path} prepare-cursor hook must receive normalized default CommandOptions",
+    )
+    for event in log.of_kind("prepare_command"):
+        command_cursor, _, command_options = event.detail
+        ctx.check(
+            command_cursor is entered,
+            f"the {path} prepare-command hook must receive the entered cursor object",
+        )
+        ctx.check(
+            command_options == CommandOptions(),
+            f"the {path} prepare-command hook must receive normalized default CommandOptions",
+        )
+
+
+def _check_prepared_handlers_reach_the_driver(ctx: AsyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: one prepare-command call per executed handler, each observing the handler
+    whose prepared SQL the driver executes next."""
+    log = connection.log
+    prepared = log.of_kind("prepare_command")
+    executed = log.of_kind("execute")
+    ctx.check(
+        len(prepared) == len(executed),
+        f"the {path} path must run the prepare-command hook exactly once per executed handler; "
+        f"saw {len(prepared)} hook call(s) for {len(executed)} execution(s)",
+    )
+    for prepare_event, execute_event in zip(prepared, executed):
+        _, handler, _ = prepare_event.detail
+        ctx.check(
+            getattr(handler, "prepared_sql", None) == execute_event.sql,
+            f"the {path} prepare-command hook must observe the handler whose prepared SQL is executed next",
+        )
+
+
+@_case(
+    "lifecycle.hook-order-buffered-query",
+    "Async buffered query runs both preparation hooks once, in order, on the entered cursor before any row is "
+    "fetched",
+    "instrumented",
+)
+async def _lifecycle_hook_order_buffered_query(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    rows = await commands.query_async("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_event_order(
+        connection.log,
+        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchall", "exit"),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "async buffered query")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "async buffered query")
+
+
+@_case(
+    "lifecycle.hook-order-unbuffered-query",
+    "Async unbuffered query defers both preparation hooks to first consumption, then runs them once, in order, "
+    "on the entered cursor",
+    "instrumented",
+)
+async def _lifecycle_hook_order_unbuffered_query(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    generator = await commands.query_async("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1}, buffered=False)
+    ctx.check(
+        connection.log.kinds() == (),
+        f"an unconsumed unbuffered query must not run the preparation hooks; observed {connection.log.kinds()!r}",
+    )
+    rows = [row async for row in generator]
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_event_order(
+        connection.log,
+        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchone", "fetchone", "fetchone", "exit"),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "async unbuffered query")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "async unbuffered query")
+
+
+@_case(
+    "lifecycle.hook-order-single-row-commands",
+    "query_first_async, query_single_async, and execute_scalar_async each run both preparation hooks once, in "
+    "order, on the entered cursor before executing",
+    "instrumented",
+)
+async def _lifecycle_hook_order_single_row_commands(ctx: AsyncCaseContext) -> None:
+    # every single-row family owns its own cursor block, so each is a distinct preparation path;
+    # only the prefix is pinned because documented adapter-specific traffic legitimately follows
+    # the execution
+    for method_name in ("query_first_async", "query_single_async", "execute_scalar_async"):
+        connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
+        commands = ctx.instrumented_commands(connection)
+        ctx.install_hook_recorder(commands, connection.log)
+        await getattr(commands, method_name)("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
+        _check_preparation_prefix(ctx, connection, method_name)
+        _check_hooks_prepared_the_entered_cursor(ctx, connection, method_name)
+        _check_prepared_handlers_reach_the_driver(ctx, connection, method_name)
+
+
+@_case(
+    "lifecycle.hook-order-query-multiple",
+    "query_multiple_async prepares its shared cursor once and prepares each handler immediately before that "
+    "handler executes",
+    "instrumented",
+)
+async def _lifecycle_hook_order_query_multiple(ctx: AsyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    results = await commands.query_multiple_async(
+        ("SELECT id, label FROM t WHERE id = ?id?", "SELECT id, label FROM t"),
+        params={"id": 1},
+    )
+    ctx.check(len(results) == 2, f"query_multiple_async must return one result set per query, got {len(results)}")
+    ctx.check_event_order(
+        connection.log,
+        (
+            "cursor",
+            "enter",
+            "prepare_cursor",
+            "prepare_command",
+            "execute",
+            "fetchall",
+            "prepare_command",
+            "execute",
+            "fetchall",
+            "exit",
+        ),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "query_multiple_async")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "query_multiple_async")
+
+
 # --------------------------------------------------------------------------------------
 # parameters and execution
 # --------------------------------------------------------------------------------------

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -545,10 +545,12 @@ async def _lifecycle_hook_order_unbuffered_query(ctx: AsyncCaseContext) -> None:
     )
     rows = [row async for row in generator]
     ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
-    ctx.check_event_order(
-        connection.log,
-        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchone", "fetchone", "fetchone", "exit"),
-    )
+    # only the preparation prefix is pinned: how an adapter drains an unbuffered result set
+    # (one fetchone per row, fetchmany batches, a driver-side iterator) is a fetch-strategy
+    # choice this case is not about, and pinning the whole sequence would fail a conformant
+    # adapter for making a different one. The prefix still proves no row is fetched before
+    # both hooks have run, and the helpers below still bound how often each hook may run.
+    _check_preparation_prefix(ctx, connection, "async unbuffered query")
     _check_hooks_prepared_the_entered_cursor(ctx, connection, "async unbuffered query")
     _check_prepared_handlers_reach_the_driver(ctx, connection, "async unbuffered query")
 

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -398,6 +398,174 @@ def _lifecycle_hook_order(ctx: SyncCaseContext) -> None:
     )
 
 
+#: The driver interactions every command path must perform, in order, before any SQL runs.
+#: Paths whose remaining traffic is adapter-specific (a documented extra drain, for example)
+#: are pinned by this prefix instead of a full event-order assertion.
+_PREPARATION_PREFIX: Tuple[str, ...] = ("cursor", "enter", "prepare_cursor", "prepare_command", "execute")
+
+
+def _check_preparation_prefix(ctx: SyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: the path enters one cursor and runs both hooks, in order, before executing."""
+    ctx.check(
+        connection.log.kinds()[: len(_PREPARATION_PREFIX)] == _PREPARATION_PREFIX,
+        f"the {path} path must acquire and enter a cursor, run the preparation hooks in order, and only then "
+        f"execute; observed {connection.log.kinds()!r}",
+    )
+
+
+def _check_hooks_prepared_the_entered_cursor(ctx: SyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: one prepare-cursor call per cursor, and every hook saw the entered cursor.
+
+    The two count assertions come first on purpose: they are what makes the cursor and
+    event lookups below safe, so this helper is self-guarding and may be called in any
+    order relative to the other checks in a case.
+    """
+    log = connection.log
+    ctx.check(
+        len(connection.cursors) == 1,
+        f"the {path} path must acquire exactly one command-owned cursor, saw {len(connection.cursors)}",
+    )
+    ctx.check(
+        log.count("prepare_cursor") == 1,
+        f"the {path} path must run the prepare-cursor hook exactly once per cursor, "
+        f"saw {log.count('prepare_cursor')}",
+    )
+    entered = getattr(connection.cursors[0], "entered_cursor", None)
+    hook_cursor, hook_options = log.of_kind("prepare_cursor")[0].detail
+    ctx.check(hook_cursor is entered, f"the {path} prepare-cursor hook must receive the entered cursor object")
+    ctx.check(
+        hook_options == CommandOptions(),
+        f"the {path} prepare-cursor hook must receive normalized default CommandOptions",
+    )
+    for event in log.of_kind("prepare_command"):
+        command_cursor, _, command_options = event.detail
+        ctx.check(
+            command_cursor is entered,
+            f"the {path} prepare-command hook must receive the entered cursor object",
+        )
+        ctx.check(
+            command_options == CommandOptions(),
+            f"the {path} prepare-command hook must receive normalized default CommandOptions",
+        )
+
+
+def _check_prepared_handlers_reach_the_driver(ctx: SyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: one prepare-command call per executed handler, each observing the handler
+    whose prepared SQL the driver executes next."""
+    log = connection.log
+    prepared = log.of_kind("prepare_command")
+    executed = log.of_kind("execute")
+    ctx.check(
+        len(prepared) == len(executed),
+        f"the {path} path must run the prepare-command hook exactly once per executed handler; "
+        f"saw {len(prepared)} hook call(s) for {len(executed)} execution(s)",
+    )
+    for prepare_event, execute_event in zip(prepared, executed):
+        _, handler, _ = prepare_event.detail
+        ctx.check(
+            getattr(handler, "prepared_sql", None) == execute_event.sql,
+            f"the {path} prepare-command hook must observe the handler whose prepared SQL is executed next",
+        )
+
+
+@_case(
+    "lifecycle.hook-order-buffered-query",
+    "Buffered query runs both preparation hooks once, in order, on the entered cursor before any row is fetched",
+    "instrumented",
+)
+def _lifecycle_hook_order_buffered_query(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    rows = commands.query("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_event_order(
+        connection.log,
+        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchall", "exit"),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "buffered query")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "buffered query")
+
+
+@_case(
+    "lifecycle.hook-order-unbuffered-query",
+    "Unbuffered query defers both preparation hooks to first consumption, then runs them once, in order, "
+    "on the entered cursor",
+    "instrumented",
+)
+def _lifecycle_hook_order_unbuffered_query(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"), (2, "beta"))))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    generator = commands.query("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1}, buffered=False)
+    ctx.check(
+        connection.log.kinds() == (),
+        f"an unconsumed unbuffered query must not run the preparation hooks; observed {connection.log.kinds()!r}",
+    )
+    rows = list(generator)
+    ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
+    ctx.check_event_order(
+        connection.log,
+        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchone", "fetchone", "fetchone", "exit"),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "unbuffered query")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "unbuffered query")
+
+
+@_case(
+    "lifecycle.hook-order-single-row-commands",
+    "query_first, query_single, and execute_scalar each run both preparation hooks once, in order, on the "
+    "entered cursor before executing",
+    "instrumented",
+)
+def _lifecycle_hook_order_single_row_commands(ctx: SyncCaseContext) -> None:
+    # every single-row family owns its own cursor block, so each is a distinct preparation path;
+    # only the prefix is pinned because documented adapter-specific traffic (the MySQL unread-result
+    # drain, for example) legitimately follows the execution
+    for method_name in ("query_first", "query_single", "execute_scalar"):
+        connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
+        commands = ctx.instrumented_commands(connection)
+        ctx.install_hook_recorder(commands, connection.log)
+        getattr(commands, method_name)("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
+        _check_preparation_prefix(ctx, connection, method_name)
+        _check_hooks_prepared_the_entered_cursor(ctx, connection, method_name)
+        _check_prepared_handlers_reach_the_driver(ctx, connection, method_name)
+
+
+@_case(
+    "lifecycle.hook-order-query-multiple",
+    "query_multiple prepares its shared cursor once and prepares each handler immediately before that handler "
+    "executes",
+    "instrumented",
+)
+def _lifecycle_hook_order_query_multiple(ctx: SyncCaseContext) -> None:
+    connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
+    commands = ctx.instrumented_commands(connection)
+    ctx.install_hook_recorder(commands, connection.log)
+    results = commands.query_multiple(
+        ("SELECT id, label FROM t WHERE id = ?id?", "SELECT id, label FROM t"),
+        params={"id": 1},
+    )
+    ctx.check(len(results) == 2, f"query_multiple must return one result set per query, got {len(results)}")
+    ctx.check_event_order(
+        connection.log,
+        (
+            "cursor",
+            "enter",
+            "prepare_cursor",
+            "prepare_command",
+            "execute",
+            "fetchall",
+            "prepare_command",
+            "execute",
+            "fetchall",
+            "exit",
+        ),
+    )
+    _check_hooks_prepared_the_entered_cursor(ctx, connection, "query_multiple")
+    _check_prepared_handlers_reach_the_driver(ctx, connection, "query_multiple")
+
+
 # --------------------------------------------------------------------------------------
 # parameters and execution
 # --------------------------------------------------------------------------------------

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -504,10 +504,12 @@ def _lifecycle_hook_order_unbuffered_query(ctx: SyncCaseContext) -> None:
     )
     rows = list(generator)
     ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
-    ctx.check_event_order(
-        connection.log,
-        ("cursor", "enter", "prepare_cursor", "prepare_command", "execute", "fetchone", "fetchone", "fetchone", "exit"),
-    )
+    # only the preparation prefix is pinned: how an adapter drains an unbuffered result set
+    # (one fetchone per row, fetchmany batches, a driver-side iterator) is a fetch-strategy
+    # choice this case is not about, and pinning the whole sequence would fail a conformant
+    # adapter for making a different one. The prefix still proves no row is fetched before
+    # both hooks have run, and the helpers below still bound how often each hook may run.
+    _check_preparation_prefix(ctx, connection, "unbuffered query")
     _check_hooks_prepared_the_entered_cursor(ctx, connection, "unbuffered query")
     _check_prepared_handlers_reach_the_driver(ctx, connection, "unbuffered query")
 

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -413,6 +413,22 @@ def _check_preparation_prefix(ctx: SyncCaseContext, connection: Any, path: str) 
     )
 
 
+def _check_executed_exactly_once(ctx: SyncCaseContext, connection: Any, path: str) -> None:
+    """Framework check: a single-statement path runs that statement exactly once.
+
+    This is the constraint a path pinned by the preparation prefix would otherwise lose. A
+    path that runs prepare-command plus execute twice and then drains once keeps the prefix
+    intact, keeps one prepare-cursor call, and still pairs one prepare-command call with each
+    execution, so nothing else in the inventory can see the repeated execution. Counting
+    executions catches it without saying anything about how the rows are fetched.
+    """
+    executions = connection.log.count("execute")
+    ctx.check(
+        executions == 1,
+        f"the {path} path must execute its statement exactly once; saw {executions}",
+    )
+
+
 def _check_hooks_prepared_the_entered_cursor(ctx: SyncCaseContext, connection: Any, path: str) -> None:
     """Framework check: one prepare-cursor call per cursor, and every hook saw the entered cursor.
 
@@ -504,12 +520,14 @@ def _lifecycle_hook_order_unbuffered_query(ctx: SyncCaseContext) -> None:
     )
     rows = list(generator)
     ctx.check(rows == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}], f"unexpected projection {rows!r}")
-    # only the preparation prefix is pinned: how an adapter drains an unbuffered result set
-    # (one fetchone per row, fetchmany batches, a driver-side iterator) is a fetch-strategy
-    # choice this case is not about, and pinning the whole sequence would fail a conformant
-    # adapter for making a different one. The prefix still proves no row is fetched before
-    # both hooks have run, and the helpers below still bound how often each hook may run.
+    # this case pins the preparation ordering and that the statement runs exactly once; it
+    # deliberately does not pin how the rows are drained, because that (one fetchone per row,
+    # fetchmany batches, a driver-side iterator) is a fetch-strategy choice, and pinning the
+    # whole sequence would fail a conformant adapter for making a different one. The prefix
+    # still proves no row is fetched before both hooks have run, and the helpers below still
+    # bound how often each hook, and the statement itself, may run.
     _check_preparation_prefix(ctx, connection, "unbuffered query")
+    _check_executed_exactly_once(ctx, connection, "unbuffered query")
     _check_hooks_prepared_the_entered_cursor(ctx, connection, "unbuffered query")
     _check_prepared_handlers_reach_the_driver(ctx, connection, "unbuffered query")
 
@@ -522,14 +540,16 @@ def _lifecycle_hook_order_unbuffered_query(ctx: SyncCaseContext) -> None:
 )
 def _lifecycle_hook_order_single_row_commands(ctx: SyncCaseContext) -> None:
     # every single-row family owns its own cursor block, so each is a distinct preparation path;
-    # only the prefix is pinned because documented adapter-specific traffic (the MySQL unread-result
-    # drain, for example) legitimately follows the execution
+    # the fetch traffic is left unpinned because documented adapter-specific traffic (the MySQL
+    # unread-result drain, for example) legitimately follows the execution, so each leg pins the
+    # preparation prefix plus the execution count instead of the whole event sequence
     for method_name in ("query_first", "query_single", "execute_scalar"):
         connection = ctx.recording_connection(CursorScript(rows=((1, "alpha"),)))
         commands = ctx.instrumented_commands(connection)
         ctx.install_hook_recorder(commands, connection.log)
         getattr(commands, method_name)("SELECT id, label FROM t WHERE id = ?id?", params={"id": 1})
         _check_preparation_prefix(ctx, connection, method_name)
+        _check_executed_exactly_once(ctx, connection, method_name)
         _check_hooks_prepared_the_entered_cursor(ctx, connection, method_name)
         _check_prepared_handlers_reach_the_driver(ctx, connection, method_name)
 

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -16,6 +16,7 @@ import textwrap
 import zipfile
 from contextlib import contextmanager
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -25,6 +26,7 @@ from pydapper import main
 from pydapper._context import _AwaitableAsyncContextManager as _RealAwaitableAsyncContextManager
 from pydapper.bigquery import GoogleBigqueryClientCommands
 from pydapper.capabilities import AdapterCapability
+from pydapper.command_options import CommandOptions
 from pydapper.commands import Commands
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.mssql import PymssqlCommands
@@ -487,6 +489,100 @@ def _recorded_hook_calls(commands, hook_name):
         setattr(commands, hook_name, real_hook)
 
 
+class _OtherHandlerStandIn:
+    """A forwarding handler stand-in reporting SQL the driver never executes."""
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    def __getattr__(self, name):
+        return getattr(self._handler, name)
+
+    @property
+    def prepared_sql(self):
+        return f"{self._handler.prepared_sql} -- never executed"
+
+
+@contextmanager
+def _other_handler_for_prepare_command(commands, hook_name, awaitable):
+    """Show the prepare-command hook a handler other than the one the driver executes.
+
+    Hook call counts, driver event order, options and cursor identity all stay conformant,
+    so the prepared-handler pairing assertion is the only thing that can catch this one.
+    """
+    real_hook = getattr(commands, hook_name)
+
+    def hook(cursor, handler, **kwargs):
+        return real_hook(cursor, _OtherHandlerStandIn(handler), **kwargs)
+
+    async def hook_async(cursor, handler, **kwargs):
+        await real_hook(cursor, _OtherHandlerStandIn(handler), **kwargs)
+
+    setattr(commands, hook_name, hook_async if awaitable else hook)
+    try:
+        yield
+    finally:
+        setattr(commands, hook_name, real_hook)
+
+
+@contextmanager
+def _handlers_prepared_one_query_late(commands, hook_name, awaitable):
+    """Prepare handler i+1 immediately before executing handler i.
+
+    Every hook call count, the full driver event order, the options and the entered-cursor
+    identity stay exactly conformant: only the pairing between the handler a hook observes
+    and the statement the driver runs next is wrong. That is the ``query_multiple``
+    mis-pairing a false certificate would otherwise hide, and the pairing assertion is the
+    only check in the whole inventory that can see it.
+    """
+    real_hook = getattr(commands, hook_name)
+    real_handler_class = commands.SqlParamHandler
+    handlers = []
+
+    def handler_class(*args, **kwargs):
+        handler = real_handler_class(*args, **kwargs)
+        handlers.append(handler)
+        return handler
+
+    def rotated(handler):
+        return handlers[(handlers.index(handler) + 1) % len(handlers)]
+
+    def hook(cursor, handler, **kwargs):
+        return real_hook(cursor, rotated(handler), **kwargs)
+
+    async def hook_async(cursor, handler, **kwargs):
+        await real_hook(cursor, rotated(handler), **kwargs)
+
+    commands.SqlParamHandler = handler_class
+    setattr(commands, hook_name, hook_async if awaitable else hook)
+    try:
+        yield
+    finally:
+        del commands.SqlParamHandler
+        setattr(commands, hook_name, real_hook)
+
+
+@contextmanager
+def _denormalized_options_for_hook(commands, hook_name, awaitable):
+    """Hand one hook options the caller never asked for instead of the normalized instance."""
+    real_hook = getattr(commands, hook_name)
+    substitute = CommandOptions(max_rows=5)
+
+    def hook(cursor, *args, **kwargs):
+        kwargs["options"] = substitute
+        return real_hook(cursor, *args, **kwargs)
+
+    async def hook_async(cursor, *args, **kwargs):
+        kwargs["options"] = substitute
+        await real_hook(cursor, *args, **kwargs)
+
+    setattr(commands, hook_name, hook_async if awaitable else hook)
+    try:
+        yield
+    finally:
+        setattr(commands, hook_name, real_hook)
+
+
 def _sync_mutation(commands, mutation):
     return mutation(commands, "_prepare_cursor", "_prepare_command", False)
 
@@ -513,10 +609,42 @@ class _SwappedHooksInUnbufferedQueryCommands(MockSyncConformanceCommands):
             yield from super()._unbuffered_query(*args, **kwargs)
 
 
+class _ExtraCursorAfterUnbufferedQueryCommands(MockSyncConformanceCommands):
+    """Acquires a second, never-prepared cursor once the streamed result set is exhausted."""
+
+    def _unbuffered_query(self, *args, **kwargs):
+        yield from super()._unbuffered_query(*args, **kwargs)
+        self.cursor()
+
+
+class _NonEnteredHooksInUnbufferedQueryCommands(MockSyncConformanceCommands):
+    def _unbuffered_query(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_cursor", False):
+            yield from super()._unbuffered_query(*args, **kwargs)
+
+
+class _OtherHandlerInUnbufferedQueryCommands(MockSyncConformanceCommands):
+    def _unbuffered_query(self, *args, **kwargs):
+        with _other_handler_for_prepare_command(self, "_prepare_command", False):
+            yield from super()._unbuffered_query(*args, **kwargs)
+
+
 class _NoHooksInQueryFirstCommands(MockSyncConformanceCommands):
     def query_first(self, *args, **kwargs):
         with _sync_mutation(self, _skipped_hooks):
             return super().query_first(*args, **kwargs)
+
+
+class _NoHooksInQuerySingleCommands(MockSyncConformanceCommands):
+    def query_single(self, *args, **kwargs):
+        with _sync_mutation(self, _skipped_hooks):
+            return super().query_single(*args, **kwargs)
+
+
+class _NoHooksInExecuteScalarCommands(MockSyncConformanceCommands):
+    def execute_scalar(self, *args, **kwargs):
+        with _sync_mutation(self, _skipped_hooks):
+            return super().execute_scalar(*args, **kwargs)
 
 
 class _PerQueryPrepareCursorCommands(MockSyncConformanceCommands):
@@ -531,6 +659,25 @@ class _SwappedHooksInQueryMultipleCommands(MockSyncConformanceCommands):
             return super().query_multiple(*args, **kwargs)
 
 
+class _NonEnteredHooksInQueryMultipleCommands(MockSyncConformanceCommands):
+    def query_multiple(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_cursor", False):
+            return super().query_multiple(*args, **kwargs)
+
+
+class _MispairedHandlersInQueryMultipleCommands(MockSyncConformanceCommands):
+    def query_multiple(self, *args, **kwargs):
+        with _handlers_prepared_one_query_late(self, "_prepare_command", False):
+            return super().query_multiple(*args, **kwargs)
+
+
+class _TruncatedQueryMultipleResultsCommands(MockSyncConformanceCommands):
+    """Runs every query but drops all but the first result set from the return value."""
+
+    def query_multiple(self, *args, **kwargs):
+        return super().query_multiple(*args, **kwargs)[:1]
+
+
 class _NonEnteredPrepareCursorCommands(MockSyncConformanceCommands):
     def _buffered_query(self, *args, **kwargs):
         with _non_entered_cursor_for_hook(self, "_prepare_cursor", False):
@@ -540,6 +687,24 @@ class _NonEnteredPrepareCursorCommands(MockSyncConformanceCommands):
 class _NonEnteredPrepareCommandCommands(MockSyncConformanceCommands):
     def _buffered_query(self, *args, **kwargs):
         with _non_entered_cursor_for_hook(self, "_prepare_command", False):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _DenormalizedOptionsForPrepareCursorCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _denormalized_options_for_hook(self, "_prepare_cursor", False):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _DenormalizedOptionsForPrepareCommandCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _denormalized_options_for_hook(self, "_prepare_command", False):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _OtherHandlerInBufferedQueryCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _other_handler_for_prepare_command(self, "_prepare_command", False):
             return super()._buffered_query(*args, **kwargs)
 
 
@@ -601,10 +766,57 @@ class _SwappedHooksInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
             await inner.aclose()
 
 
+class _ExtraCursorAfterAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    """Acquires a second, never-prepared cursor once the streamed result set is exhausted."""
+
+    async def _unbuffered_query(self, *args, **kwargs):
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            async for row in inner:
+                yield row
+        finally:
+            await inner.aclose()
+        await self.cursor()
+
+
+class _NonEnteredHooksInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _unbuffered_query(self, *args, **kwargs):
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            with _non_entered_cursor_for_hook(self, "_prepare_cursor_async", True):
+                async for row in inner:
+                    yield row
+        finally:
+            await inner.aclose()
+
+
+class _OtherHandlerInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _unbuffered_query(self, *args, **kwargs):
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            with _other_handler_for_prepare_command(self, "_prepare_command_async", True):
+                async for row in inner:
+                    yield row
+        finally:
+            await inner.aclose()
+
+
 class _NoHooksInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
     async def query_first_async(self, *args, **kwargs):
         with _async_mutation(self, _skipped_hooks):
             return await super().query_first_async(*args, **kwargs)
+
+
+class _NoHooksInAsyncQuerySingleCommands(MockAsyncConformanceCommands):
+    async def query_single_async(self, *args, **kwargs):
+        with _async_mutation(self, _skipped_hooks):
+            return await super().query_single_async(*args, **kwargs)
+
+
+class _NoHooksInAsyncExecuteScalarCommands(MockAsyncConformanceCommands):
+    async def execute_scalar_async(self, *args, **kwargs):
+        with _async_mutation(self, _skipped_hooks):
+            return await super().execute_scalar_async(*args, **kwargs)
 
 
 class _PerQueryPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
@@ -619,6 +831,25 @@ class _SwappedHooksInAsyncQueryMultipleCommands(MockAsyncConformanceCommands):
             return await super().query_multiple_async(*args, **kwargs)
 
 
+class _NonEnteredHooksInAsyncQueryMultipleCommands(MockAsyncConformanceCommands):
+    async def query_multiple_async(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_cursor_async", True):
+            return await super().query_multiple_async(*args, **kwargs)
+
+
+class _MispairedHandlersInAsyncQueryMultipleCommands(MockAsyncConformanceCommands):
+    async def query_multiple_async(self, *args, **kwargs):
+        with _handlers_prepared_one_query_late(self, "_prepare_command_async", True):
+            return await super().query_multiple_async(*args, **kwargs)
+
+
+class _TruncatedAsyncQueryMultipleResultsCommands(MockAsyncConformanceCommands):
+    """Runs every query but drops all but the first result set from the return value."""
+
+    async def query_multiple_async(self, *args, **kwargs):
+        return (await super().query_multiple_async(*args, **kwargs))[:1]
+
+
 class _NonEnteredPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
     async def _buffered_query(self, *args, **kwargs):
         with _non_entered_cursor_for_hook(self, "_prepare_cursor_async", True):
@@ -628,6 +859,24 @@ class _NonEnteredPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
 class _NonEnteredPrepareCommandAsyncCommands(MockAsyncConformanceCommands):
     async def _buffered_query(self, *args, **kwargs):
         with _non_entered_cursor_for_hook(self, "_prepare_command_async", True):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _DenormalizedOptionsForPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _denormalized_options_for_hook(self, "_prepare_cursor_async", True):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _DenormalizedOptionsForPrepareCommandAsyncCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _denormalized_options_for_hook(self, "_prepare_command_async", True):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _OtherHandlerInAsyncBufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _other_handler_for_prepare_command(self, "_prepare_command_async", True):
             return await super()._buffered_query(*args, **kwargs)
 
 
@@ -655,108 +904,293 @@ class _LatePrepareCommandInAsyncQueryFirstCommands(MockAsyncConformanceCommands)
         return result
 
 
-#: (slug, case the mutant must fail, assertion it pins, sync class, async class). Together these
-#: pin every assertion the four new cases add: event order, the preparation prefix, the
-#: once-per-cursor and once-per-handler counts, and entered-cursor identity.
+class _Assertion(NamedTuple):
+    """One assertion the new cases make, plus the text that identifies it in a failure message.
+
+    ``fragment`` is what turns the ``assertion`` column of the table below from a comment into
+    a checked claim: the negative tests require it to appear in the failure the mutant
+    produces, so a row naming the wrong assertion fails instead of quietly drifting.
+    """
+
+    label: str
+    fragment: str
+
+
+_EVENT_ORDER = _Assertion("full driver event order", "expected driver interaction order")
+_PREPARATION_PREFIX = _Assertion(
+    "preparation prefix",
+    "must acquire and enter a cursor, run the preparation hooks in order",
+)
+_ONE_COMMAND_CURSOR = _Assertion("one command-owned cursor", "must acquire exactly one command-owned cursor")
+_PREPARE_CURSOR_ONCE = _Assertion(
+    "once-per-cursor prepare-cursor count",
+    "must run the prepare-cursor hook exactly once per cursor",
+)
+_PREPARE_COMMAND_ONCE = _Assertion(
+    "once-per-handler prepare-command count",
+    "must run the prepare-command hook exactly once per executed handler",
+)
+_PREPARE_CURSOR_ENTERED_CURSOR = _Assertion(
+    "prepare-cursor entered-cursor identity",
+    "prepare-cursor hook must receive the entered cursor object",
+)
+_PREPARE_COMMAND_ENTERED_CURSOR = _Assertion(
+    "prepare-command entered-cursor identity",
+    "prepare-command hook must receive the entered cursor object",
+)
+_PREPARE_CURSOR_NORMALIZED_OPTIONS = _Assertion(
+    "prepare-cursor normalized options",
+    "prepare-cursor hook must receive normalized default CommandOptions",
+)
+_PREPARE_COMMAND_NORMALIZED_OPTIONS = _Assertion(
+    "prepare-command normalized options",
+    "prepare-command hook must receive normalized default CommandOptions",
+)
+_PREPARED_HANDLER_PAIRING = _Assertion(
+    "prepared-handler pairing",
+    "must observe the handler whose prepared SQL is executed next",
+)
+_ONE_RESULT_SET_PER_QUERY = _Assertion(
+    "one result set per query",
+    "must return one result set per query",
+)
+
+
+class _HookOrderMutant(NamedTuple):
+    """One non-conformant adapter, the case it must fail, and the assertion that must fail it."""
+
+    slug: str
+    case_id: str
+    assertion: _Assertion
+    sync_commands: type
+    async_commands: type
+    #: command path whose name must also appear in the failure message, which is what pins the
+    #: individual legs of the single-row case; empty for the framework's own event-order
+    #: assertion, whose message names no path
+    path: str = ""
+
+
+#: Every row is one deliberately non-conformant adapter. The negative tests require it to fail
+#: exactly one case, on exactly the assertion named here (checked against the failure message),
+#: while every other case in the profile still passes.
+#:
+#: Between them these rows pin every assertion-helper invocation the four new cases add and every
+#: check inside those helpers: delete any one of them from ``_cases_sync.py``/``_cases_async.py``
+#: and at least one row below stops failing. The remaining checks in the four cases are
+#: defence-in-depth and are deliberately *not* pinned here, because a violation that reaches them
+#: is already rejected by a case that predates this change:
+#:
+#: * the unconsumed-unbuffered ``kinds() == ()`` check -- both hooks run inside the cursor block,
+#:   so running them before consumption means acquiring a cursor before consumption, which
+#:   ``lifecycle.unbuffered-exhaustion-cleanup`` already rejects (an adapter that violates it
+#:   therefore fails two cases, which is why no row here can pin it narrowly);
+#: * the projection checks in the buffered and unbuffered cases -- ``rows.query-buffered`` and
+#:   ``rows.query-unbuffered`` own row mapping, so the same is true of them.
 _HOOK_ORDER_MUTANTS = (
-    (
-        "swapped-hooks-buffered",
-        "lifecycle.hook-order-buffered-query",
-        "event order",
-        _SwappedHooksInBufferedQueryCommands,
-        _SwappedHooksInAsyncBufferedQueryCommands,
+    _HookOrderMutant(
+        slug="swapped-hooks-buffered",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_EVENT_ORDER,
+        sync_commands=_SwappedHooksInBufferedQueryCommands,
+        async_commands=_SwappedHooksInAsyncBufferedQueryCommands,
     ),
-    (
-        "non-entered-prepare-cursor",
-        "lifecycle.hook-order-buffered-query",
-        "prepare-cursor entered-cursor identity",
-        _NonEnteredPrepareCursorCommands,
-        _NonEnteredPrepareCursorAsyncCommands,
+    _HookOrderMutant(
+        slug="non-entered-prepare-cursor",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_PREPARE_CURSOR_ENTERED_CURSOR,
+        sync_commands=_NonEnteredPrepareCursorCommands,
+        async_commands=_NonEnteredPrepareCursorAsyncCommands,
+        path="buffered query",
     ),
-    (
-        "non-entered-prepare-command",
-        "lifecycle.hook-order-buffered-query",
-        "prepare-command entered-cursor identity",
-        _NonEnteredPrepareCommandCommands,
-        _NonEnteredPrepareCommandAsyncCommands,
+    _HookOrderMutant(
+        slug="non-entered-prepare-command",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_PREPARE_COMMAND_ENTERED_CURSOR,
+        sync_commands=_NonEnteredPrepareCommandCommands,
+        async_commands=_NonEnteredPrepareCommandAsyncCommands,
+        path="buffered query",
     ),
-    (
-        "no-hooks-unbuffered",
-        "lifecycle.hook-order-unbuffered-query",
-        "once-per-cursor count",
-        _NoHooksInUnbufferedQueryCommands,
-        _NoHooksInAsyncUnbufferedQueryCommands,
+    _HookOrderMutant(
+        slug="denormalized-options-prepare-cursor",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_PREPARE_CURSOR_NORMALIZED_OPTIONS,
+        sync_commands=_DenormalizedOptionsForPrepareCursorCommands,
+        async_commands=_DenormalizedOptionsForPrepareCursorAsyncCommands,
+        path="buffered query",
     ),
-    (
-        "swapped-hooks-unbuffered",
-        "lifecycle.hook-order-unbuffered-query",
-        "event order (the only check that can see this one)",
-        _SwappedHooksInUnbufferedQueryCommands,
-        _SwappedHooksInAsyncUnbufferedQueryCommands,
+    _HookOrderMutant(
+        slug="denormalized-options-prepare-command",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_PREPARE_COMMAND_NORMALIZED_OPTIONS,
+        sync_commands=_DenormalizedOptionsForPrepareCommandCommands,
+        async_commands=_DenormalizedOptionsForPrepareCommandAsyncCommands,
+        path="buffered query",
     ),
-    (
-        "no-hooks-query-first",
-        "lifecycle.hook-order-single-row-commands",
-        "preparation prefix",
-        _NoHooksInQueryFirstCommands,
-        _NoHooksInAsyncQueryFirstCommands,
+    _HookOrderMutant(
+        slug="other-handler-buffered",
+        case_id="lifecycle.hook-order-buffered-query",
+        assertion=_PREPARED_HANDLER_PAIRING,
+        sync_commands=_OtherHandlerInBufferedQueryCommands,
+        async_commands=_OtherHandlerInAsyncBufferedQueryCommands,
+        path="buffered query",
     ),
-    (
-        "swapped-hooks-query-first",
-        "lifecycle.hook-order-single-row-commands",
-        "preparation prefix (the only check that can see this one)",
-        _SwappedHooksInQueryFirstCommands,
-        _SwappedHooksInAsyncQueryFirstCommands,
+    _HookOrderMutant(
+        slug="no-hooks-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_NoHooksInUnbufferedQueryCommands,
+        async_commands=_NoHooksInAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
     ),
-    (
-        "late-prepare-cursor-query-first",
-        "lifecycle.hook-order-single-row-commands",
-        "once-per-cursor count",
-        _LatePrepareCursorInQueryFirstCommands,
-        _LatePrepareCursorInAsyncQueryFirstCommands,
+    _HookOrderMutant(
+        slug="swapped-hooks-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_SwappedHooksInUnbufferedQueryCommands,
+        async_commands=_SwappedHooksInAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
     ),
-    (
-        "late-prepare-command-query-first",
-        "lifecycle.hook-order-single-row-commands",
-        "once-per-handler count",
-        _LatePrepareCommandInQueryFirstCommands,
-        _LatePrepareCommandInAsyncQueryFirstCommands,
+    _HookOrderMutant(
+        slug="extra-cursor-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_ONE_COMMAND_CURSOR,
+        sync_commands=_ExtraCursorAfterUnbufferedQueryCommands,
+        async_commands=_ExtraCursorAfterAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
     ),
-    (
-        "per-query-prepare-cursor",
-        "lifecycle.hook-order-query-multiple",
-        "once-per-cursor count",
-        _PerQueryPrepareCursorCommands,
-        _PerQueryPrepareCursorAsyncCommands,
+    _HookOrderMutant(
+        slug="non-entered-hooks-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_PREPARE_CURSOR_ENTERED_CURSOR,
+        sync_commands=_NonEnteredHooksInUnbufferedQueryCommands,
+        async_commands=_NonEnteredHooksInAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
     ),
-    (
-        "swapped-hooks-query-multiple",
-        "lifecycle.hook-order-query-multiple",
-        "event order (the only check that can see this one)",
-        _SwappedHooksInQueryMultipleCommands,
-        _SwappedHooksInAsyncQueryMultipleCommands,
+    _HookOrderMutant(
+        slug="other-handler-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_PREPARED_HANDLER_PAIRING,
+        sync_commands=_OtherHandlerInUnbufferedQueryCommands,
+        async_commands=_OtherHandlerInAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
+    ),
+    _HookOrderMutant(
+        slug="no-hooks-query-first",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_NoHooksInQueryFirstCommands,
+        async_commands=_NoHooksInAsyncQueryFirstCommands,
+        path="query_first",
+    ),
+    _HookOrderMutant(
+        slug="swapped-hooks-query-first",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_SwappedHooksInQueryFirstCommands,
+        async_commands=_SwappedHooksInAsyncQueryFirstCommands,
+        path="query_first",
+    ),
+    _HookOrderMutant(
+        slug="late-prepare-cursor-query-first",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARE_CURSOR_ONCE,
+        sync_commands=_LatePrepareCursorInQueryFirstCommands,
+        async_commands=_LatePrepareCursorInAsyncQueryFirstCommands,
+        path="query_first",
+    ),
+    _HookOrderMutant(
+        slug="late-prepare-command-query-first",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARE_COMMAND_ONCE,
+        sync_commands=_LatePrepareCommandInQueryFirstCommands,
+        async_commands=_LatePrepareCommandInAsyncQueryFirstCommands,
+        path="query_first",
+    ),
+    _HookOrderMutant(
+        slug="no-hooks-query-single",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_NoHooksInQuerySingleCommands,
+        async_commands=_NoHooksInAsyncQuerySingleCommands,
+        path="query_single",
+    ),
+    _HookOrderMutant(
+        slug="no-hooks-execute-scalar",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_PREPARATION_PREFIX,
+        sync_commands=_NoHooksInExecuteScalarCommands,
+        async_commands=_NoHooksInAsyncExecuteScalarCommands,
+        path="execute_scalar",
+    ),
+    _HookOrderMutant(
+        slug="per-query-prepare-cursor",
+        case_id="lifecycle.hook-order-query-multiple",
+        assertion=_EVENT_ORDER,
+        sync_commands=_PerQueryPrepareCursorCommands,
+        async_commands=_PerQueryPrepareCursorAsyncCommands,
+    ),
+    _HookOrderMutant(
+        slug="swapped-hooks-query-multiple",
+        case_id="lifecycle.hook-order-query-multiple",
+        assertion=_EVENT_ORDER,
+        sync_commands=_SwappedHooksInQueryMultipleCommands,
+        async_commands=_SwappedHooksInAsyncQueryMultipleCommands,
+    ),
+    _HookOrderMutant(
+        slug="non-entered-hooks-query-multiple",
+        case_id="lifecycle.hook-order-query-multiple",
+        assertion=_PREPARE_CURSOR_ENTERED_CURSOR,
+        sync_commands=_NonEnteredHooksInQueryMultipleCommands,
+        async_commands=_NonEnteredHooksInAsyncQueryMultipleCommands,
+        path="query_multiple",
+    ),
+    _HookOrderMutant(
+        slug="mispaired-handlers-query-multiple",
+        case_id="lifecycle.hook-order-query-multiple",
+        assertion=_PREPARED_HANDLER_PAIRING,
+        sync_commands=_MispairedHandlersInQueryMultipleCommands,
+        async_commands=_MispairedHandlersInAsyncQueryMultipleCommands,
+        path="query_multiple",
+    ),
+    _HookOrderMutant(
+        slug="truncated-query-multiple-results",
+        case_id="lifecycle.hook-order-query-multiple",
+        assertion=_ONE_RESULT_SET_PER_QUERY,
+        sync_commands=_TruncatedQueryMultipleResultsCommands,
+        async_commands=_TruncatedAsyncQueryMultipleResultsCommands,
+        path="query_multiple",
     ),
 )
 
-_HOOK_ORDER_MUTANT_IDS = [mutant[0] for mutant in _HOOK_ORDER_MUTANTS]
-_SYNC_HOOK_ORDER_MUTANTS = [(mutant[0], mutant[1], mutant[3]) for mutant in _HOOK_ORDER_MUTANTS]
-_ASYNC_HOOK_ORDER_MUTANTS = [(mutant[0], mutant[1], mutant[4]) for mutant in _HOOK_ORDER_MUTANTS]
+
+_HOOK_ORDER_MUTANT_IDS = [mutant.slug for mutant in _HOOK_ORDER_MUTANTS]
 
 
-def _assert_only_the_named_hook_case_failed(report, expected_case_id):
+def _expected_message_fragments(mutant):
+    if mutant.path:
+        return (mutant.assertion.fragment, mutant.path)
+    return (mutant.assertion.fragment,)
+
+
+def _assert_only_the_named_hook_case_failed(report, mutant):
     failed_ids = {failure.case_id for failure in report.failures}
-    assert failed_ids == {expected_case_id}, "the mutant must be caught, and caught narrowly, by its own case"
+    assert failed_ids == {mutant.case_id}, "the mutant must be caught, and caught narrowly, by its own case"
     passed_ids = {result.case_id for result in report.results if result.passed}
     assert "lifecycle.hook-order" in passed_ids, "the pre-existing execute-path case cannot see query-path hooks"
-    named = next(failure for failure in report.failures if failure.case_id == expected_case_id)
-    assert named.message
+    named = next(failure for failure in report.failures if failure.case_id == mutant.case_id)
+    for fragment in _expected_message_fragments(mutant):
+        # failing the right case on the *wrong* assertion proves nothing about the assertion the
+        # table says this row pins, so the failure message has to match it too
+        assert fragment in named.message, (
+            f"{mutant.slug} must fail {mutant.case_id} on the {mutant.assertion.label} assertion "
+            f"the table names for it: expected {fragment!r} in {named.message!r}"
+        )
 
 
-@pytest.mark.parametrize("slug,expected_case_id,commands_class", _SYNC_HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
-def test_query_path_hook_ordering_mutant_fails_its_named_case(
-    isolated_registry, slug, expected_case_id, commands_class
-):
-    name = f"conformance-mock-{slug}"
+@pytest.mark.parametrize("mutant", _HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
+def test_query_path_hook_ordering_mutant_fails_its_named_case(isolated_registry, mutant):
+    name = f"conformance-mock-{mutant.slug}"
+    commands_class = mutant.sync_commands
     _register_mock_sync(name=name, commands=commands_class)
 
     class _Harness(MockSyncConformanceHarness):
@@ -767,15 +1201,14 @@ def test_query_path_hook_ordering_mutant_fails_its_named_case(
         def create_commands(self):
             return commands_class(FakeSyncConnection(seeded_mini_db()))
 
-    _assert_only_the_named_hook_case_failed(run_core_sync(_Harness()), expected_case_id)
+    _assert_only_the_named_hook_case_failed(run_core_sync(_Harness()), mutant)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("slug,expected_case_id,commands_class", _ASYNC_HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
-async def test_async_query_path_hook_ordering_mutant_fails_its_named_case(
-    isolated_registry, slug, expected_case_id, commands_class
-):
-    name = f"conformance-mock-{slug}-async"
+@pytest.mark.parametrize("mutant", _HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
+async def test_async_query_path_hook_ordering_mutant_fails_its_named_case(isolated_registry, mutant):
+    name = f"conformance-mock-{mutant.slug}-async"
+    commands_class = mutant.async_commands
     _register_mock_async(name=name, async_commands=commands_class)
 
     class _Harness(MockAsyncConformanceHarness):
@@ -786,7 +1219,7 @@ async def test_async_query_path_hook_ordering_mutant_fails_its_named_case(
         async def create_commands(self):
             return commands_class(FakeAsyncConnection(seeded_mini_db()))
 
-    _assert_only_the_named_hook_case_failed(await run_core_async(_Harness()), expected_case_id)
+    _assert_only_the_named_hook_case_failed(await run_core_async(_Harness()), mutant)
 
 
 class _InvalidCapabilityCommands(MockSyncConformanceCommands):
@@ -1521,6 +1954,13 @@ def test_check_event_order_helper_reports_the_observed_order(isolated_registry):
     with pytest.raises(CaseCheckError) as exc_info:
         ctx.check_event_order(connection.log, ("execute",))
     assert "expected driver interaction order" in str(exc_info.value)
+
+    # the helper is an *exact* order assertion, not a prefix one: cases that mean to pin only
+    # the preparation prefix say so with their own prefix check, and every other case relies on
+    # trailing interactions being rejected here
+    with pytest.raises(CaseCheckError) as prefix_info:
+        ctx.check_event_order(connection.log, observed[:-1])
+    assert "expected driver interaction order" in str(prefix_info.value)
 
 
 def test_conformance_failure_error_tolerates_a_report_without_failures():

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -600,6 +600,35 @@ def _denormalized_options_for_hook(commands, hook_name, awaitable):
         setattr(commands, hook_name, real_hook)
 
 
+@contextmanager
+def _statement_executed_twice(commands, hook_name, awaitable):
+    """Run the whole prepare-command-then-execute pair twice for every handler.
+
+    Everything else stays conformant: one cursor, one prepare-cursor call, the preparation
+    hooks still run in order on the entered cursor before any row is fetched, every execution
+    is still immediately preceded by a prepare-command call observing the handler that runs
+    next, and the rows are still drained exactly once. Only the statement runs twice, which
+    is invisible to a case that pins the preparation *prefix* and leaves the drain unpinned.
+    """
+    real_hook = getattr(commands, hook_name)
+
+    def hook(cursor, handler, **kwargs):
+        real_hook(cursor, handler, **kwargs)
+        handler.execute(cursor)
+        return real_hook(cursor, handler, **kwargs)
+
+    async def hook_async(cursor, handler, **kwargs):
+        await real_hook(cursor, handler, **kwargs)
+        await handler.execute_async(cursor)
+        await real_hook(cursor, handler, **kwargs)
+
+    setattr(commands, hook_name, hook_async if awaitable else hook)
+    try:
+        yield
+    finally:
+        setattr(commands, hook_name, real_hook)
+
+
 def _sync_mutation(commands, mutation):
     return mutation(commands, "_prepare_cursor", "_prepare_command", False)
 
@@ -626,6 +655,14 @@ class _SwappedHooksInUnbufferedQueryCommands(MockSyncConformanceCommands):
             yield from super()._unbuffered_query(*args, **kwargs)
 
 
+class _DoubleExecuteInUnbufferedQueryCommands(MockSyncConformanceCommands):
+    """Prepares and runs the same statement twice before draining the result set once."""
+
+    def _unbuffered_query(self, *args, **kwargs):
+        with _statement_executed_twice(self, "_prepare_command", False):
+            yield from super()._unbuffered_query(*args, **kwargs)
+
+
 class _ExtraCursorAfterUnbufferedQueryCommands(MockSyncConformanceCommands):
     """Acquires a second, never-prepared cursor once the streamed result set is exhausted."""
 
@@ -649,6 +686,14 @@ class _OtherHandlerInUnbufferedQueryCommands(MockSyncConformanceCommands):
 class _NoHooksInQueryFirstCommands(MockSyncConformanceCommands):
     def query_first(self, *args, **kwargs):
         with _sync_mutation(self, _skipped_hooks):
+            return super().query_first(*args, **kwargs)
+
+
+class _DoubleExecuteInQueryFirstCommands(MockSyncConformanceCommands):
+    """Prepares and runs the same statement twice before reading the first row once."""
+
+    def query_first(self, *args, **kwargs):
+        with _statement_executed_twice(self, "_prepare_command", False):
             return super().query_first(*args, **kwargs)
 
 
@@ -783,6 +828,19 @@ class _SwappedHooksInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
             await inner.aclose()
 
 
+class _DoubleExecuteInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    """Prepares and runs the same statement twice before draining the result set once."""
+
+    async def _unbuffered_query(self, *args, **kwargs):
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            with _statement_executed_twice(self, "_prepare_command_async", True):
+                async for row in inner:
+                    yield row
+        finally:
+            await inner.aclose()
+
+
 class _ExtraCursorAfterAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
     """Acquires a second, never-prepared cursor once the streamed result set is exhausted."""
 
@@ -821,6 +879,14 @@ class _OtherHandlerInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
 class _NoHooksInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
     async def query_first_async(self, *args, **kwargs):
         with _async_mutation(self, _skipped_hooks):
+            return await super().query_first_async(*args, **kwargs)
+
+
+class _DoubleExecuteInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
+    """Prepares and runs the same statement twice before reading the first row once."""
+
+    async def query_first_async(self, *args, **kwargs):
+        with _statement_executed_twice(self, "_prepare_command_async", True):
             return await super().query_first_async(*args, **kwargs)
 
 
@@ -947,6 +1013,10 @@ _PREPARE_COMMAND_ONCE = _Assertion(
     "once-per-handler prepare-command count",
     "must run the prepare-command hook exactly once per executed handler",
 )
+_STATEMENT_EXECUTED_ONCE = _Assertion(
+    "exactly-one-execution count",
+    "must execute its statement exactly once",
+)
 _PREPARE_CURSOR_ENTERED_CURSOR = _Assertion(
     "prepare-cursor entered-cursor identity",
     "prepare-cursor hook must receive the entered cursor object",
@@ -1068,6 +1138,14 @@ _HOOK_ORDER_MUTANTS = (
         path="unbuffered query",
     ),
     _HookOrderMutant(
+        slug="double-execute-unbuffered",
+        case_id="lifecycle.hook-order-unbuffered-query",
+        assertion=_STATEMENT_EXECUTED_ONCE,
+        sync_commands=_DoubleExecuteInUnbufferedQueryCommands,
+        async_commands=_DoubleExecuteInAsyncUnbufferedQueryCommands,
+        path="unbuffered query",
+    ),
+    _HookOrderMutant(
         slug="extra-cursor-unbuffered",
         case_id="lifecycle.hook-order-unbuffered-query",
         assertion=_ONE_COMMAND_CURSOR,
@@ -1105,6 +1183,14 @@ _HOOK_ORDER_MUTANTS = (
         assertion=_PREPARATION_PREFIX,
         sync_commands=_SwappedHooksInQueryFirstCommands,
         async_commands=_SwappedHooksInAsyncQueryFirstCommands,
+        path="query_first",
+    ),
+    _HookOrderMutant(
+        slug="double-execute-query-first",
+        case_id="lifecycle.hook-order-single-row-commands",
+        assertion=_STATEMENT_EXECUTED_ONCE,
+        sync_commands=_DoubleExecuteInQueryFirstCommands,
+        async_commands=_DoubleExecuteInAsyncQueryFirstCommands,
         path="query_first",
     ),
     _HookOrderMutant(

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -340,6 +340,455 @@ def test_error_masking_adapter_fails_named_case(isolated_registry):
     assert isinstance(named.cause, _CleanupMask)
 
 
+# ---------------------------------------------- hook-ordering mutants fail the named query-path cases
+#
+# The query-path hook-ordering cases are only worth shipping if they can fail, so each is pinned here by
+# a deliberately non-conformant adapter. Every mutant keeps the real command body *and* the real hook
+# implementations and rewires only *when* the body's two hook calls reach them, so it differs from a
+# conformant adapter in preparation-hook ordering alone -- nothing else can be what fails the case.
+
+
+@contextmanager
+def _swapped_hooks(commands, cursor_hook_name, command_hook_name, awaitable):
+    """Defer the prepare-cursor hook until just after the prepare-command hook."""
+    real_cursor_hook = getattr(commands, cursor_hook_name)
+    real_command_hook = getattr(commands, command_hook_name)
+    deferred = []
+
+    def prepare_cursor(cursor, *, options):
+        deferred.append((cursor, options))
+
+    def prepare_command(cursor, handler, *, options):
+        real_command_hook(cursor, handler, options=options)
+        while deferred:
+            deferred_cursor, deferred_options = deferred.pop(0)
+            real_cursor_hook(deferred_cursor, options=deferred_options)
+
+    async def prepare_cursor_async(cursor, *, options):
+        deferred.append((cursor, options))
+
+    async def prepare_command_async(cursor, handler, *, options):
+        await real_command_hook(cursor, handler, options=options)
+        while deferred:
+            deferred_cursor, deferred_options = deferred.pop(0)
+            await real_cursor_hook(deferred_cursor, options=deferred_options)
+
+    setattr(commands, cursor_hook_name, prepare_cursor_async if awaitable else prepare_cursor)
+    setattr(commands, command_hook_name, prepare_command_async if awaitable else prepare_command)
+    try:
+        yield
+    finally:
+        setattr(commands, cursor_hook_name, real_cursor_hook)
+        setattr(commands, command_hook_name, real_command_hook)
+
+
+@contextmanager
+def _skipped_hooks(commands, cursor_hook_name, command_hook_name, awaitable):
+    """Never let either hook call reach its implementation."""
+    real_cursor_hook = getattr(commands, cursor_hook_name)
+    real_command_hook = getattr(commands, command_hook_name)
+
+    def prepare_cursor(cursor, *, options):
+        return None
+
+    def prepare_command(cursor, handler, *, options):
+        return None
+
+    async def prepare_cursor_async(cursor, *, options):
+        return None
+
+    async def prepare_command_async(cursor, handler, *, options):
+        return None
+
+    setattr(commands, cursor_hook_name, prepare_cursor_async if awaitable else prepare_cursor)
+    setattr(commands, command_hook_name, prepare_command_async if awaitable else prepare_command)
+    try:
+        yield
+    finally:
+        setattr(commands, cursor_hook_name, real_cursor_hook)
+        setattr(commands, command_hook_name, real_command_hook)
+
+
+@contextmanager
+def _prepare_cursor_moved_into_the_query_loop(commands, cursor_hook_name, command_hook_name, awaitable):
+    """Drop the once-per-cursor prepare-cursor call and re-run it before every handler instead."""
+    real_cursor_hook = getattr(commands, cursor_hook_name)
+    real_command_hook = getattr(commands, command_hook_name)
+
+    def prepare_cursor(cursor, *, options):
+        return None
+
+    def prepare_command(cursor, handler, *, options):
+        real_cursor_hook(cursor, options=options)
+        real_command_hook(cursor, handler, options=options)
+
+    async def prepare_cursor_async(cursor, *, options):
+        return None
+
+    async def prepare_command_async(cursor, handler, *, options):
+        await real_cursor_hook(cursor, options=options)
+        await real_command_hook(cursor, handler, options=options)
+
+    setattr(commands, cursor_hook_name, prepare_cursor_async if awaitable else prepare_cursor)
+    setattr(commands, command_hook_name, prepare_command_async if awaitable else prepare_command)
+    try:
+        yield
+    finally:
+        setattr(commands, cursor_hook_name, real_cursor_hook)
+        setattr(commands, command_hook_name, real_command_hook)
+
+
+class _CursorStandIn:
+    """A forwarding stand-in that is *not* the object the command body entered."""
+
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+
+@contextmanager
+def _non_entered_cursor_for_hook(commands, hook_name, awaitable):
+    """Hand one hook a stand-in instead of the cursor the command body entered.
+
+    Only one hook is mis-targeted per mutant so each entered-cursor assertion is pinned on
+    its own rather than by its sibling.
+    """
+    real_hook = getattr(commands, hook_name)
+
+    def hook(cursor, *args, **kwargs):
+        return real_hook(_CursorStandIn(cursor), *args, **kwargs)
+
+    async def hook_async(cursor, *args, **kwargs):
+        await real_hook(_CursorStandIn(cursor), *args, **kwargs)
+
+    setattr(commands, hook_name, hook_async if awaitable else hook)
+    try:
+        yield
+    finally:
+        setattr(commands, hook_name, real_hook)
+
+
+@contextmanager
+def _recorded_hook_calls(commands, hook_name):
+    """Let one hook through untouched while capturing its arguments for a later replay."""
+    real_hook = getattr(commands, hook_name)
+    calls = []
+
+    def hook(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real_hook(*args, **kwargs)
+
+    setattr(commands, hook_name, hook)
+    try:
+        yield calls
+    finally:
+        setattr(commands, hook_name, real_hook)
+
+
+def _sync_mutation(commands, mutation):
+    return mutation(commands, "_prepare_cursor", "_prepare_command", False)
+
+
+def _async_mutation(commands, mutation):
+    return mutation(commands, "_prepare_cursor_async", "_prepare_command_async", True)
+
+
+class _SwappedHooksInBufferedQueryCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _sync_mutation(self, _swapped_hooks):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _NoHooksInUnbufferedQueryCommands(MockSyncConformanceCommands):
+    def _unbuffered_query(self, *args, **kwargs):
+        with _sync_mutation(self, _skipped_hooks):
+            yield from super()._unbuffered_query(*args, **kwargs)
+
+
+class _SwappedHooksInUnbufferedQueryCommands(MockSyncConformanceCommands):
+    def _unbuffered_query(self, *args, **kwargs):
+        with _sync_mutation(self, _swapped_hooks):
+            yield from super()._unbuffered_query(*args, **kwargs)
+
+
+class _NoHooksInQueryFirstCommands(MockSyncConformanceCommands):
+    def query_first(self, *args, **kwargs):
+        with _sync_mutation(self, _skipped_hooks):
+            return super().query_first(*args, **kwargs)
+
+
+class _PerQueryPrepareCursorCommands(MockSyncConformanceCommands):
+    def query_multiple(self, *args, **kwargs):
+        with _sync_mutation(self, _prepare_cursor_moved_into_the_query_loop):
+            return super().query_multiple(*args, **kwargs)
+
+
+class _SwappedHooksInQueryMultipleCommands(MockSyncConformanceCommands):
+    def query_multiple(self, *args, **kwargs):
+        with _sync_mutation(self, _swapped_hooks):
+            return super().query_multiple(*args, **kwargs)
+
+
+class _NonEnteredPrepareCursorCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_cursor", False):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _NonEnteredPrepareCommandCommands(MockSyncConformanceCommands):
+    def _buffered_query(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_command", False):
+            return super()._buffered_query(*args, **kwargs)
+
+
+class _SwappedHooksInQueryFirstCommands(MockSyncConformanceCommands):
+    def query_first(self, *args, **kwargs):
+        with _sync_mutation(self, _swapped_hooks):
+            return super().query_first(*args, **kwargs)
+
+
+class _LatePrepareCursorInQueryFirstCommands(MockSyncConformanceCommands):
+    """Repeats the prepare-cursor hook once the cursor block has already closed."""
+
+    def query_first(self, *args, **kwargs):
+        with _recorded_hook_calls(self, "_prepare_cursor") as calls:
+            result = super().query_first(*args, **kwargs)
+        for call_args, call_kwargs in calls:
+            self._prepare_cursor(*call_args, **call_kwargs)
+        return result
+
+
+class _LatePrepareCommandInQueryFirstCommands(MockSyncConformanceCommands):
+    """Repeats the prepare-command hook for a handler that is never executed again."""
+
+    def query_first(self, *args, **kwargs):
+        with _recorded_hook_calls(self, "_prepare_command") as calls:
+            result = super().query_first(*args, **kwargs)
+        for call_args, call_kwargs in calls:
+            self._prepare_command(*call_args, **call_kwargs)
+        return result
+
+
+class _SwappedHooksInAsyncBufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _async_mutation(self, _swapped_hooks):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _NoHooksInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _unbuffered_query(self, *args, **kwargs):
+        # the inner generator is aclosed explicitly so wrapping it stays invisible to the
+        # unbuffered cleanup cases; only the hook calls differ from a conformant adapter
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            with _async_mutation(self, _skipped_hooks):
+                async for row in inner:
+                    yield row
+        finally:
+            await inner.aclose()
+
+
+class _SwappedHooksInAsyncUnbufferedQueryCommands(MockAsyncConformanceCommands):
+    async def _unbuffered_query(self, *args, **kwargs):
+        inner = super()._unbuffered_query(*args, **kwargs)
+        try:
+            with _async_mutation(self, _swapped_hooks):
+                async for row in inner:
+                    yield row
+        finally:
+            await inner.aclose()
+
+
+class _NoHooksInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
+    async def query_first_async(self, *args, **kwargs):
+        with _async_mutation(self, _skipped_hooks):
+            return await super().query_first_async(*args, **kwargs)
+
+
+class _PerQueryPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
+    async def query_multiple_async(self, *args, **kwargs):
+        with _async_mutation(self, _prepare_cursor_moved_into_the_query_loop):
+            return await super().query_multiple_async(*args, **kwargs)
+
+
+class _SwappedHooksInAsyncQueryMultipleCommands(MockAsyncConformanceCommands):
+    async def query_multiple_async(self, *args, **kwargs):
+        with _async_mutation(self, _swapped_hooks):
+            return await super().query_multiple_async(*args, **kwargs)
+
+
+class _NonEnteredPrepareCursorAsyncCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_cursor_async", True):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _NonEnteredPrepareCommandAsyncCommands(MockAsyncConformanceCommands):
+    async def _buffered_query(self, *args, **kwargs):
+        with _non_entered_cursor_for_hook(self, "_prepare_command_async", True):
+            return await super()._buffered_query(*args, **kwargs)
+
+
+class _SwappedHooksInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
+    async def query_first_async(self, *args, **kwargs):
+        with _async_mutation(self, _swapped_hooks):
+            return await super().query_first_async(*args, **kwargs)
+
+
+class _LatePrepareCursorInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
+    async def query_first_async(self, *args, **kwargs):
+        with _recorded_hook_calls(self, "_prepare_cursor_async") as calls:
+            result = await super().query_first_async(*args, **kwargs)
+        for call_args, call_kwargs in calls:
+            await self._prepare_cursor_async(*call_args, **call_kwargs)
+        return result
+
+
+class _LatePrepareCommandInAsyncQueryFirstCommands(MockAsyncConformanceCommands):
+    async def query_first_async(self, *args, **kwargs):
+        with _recorded_hook_calls(self, "_prepare_command_async") as calls:
+            result = await super().query_first_async(*args, **kwargs)
+        for call_args, call_kwargs in calls:
+            await self._prepare_command_async(*call_args, **call_kwargs)
+        return result
+
+
+#: (slug, case the mutant must fail, assertion it pins, sync class, async class). Together these
+#: pin every assertion the four new cases add: event order, the preparation prefix, the
+#: once-per-cursor and once-per-handler counts, and entered-cursor identity.
+_HOOK_ORDER_MUTANTS = (
+    (
+        "swapped-hooks-buffered",
+        "lifecycle.hook-order-buffered-query",
+        "event order",
+        _SwappedHooksInBufferedQueryCommands,
+        _SwappedHooksInAsyncBufferedQueryCommands,
+    ),
+    (
+        "non-entered-prepare-cursor",
+        "lifecycle.hook-order-buffered-query",
+        "prepare-cursor entered-cursor identity",
+        _NonEnteredPrepareCursorCommands,
+        _NonEnteredPrepareCursorAsyncCommands,
+    ),
+    (
+        "non-entered-prepare-command",
+        "lifecycle.hook-order-buffered-query",
+        "prepare-command entered-cursor identity",
+        _NonEnteredPrepareCommandCommands,
+        _NonEnteredPrepareCommandAsyncCommands,
+    ),
+    (
+        "no-hooks-unbuffered",
+        "lifecycle.hook-order-unbuffered-query",
+        "once-per-cursor count",
+        _NoHooksInUnbufferedQueryCommands,
+        _NoHooksInAsyncUnbufferedQueryCommands,
+    ),
+    (
+        "swapped-hooks-unbuffered",
+        "lifecycle.hook-order-unbuffered-query",
+        "event order (the only check that can see this one)",
+        _SwappedHooksInUnbufferedQueryCommands,
+        _SwappedHooksInAsyncUnbufferedQueryCommands,
+    ),
+    (
+        "no-hooks-query-first",
+        "lifecycle.hook-order-single-row-commands",
+        "preparation prefix",
+        _NoHooksInQueryFirstCommands,
+        _NoHooksInAsyncQueryFirstCommands,
+    ),
+    (
+        "swapped-hooks-query-first",
+        "lifecycle.hook-order-single-row-commands",
+        "preparation prefix (the only check that can see this one)",
+        _SwappedHooksInQueryFirstCommands,
+        _SwappedHooksInAsyncQueryFirstCommands,
+    ),
+    (
+        "late-prepare-cursor-query-first",
+        "lifecycle.hook-order-single-row-commands",
+        "once-per-cursor count",
+        _LatePrepareCursorInQueryFirstCommands,
+        _LatePrepareCursorInAsyncQueryFirstCommands,
+    ),
+    (
+        "late-prepare-command-query-first",
+        "lifecycle.hook-order-single-row-commands",
+        "once-per-handler count",
+        _LatePrepareCommandInQueryFirstCommands,
+        _LatePrepareCommandInAsyncQueryFirstCommands,
+    ),
+    (
+        "per-query-prepare-cursor",
+        "lifecycle.hook-order-query-multiple",
+        "once-per-cursor count",
+        _PerQueryPrepareCursorCommands,
+        _PerQueryPrepareCursorAsyncCommands,
+    ),
+    (
+        "swapped-hooks-query-multiple",
+        "lifecycle.hook-order-query-multiple",
+        "event order (the only check that can see this one)",
+        _SwappedHooksInQueryMultipleCommands,
+        _SwappedHooksInAsyncQueryMultipleCommands,
+    ),
+)
+
+_HOOK_ORDER_MUTANT_IDS = [mutant[0] for mutant in _HOOK_ORDER_MUTANTS]
+_SYNC_HOOK_ORDER_MUTANTS = [(mutant[0], mutant[1], mutant[3]) for mutant in _HOOK_ORDER_MUTANTS]
+_ASYNC_HOOK_ORDER_MUTANTS = [(mutant[0], mutant[1], mutant[4]) for mutant in _HOOK_ORDER_MUTANTS]
+
+
+def _assert_only_the_named_hook_case_failed(report, expected_case_id):
+    failed_ids = {failure.case_id for failure in report.failures}
+    assert failed_ids == {expected_case_id}, "the mutant must be caught, and caught narrowly, by its own case"
+    passed_ids = {result.case_id for result in report.results if result.passed}
+    assert "lifecycle.hook-order" in passed_ids, "the pre-existing execute-path case cannot see query-path hooks"
+    named = next(failure for failure in report.failures if failure.case_id == expected_case_id)
+    assert named.message
+
+
+@pytest.mark.parametrize("slug,expected_case_id,commands_class", _SYNC_HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
+def test_query_path_hook_ordering_mutant_fails_its_named_case(
+    isolated_registry, slug, expected_case_id, commands_class
+):
+    name = f"conformance-mock-{slug}"
+    _register_mock_sync(name=name, commands=commands_class)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = commands_class
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return commands_class(FakeSyncConnection(seeded_mini_db()))
+
+    _assert_only_the_named_hook_case_failed(run_core_sync(_Harness()), expected_case_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug,expected_case_id,commands_class", _ASYNC_HOOK_ORDER_MUTANTS, ids=_HOOK_ORDER_MUTANT_IDS)
+async def test_async_query_path_hook_ordering_mutant_fails_its_named_case(
+    isolated_registry, slug, expected_case_id, commands_class
+):
+    name = f"conformance-mock-{slug}-async"
+    _register_mock_async(name=name, async_commands=commands_class)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = commands_class
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return commands_class(FakeAsyncConnection(seeded_mini_db()))
+
+    _assert_only_the_named_hook_case_failed(await run_core_async(_Harness()), expected_case_id)
+
+
 class _InvalidCapabilityCommands(MockSyncConformanceCommands):
     capabilities = {"transactions"}  # type: ignore[assignment]  # deliberately wrong: set of str
 


### PR DESCRIPTION
Found by an audit of the completed **v1 M2** milestone.

## What was wrong

The shipped adapter-conformance suite issued **false certificates** for preparation-hook ordering. `lifecycle.hook-order` drove the hooks only through `execute()`/`execute_async()`, so no case in either 54-case inventory observed them on the buffered or unbuffered query paths.

Proven by mutation — an adapter that **swaps**, **skips**, or **double-calls** `_prepare_cursor`/`_prepare_command` inside `_buffered_query` passed all 54 cases. Since third-party adapter authors run this suite to establish correctness, that is a defect in a shipped product, not a gap in our tests.

## What changed

Four new cases per mode, covering the distinct code paths rather than redundantly covering every public method:

| Case | Path |
|---|---|
| `lifecycle.hook-order-buffered-query` | `_buffered_query` |
| `lifecycle.hook-order-unbuffered-query` | `_unbuffered_query` |
| `lifecycle.hook-order-single-row-commands` | `query_first` / `query_single` / `execute_scalar` |
| `lifecycle.hook-order-query-multiple` | one `_prepare_cursor` per cursor, one `_prepare_command` per handler |

Core profiles go **54 → 58 cases**.

## Every new case is proven able to fail

The original defect was a case that could not fail, so shipping more unfalsifiable cases would have recreated it one level up. **11 mutant adapters × 2 modes = 22 negative tests** assert that a specific violation fails a specific *named* case while unrelated cases still pass.

Each mutant delegates to the real command body via `super()` and keeps the real hook implementations, rewiring only *when* the hooks are called — so hook ordering is provably the only thing that can fail the case.

## ⚠️ For adapter authors

A third-party adapter that passed before **may now fail** if it mishandles hooks on the query paths. That is the intent: the previous pass did not mean what it appeared to mean.

## Verification

Full suite with all seven backends live: **1631 passed, 100% coverage** (0 missed lines, 0 partial branches). `mypy pydapper`, `mypy tests/type_tests.py`, `black --check`, `isort --check`, `mkdocs build --strict` all clean. Both documented examples exit 0 reporting 58 cases.

## Notes

- Public API unchanged; no new dependencies; `poetry.lock` untouched.
- Case-count comments updated in both `docs_src/` examples. Note those figures are trailing comments: the test
  suite executes the examples and asserts they exit 0, but does **not** assert the printed count, so they are
  documentation rather than a verified invariant. `docs/adapter_conformance.md` carries no case count and was
  not changed for one.
- Does not touch `docs/release_notes.md`, so it will not conflict with the sibling audit PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
