### PR TITLE
docs: document command-owned cursor exits and the #541 behavior change

### DIFF
--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -297,6 +297,54 @@ the feature.
 Adapters prove these contracts — the mandatory per-mode core behavior and, once implemented, each declared
 capability — with the reusable conformance suite; see [Adapter conformance](adapter_conformance.md).
 
+## Command-owned cursor lifecycle
+
+A command method that reaches the DBAPI acquires exactly one cursor and owns it for the whole call. pydapper — not
+the driver — decides what that cursor's disposal is allowed to do to the outcome of the call:
+
+* All result work happens inside the lifecycle. Execution, fetching, cardinality checks, duplicate-column
+  validation, scalar extraction, and row projection run while the cursor is still open, so a failure in any of them
+  is the active exception when cleanup runs.
+* Once the cursor has been entered, cleanup runs exactly once, on both the success and the failure path. A cursor
+  that implements `__enter__` / `__exit__` (or `__aenter__` / `__aexit__`) is entered and exited through them; a
+  cursor that does not is closed through `close()` when it has one. A cursor whose `__enter__` / `__aenter__`
+  raises is never entered, so — as in a plain Python `with` block — neither the exit nor `close()` runs and the
+  acquisition error propagates.
+* **A command-owned cursor exit may not suppress the command error.** A truthy `__exit__` / `__aexit__` return
+  value is ignored while a command error is active, and the original exception propagates as the same object.
+* **A cleanup failure never replaces an active command error.** If cleanup itself raises while a command error is
+  active, the cleanup exception is discarded and the command error propagates. With no active error there is
+  nothing to preserve, so a cleanup failure propagates normally.
+
+Two public shapes qualify "one cursor per call". `execute()` with an empty parameter list returns `0` without
+touching the DBAPI, so it acquires no cursor at all. An unbuffered `query()` (`buffered=False`) returns a generator
+instead of rows, so it acquires its cursor on the first iteration and disposes of it when the generator is
+exhausted or closed; the cursor outlives the call that produced it, but the rules above still govern it.
+
+Together these mean a failing command always raises. A driver cursor cannot turn an internal failure into a
+returned value, so callers never receive a partial or invalid result in place of an exception — a
+`query_multiple()` tuple shorter than the batch it was given, `None` from a `query()` that promises a list of rows,
+or an unrelated error from work the swallowed failure never completed.
+
+### Command-owned cursors vs. user-visible connection context managers
+
+This non-suppression rule is deliberately scoped to the cursors pydapper owns. It is not the rule for the
+connection context manager the caller writes:
+
+| | Command-owned cursor exit | User-visible connection context manager |
+|---|---|---|
+| What it wraps | one command call's own cursor | the dbapi connection the caller entered |
+| Who owns it | pydapper, for one command call | the caller and the driver, for the caller's block |
+| Truthy exit return value | ignored while a command error is active | honored, as in a plain Python `with` block |
+| Exit itself raises | discarded while a command error is active | propagates |
+
+The user-visible form is the one used throughout these docs: `with pydapper.connect(...) as commands:` and
+`async with pydapper.connect_async(...) as commands:`. `Commands.__enter__` / `__exit__` proxy to the connection's
+own context manager when the connection implements one, and `CommandsAsync.__aenter__` / `__aexit__` proxy
+unconditionally because `AsyncConnectionType` requires `__aenter__` / `__aexit__`. Either way a driver that
+commits, rolls back, or suppresses on exit behaves exactly as it would without pydapper. Adapter authors should
+keep that proxying intact: pass the exception triple through and return what the connection returns.
+
 ## Preparation hooks
 
 Command classes may override four protected, documented adapter-author hooks. They are extension points for

