### PR TITLE
fix: identify connections by type, not repr, in selection errors

### DIFF
--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -369,6 +369,12 @@ match also raises `ValueError`, names the matching adapters, and asks the caller
 order never resolves an ambiguous match. If a predicate raises an exception, selection raises `ValueError` identifying
 the adapter and preserves the original exception as its cause.
 
+Both selection failures identify the connection by the module-qualified name of its type — for example
+`'sqlite3.Connection'` — and never by `repr(connection)`, so a driver representation that embeds the DSN the
+connection was opened with cannot reach a pydapper error message. The label names the module that *defines* the
+connection class, which is not always the driver's public import path, and it identifies the driver rather than
+naming an adapter — pass the adapter's registered name to `adapter=`.
+
 Using connection predicates should be synchronous and side-effect-free. In particular, they should inspect connection
 metadata without importing optional drivers. Built-in predicates inspect the class MRO so ordinary driver subclasses
 work, but arbitrary wrappers and proxies are intentionally not inferred.

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -371,9 +371,12 @@ the adapter and preserves the original exception as its cause.
 
 Both selection failures identify the connection by the module-qualified name of its type — for example
 `'sqlite3.Connection'` — and never by `repr(connection)`, so a driver representation that embeds the DSN the
-connection was opened with cannot reach a pydapper error message. The label names the module that *defines* the
-connection class, which is not always the driver's public import path, and it identifies the driver rather than
-naming an adapter — pass the adapter's registered name to `adapter=`.
+connection was opened with cannot reach a pydapper error message. The label names the module that *defines* the class
+of the connection object itself, which is not always the driver's public import path: for a driver subclass or a
+connection wrapper it names that subclass or wrapper rather than the underlying driver class the built-in predicates
+match through the MRO. It is not an adapter name either — pass the adapter's registered name to `adapter=`. A
+connection type with a missing or non-string `__module__` or `__qualname__` degrades the label instead of raising, so
+selection still fails with the documented `ValueError`.
 
 Using connection predicates should be synchronous and side-effect-free. In particular, they should inspect connection
 metadata without importing optional drivers. Built-in predicates inspect the class MRO so ordinary driver subclasses

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 ## Latest Changes
 