--- a/docs/database_support/intro.md
+++ b/docs/database_support/intro.md
@@ -153,6 +153,17 @@ async def main():
 asyncio.run(main())
 ```
 
+### Context manager semantics
+The connection context manager belongs to you and to the dbapi, not to *pydapper*. `__enter__` / `__exit__` are
+proxied to the connection's own context manager when the connection implements one, and `__aenter__` / `__aexit__`
+are proxied unconditionally, so ordinary Python semantics apply: whatever the driver does on exit — commit, roll
+back, close, or suppress the exception by returning a truthy value — is what happens to the code in your block.
+
+That is deliberately different from the cursors *pydapper* owns inside a single command call. A command-owned
+cursor is never allowed to suppress a command failure or to replace it with a cleanup error, so a failing command
+always raises instead of returning a partial or invalid result. See
+[Command-owned cursor lifecycle](../adapter_registration.md#command-owned-cursor-lifecycle) for that contract.
+
 ### `using`
 You should use the `using` method when you want to use your own connection.  A use case
 for this could be if you have a custom connection pool in your application and you don't want a framework

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -71,6 +71,21 @@
   `query_single`; see **Breaking Changes** below for the subclass-override impact.
 * feat: add AdapterCapability vocabulary and command capability checks. PR [#554](https://github.com/zschumacher/pydapper/pull/554) by [@zschumacher](https://github.com/zschumacher).
 * test: cover query_multiple runtime failures inside the command-owned cursor lifecycle. PR [#553](https://github.com/zschumacher/pydapper/pull/553) by [@zschumacher](https://github.com/zschumacher).
+* v1: a driver cursor can no longer suppress an internal command failure. Every sync and async command method does
+  all of its result work — execution, fetching, cardinality checks, duplicate-column validation, scalar extraction,
+  and row projection — inside the one cursor the command owns, and that cursor's disposal can no longer change the
+  outcome of the call: a native cursor `__exit__` / `__aexit__` that returns a truthy value is ignored while a
+  command error is active, and a cleanup failure never replaces an active command error, which still propagates as
+  the same exception object after cleanup runs exactly once. Previously a driver cursor exit could change that
+  outcome in two distinct ways. A truthy exit swallowed the real failure and let the command fall through instead of
+  raising, so a caller could receive a partial or invalid value in place of the error — a `query_multiple()` tuple
+  shorter than the batch it was given, `None` from a `query()` that promises a list of rows, or an unrelated
+  `UnboundLocalError` from work the swallowed failure never completed. An exit that raised replaced the real command
+  error with its own cleanup exception, so the caller was told the cursor failed to close rather than why the
+  command failed. This rule is scoped to cursors pydapper owns internally; the user-visible connection context
+  managers (`with pydapper.connect(...) as commands:` and `async with pydapper.connect_async(...) as commands:`)
+  still proxy to the dbapi connection and keep ordinary Python suppression semantics. See
+  [Command-owned cursor lifecycle](adapter_registration.md#command-owned-cursor-lifecycle).
 * fix: project query_single rows inside the command-owned cursor lifecycle. PR [#551](https://github.com/zschumacher/pydapper/pull/551) by [@zschumacher](https://github.com/zschumacher).
 * fix: run mysql query_first inside the command-owned cursor lifecycle. PR [#552](https://github.com/zschumacher/pydapper/pull/552) by [@zschumacher](https://github.com/zschumacher).
 * fix: project query_single rows inside the command-owned cursor lifecycle. PR [#550](https://github.com/zschumacher/pydapper/pull/550) by [@zschumacher](https://github.com/zschumacher).


### PR DESCRIPTION
Found by an audit of the completed **v1 M2** milestone. Closes an unmet acceptance criterion from #541.

## What was wrong

#541's "Documentation and release notes" section required two things:

1. a release-note entry explaining that driver cursor exits can no longer suppress internal command failures, and that this prevents partial or invalid command return values;
2. documentation of the distinction between **command-owned cursor exits** and **user-visible connection context managers**.

Neither shipped. `docs/release_notes.md` carried only auto-generated PR-title bullets for the entire eight-PR family (#546–#553), while every neighbouring feature (#545, #555, #557, #564, #565) got hand-written prose.

Requirement 2 was *partially* met: `docs/adapter_registration.md` stated that a preparation exception survives a truthy `__exit__`, but scoped specifically to **preparation-hook** failures. The general rule for any command error, and the contrast with connection context managers, were absent.

## What changed

- **Release note** naming the two concrete failure modes a user of the last *released* version could hit: a truthy exit swallowing the error and letting a partial or invalid value reach the caller (a short `query_multiple()` tuple, `None` from a `query()` that promises a list, a stray `UnboundLocalError`); and a raising exit replacing the real command error with a cleanup error.
- **"Command-owned cursor lifecycle" section** stating the general rule and contrasting it with `with pydapper.connect(...) as commands:`, which keeps ordinary Python suppression semantics. Kept consistent with the existing #540 entry, which covers the connection side.

### Attribution note

Both modes are correctly described as "previously" relative to the last release, since both fixes are
unreleased. But they were not fixed by the same work: the **raising-exit** mode was fixed earlier by #529
(*guarantee query cursor cleanup*, merged 2026-07-13), while the **truthy-exit** mode was fixed by the #541
family (#546-#553, from 2026-07-18). The release-note prose is accurate as written; this note is here so the
PR itself does not imply the #541 family fixed both.

## This documents existing behavior — nothing is being fixed

The runtime was independently verified correct during the audit: **139 adversarial cases** against deliberately faulty cursors (sync/async, context-managed and plain, real sqlite3 behind a failing-close proxy, a fake mysql-connector cursor) found **zero** behavioral deviations. Every claim written here was checked against `pydapper/commands.py` and `pydapper/_context.py` first.

## Verification

`pytest -m core` (1392 passed), `pytest -m sqlite` (30 passed), `mkdocs build --strict`, `black --check`, `isort --check` — all clean.

**Driver suites not run:** documentation-only change, and this worktree deliberately has no optional drivers installed. CI covers them.

## Notes

- No runtime or public API change; no dependencies; `poetry.lock` untouched.
- Touches `docs/release_notes.md`, so expect a trivial conflict with the sibling audit PRs (#575, #576) depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