+* fix: keep connection representations out of automatic adapter-selection errors. The zero-match and
+  ambiguous-match `using()` / `using_async()` failures now identify the connection by the module-qualified
+  name of its type — for example `'sqlite3.Connection'` — instead of interpolating `repr(connection)`, so a
+  driver representation that embeds the DSN the connection was opened with can no longer reach a pydapper
+  error message. Both messages still name the requested mode, the matching adapters in the ambiguous case,
+  and the `adapter=` escape hatch.
 * feat: add reusable adapter conformance suite and capability profiles. PR [#565](https://github.com/zschumacher/pydapper/pull/565) by [@zschumacher](https://github.com/zschumacher).
 * v1: a reusable adapter conformance suite now ships in the installed distribution at
   `pydapper.testing.adapter_conformance`. Adapter authors implement a typed `SyncAdapterHarness` /

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -554,12 +554,28 @@ def _connection_type_label(connection: object) -> str:
     useless on its own: psycopg2's connection class is named ``connection``,
     and other drivers' are named ``Connection`` just as ``sqlite3``'s is. Note
     this is the module that *defines* the class, which is not always the
-    driver's public import path. It identifies the driver, which is what the
-    caller needs in order to choose an adapter; it is not itself an adapter
-    name to hand to ``adapter=``.
+    driver's public import path.
+
+    What the label names is the class of the connection object itself and
+    nothing further up its MRO. For an ordinary driver connection that is the
+    driver's class, but for a driver subclass or a connection wrapper it names
+    the subclass or the wrapper rather than the underlying driver class that
+    the built-in MRO-walking predicates match on. It is never an adapter name
+    to hand to ``adapter=`` either.
+
+    Reading those identity attributes is itself defensive, the same way
+    ``_connection_module_matches`` is: a connection type whose ``__module__``
+    or ``__qualname__`` is missing or is not a string degrades the label
+    instead of raising, so a pathological type still fails selection with the
+    documented ValueError rather than an AttributeError from the error path.
     """
     connection_type = type(connection)
-    return f"{connection_type.__module__}.{connection_type.__qualname__}"
+    qualname = getattr(connection_type, "__qualname__", None)
+    label = qualname if isinstance(qualname, str) and qualname else "<unknown type>"
+    module = getattr(connection_type, "__module__", None)
+    if isinstance(module, str) and module:
+        return f"{module}.{label}"
+    return label
 
 
 def _select_registration(connection: object, mode: str) -> _AdapterRegistration:

--- a/pydapper/main.py
+++ b/pydapper/main.py
@@ -537,6 +537,31 @@ def _get_async_commands_class(name: str) -> type[CommandsAsync]:
     return registration.async_commands
 
 
+def _connection_type_label(connection: object) -> str:
+    """Identify a connection for an error message without rendering the connection.
+
+    ``repr(connection)`` is driver-controlled and unbounded: DB-API connection
+    reprs routinely embed the DSN the connection was opened with (user, host,
+    port, database) and a third-party driver may render anything at all,
+    credentials included. The type is the bounded identifier that carries no
+    per-connection state, and it is what pydapper's own predicates match on
+    (see ``_connection_module_matches``), so it is what a selection failure
+    names. A user-supplied ``using_connection_predicate`` may inspect the
+    connection however it likes — that is the public contract — so this label
+    describes what failed to be claimed, not what every predicate examined.
+
+    The defining module is included because the bare class name is frequently
+    useless on its own: psycopg2's connection class is named ``connection``,
+    and other drivers' are named ``Connection`` just as ``sqlite3``'s is. Note
+    this is the module that *defines* the class, which is not always the
+    driver's public import path. It identifies the driver, which is what the
+    caller needs in order to choose an adapter; it is not itself an adapter
+    name to hand to ``adapter=``.
+    """
+    connection_type = type(connection)
+    return f"{connection_type.__module__}.{connection_type.__qualname__}"
+
+
 def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
     """Choose the one adapter whose connection predicate claims a connection.
 
@@ -565,6 +590,11 @@ def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
     provider error. Only once the pass succeeds does the existing behavior
     resume unchanged: filter by requested mode, evaluate the eligible predicates
     in deterministic adapter-name order, and apply the zero/one/multiple rule.
+
+    The zero-match and ambiguous-match failures hold to the same rule: they
+    identify the connection by _connection_type_label() alone, never by
+    ``repr(connection)``, so no driver-controlled connection representation
+    reaches a selection error either.
     """
     _load_all_adapter_providers()
 
@@ -590,13 +620,14 @@ def _select_registration(connection: object, mode: str) -> _AdapterRegistration:
         return matches[0]
     if not matches:
         raise ValueError(
-            f"No registered {mode} adapter can handle {connection!r}; "
+            f"No registered {mode} adapter can handle a connection of type {_connection_type_label(connection)!r}; "
             "register an adapter or pass adapter= explicitly"
         )
 
     matching_names = ", ".join(registration.name for registration in matches)
     raise ValueError(
-        f"Multiple registered {mode} adapters can handle {connection!r}: {matching_names}. Pass adapter= explicitly"
+        f"Multiple registered {mode} adapters can handle a connection of type "
+        f"{_connection_type_label(connection)!r}: {matching_names}. Pass adapter= explicitly"
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,19 @@ DSN = "somedb+tests://localhost"
 
 pytestmark = pytest.mark.core
 
+# real DB-API connection reprs embed the DSN the connection was opened with, and a third-party
+# driver's repr is unbounded, so the sentinel stands in for whatever a driver might render
+CREDENTIAL_BEARING_REPR_SENTINEL = "user=admin password=hunter2 host=db.internal dbname=prod"
+
+
+class CredentialLeakingConnection:
+    def __repr__(self):
+        return f"<connection object at 0x0; dsn: '{CREDENTIAL_BEARING_REPR_SENTINEL}'>"
+
+
+# spelled out rather than derived from the class, so the assertions pin the exact rendering
+EXPECTED_CONNECTION_TYPE_LABEL = "tests.test_main.CredentialLeakingConnection"
+
 
 @pytest.fixture
 def adapter_registry(monkeypatch):
@@ -370,6 +383,49 @@ def test_automatic_selection_rejects_ambiguity_regardless_of_registration_order(
     assert "second" in message
     assert message.index("first") < message.index("second")
     assert predicate_calls == [connection, connection]
+
+
+@pytest.mark.parametrize("factory", [pydapper.using, pydapper.using_async])
+def test_automatic_selection_zero_match_error_names_the_connection_type_not_its_repr(adapter_registry, factory):
+    connection = CredentialLeakingConnection()
+
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        factory(connection)
+
+    message = str(exc_info.value)
+    # the driver-controlled repr -- credentials and all -- must not reach the message
+    assert CREDENTIAL_BEARING_REPR_SENTINEL not in message
+    assert repr(connection) not in message
+    # the connection is still identified, by module-qualified type: enough to tell a caller which
+    # driver pydapper looked at and could not place
+    assert repr(EXPECTED_CONNECTION_TYPE_LABEL) in message
+    assert "register an adapter" in message
+
+
+@pytest.mark.parametrize(
+    ("factory", "registration_kwargs"),
+    [
+        (pydapper.using, {"commands": MockCommands}),
+        (pydapper.using_async, {"async_commands": MockAsyncCommands}),
+    ],
+)
+def test_automatic_selection_ambiguity_error_names_the_connection_type_not_its_repr(
+    adapter_registry, factory, registration_kwargs
+):
+    for name in ("first", "second"):
+        pydapper.register_adapter(name, using_connection_predicate=lambda connection: True, **registration_kwargs)
+
+    connection = CredentialLeakingConnection()
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        factory(connection)
+
+    message = str(exc_info.value)
+    assert CREDENTIAL_BEARING_REPR_SENTINEL not in message
+    assert repr(connection) not in message
+    assert repr(EXPECTED_CONNECTION_TYPE_LABEL) in message
+    # the ambiguity is still actionable: both matching adapters are still named
+    assert "first" in message
+    assert "second" in message
 
 
 def test_sync_selection_does_not_call_async_only_predicates(adapter_registry):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,24 @@ class CredentialLeakingConnection:
 EXPECTED_CONNECTION_TYPE_LABEL = "tests.test_main.CredentialLeakingConnection"
 
 
+class UnreadableTypeIdentityMeta(type):
+    """Makes a connection class's own identity attributes unreadable, as a hostile driver could."""
+
+    def __getattribute__(cls, name):
+        if name in ("__module__", "__qualname__"):
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+
+class NonStringTypeIdentityMeta(type):
+    """Same, except the identity attributes are readable and are not strings."""
+
+    def __getattribute__(cls, name):
+        if name in ("__module__", "__qualname__"):
+            return 42
+        return super().__getattribute__(name)
+
+
 @pytest.fixture
 def adapter_registry(monkeypatch):
     registry = main._adapter_registry.copy()
@@ -426,6 +444,37 @@ def test_automatic_selection_ambiguity_error_names_the_connection_type_not_its_r
     # the ambiguity is still actionable: both matching adapters are still named
     assert "first" in message
     assert "second" in message
+
+
+@pytest.mark.parametrize("factory", [pydapper.using, pydapper.using_async])
+def test_automatic_selection_error_falls_back_to_the_class_name_when_the_module_is_unusable(adapter_registry, factory):
+    connection_class = type("ConnectionWithNonStringModule", (), {})
+    connection_class.__module__ = None
+
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        factory(connection_class())
+
+    message = str(exc_info.value)
+    # no "None." prefix and no bare leading dot: an unusable module drops out of the label entirely
+    assert "a connection of type 'ConnectionWithNonStringModule'" in message
+
+
+@pytest.mark.parametrize("metaclass", [UnreadableTypeIdentityMeta, NonStringTypeIdentityMeta])
+@pytest.mark.parametrize("factory", [pydapper.using, pydapper.using_async])
+def test_automatic_selection_still_raises_value_error_for_an_unlabelable_connection_type(
+    adapter_registry, factory, metaclass
+):
+    # reading type identity off a connection must not be able to turn the documented ValueError
+    # into an AttributeError (or anything else a driver's metaclass chooses to raise)
+    connection_class = metaclass("PathologicalConnection", (), {})
+
+    with pytest.raises(ValueError, match="adapter=") as exc_info:
+        factory(connection_class())
+
+    message = str(exc_info.value)
+    # still a usable message: what pydapper was asked to do, and what to do about it
+    assert "a connection of type '<unknown type>'" in message
+    assert "register an adapter" in message
 
 
 def test_sync_selection_does_not_call_async_only_predicates(adapter_registry):


### PR DESCRIPTION
Found by an audit of the completed **v1 M2** milestone. Closes an unmet implementation guardrail from #468.

## What was wrong

#468 requires that pydapper not include *"credential-bearing DSNs or **unsafe connection representations** in errors/logs"*.

Automatic adapter selection violated this: both the zero-match and ambiguous-match `ValueError`s interpolated `{connection!r}`, and `repr()` of a user-supplied connection object is unbounded by definition.

Aggravating — the same function's own docstring already stated the policy 30 lines earlier: a load failure *"is never re-wrapped with `connection` so a credential-bearing connection repr cannot reach a provider error."* The code contradicted its own documented contract.

## Measured impact

Tested against a live PostgreSQL container: **psycopg2 masks the password** (`password=xxx`), so no secret leaked in practice. But `user`, `dbname`, `host` and `port` did — and a third-party driver's `repr` is arbitrary. The criterion is violated as written regardless of what any one driver happens to do.

## Before / after

**Before**
```
No registered async adapter can handle <connection object at 0x105558970; dsn:
'user=pyduser password=xxx dbname=pydb host=localhost port=63075', closed: 0>;
register an adapter or pass adapter= explicitly
```

**After**
```
No registered async adapter can handle a connection of type
'psycopg2.extensions.connection'; register an adapter or pass adapter= explicitly
```

The module qualifier is deliberate: `psycopg2.extensions.connection` vs `sqlite3.Connection` is exactly what a user needs in order to register or select an adapter, and the bare class name would not serve — psycopg2's is just `connection`. The messages otherwise keep their guidance (requested mode, matching adapter names when ambiguous, pointer to explicit `adapter=`).

## Tests

Regression tests use a connection whose `__repr__` returns a secret-looking sentinel, then assert the sentinel is **absent** while the type name is **present** — so the test fails if anyone reintroduces a repr.

I also searched the rest of `pydapper/` for other places interpolating a connection object into an error or log; there are none.

## Verification

`pytest -m core` (1396 passed), `pytest -m sqlite` (30 passed), `mypy pydapper`, `black --check`, `isort --check`, `mkdocs build --strict` — all clean.

`pydapper/main.py` is at **100%** (268 stmts, 0 missed, 0 partial). The run-level total shows the same 3 missed / 6 partial as an *identically restricted* baseline on unmodified code — those are pre-existing backend-only lines, so this change adds **zero** new gaps.

**Driver suites not run:** this worktree has no optional drivers and the change is driver-independent; CI covers them.

## Notes

- Error message text is not a documented compatibility guarantee, but this is a user-visible string change.
- Touches `docs/release_notes.md`, so expect a trivial conflict with the sibling audit PRs (#574, #576) depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)