### PR TITLE
fix: close five gaps in the owned-resource and adapter-registration contracts

### DIFF
--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -348,8 +348,11 @@ Hook restrictions and error behavior:
 * Hooks must not mutate `CommandOptions`; it is immutable.
 * A hook may raise. A preparation failure is an active command error: the cursor is cleaned up through the shared
   lifecycle exactly once, command preparation and execution do not run after a cursor-preparation failure, and the
-  original preparation exception propagates even if cleanup also fails or a native cursor `__exit__` returns a
-  truthy value.
+  original preparation exception propagates even if cleanup fails with an ordinary `Exception` or a native cursor
+  `__exit__` returns a truthy value. A cleanup failure that is a `BaseException` but not an `Exception` —
+  `KeyboardInterrupt`, `SystemExit`, `asyncio.CancelledError`, or `GeneratorExit` — is deliberately never
+  discarded, because swallowing an interrupt or a cancellation is worse than losing the command error: it
+  propagates in place of the preparation failure, which is preserved as its `__context__`.
 
 Drivers with unusual cursor-factory shapes should normalize the cursor factory by overriding `cursor()`, as the
 psycopg3 async commands already do, rather than replacing cursor ownership inside a preparation hook.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,32 @@
 ## Latest Changes
 
+* fix: harden command-owned cursor cleanup and complete the async drain seam. Four
+  user-observable behaviors changed. First, cleaning up a command-owned cursor no longer discards
+  a `BaseException` that is not an `Exception`: a `KeyboardInterrupt`, `SystemExit`,
+  `asyncio.CancelledError`, or `GeneratorExit` raised by a cursor's `__exit__`/`__aexit__` or
+  `close()` while a command error is already propagating now propagates in place of that command
+  error, which is preserved as its `__context__`. Previously a Ctrl-C or a cancellation raised
+  during cleanup was silently swallowed. Ordinary `Exception` cleanup failures are still discarded
+  so the active command error is re-raised unchanged, but they are now recorded at `DEBUG` on the
+  `pydapper._context` logger with their traceback instead of vanishing. Second, a cursor whose
+  `__enter__`/`__aenter__` raises is now closed best-effort instead of leaking; pydapper created
+  and solely owns that cursor, `__exit__`/`__aexit__` is still not called for a cursor that never
+  entered, and a failing `close()` never replaces the entry error. Third, `CommandsAsync` gained
+  `_on_query_single_more_than_one_result_async`, the previously missing async twin of the sync
+  `query_single` drain seam, invoked at the same point of `query_single_async`, so sync and async
+  exception timing match for an adapter that must drain unread rows before its cursor can be
+  closed. The default is a no-op and no first-party adapter overrides it. Documenting the `_on_*`
+  drain seams alongside the `_prepare_*` hooks is deliberately deferred to the v1 export and typing
+  audit ([#484](https://github.com/zschumacher/pydapper/issues/484)); they remain private hooks
+  outside the documented compatibility surface. Fourth, cancelling a task that is awaiting an async
+  cursor or `connect_async()` no longer leaks the resource when the cancellation lands after
+  acquisition has already completed. Acquisition runs as an independent future, so `await` and
+  `async with` could raise `CancelledError` while that future held a fully created cursor with no
+  owner: the raising `await` binds nothing and a failed `__aenter__` is never exited, so nothing was
+  left to close it. The stranded object is now closed best-effort through the same discard policy,
+  the `CancelledError` is never suppressed, an object another task is concurrently awaiting is never
+  closed, and a wrapper whose resource was discarded this way raises `RuntimeError` rather than
+  handing the closed object out again.
 * feat: add reusable adapter conformance suite and capability profiles. PR [#565](https://github.com/zschumacher/pydapper/pull/565) by [@zschumacher](https://github.com/zschumacher).
 * v1: a reusable adapter conformance suite now ships in the installed distribution at
   `pydapper.testing.adapter_conformance`. Adapter authors implement a typed `SyncAdapterHarness` /

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -19,14 +19,20 @@
   drain seams alongside the `_prepare_*` hooks is deliberately deferred to the v1 export and typing
   audit ([#484](https://github.com/zschumacher/pydapper/issues/484)); they remain private hooks
   outside the documented compatibility surface. Fourth, cancelling a task that is awaiting an async
-  cursor or `connect_async()` no longer leaks the resource when the cancellation lands after
-  acquisition has already completed. Acquisition runs as an independent future, so `await` and
-  `async with` could raise `CancelledError` while that future held a fully created cursor with no
-  owner: the raising `await` binds nothing and a failed `__aenter__` is never exited, so nothing was
-  left to close it. The stranded object is now closed best-effort through the same discard policy,
-  the `CancelledError` is never suppressed, an object another task is concurrently awaiting is never
-  closed, and a wrapper whose resource was discarded this way raises `RuntimeError` rather than
-  handing the closed object out again.
+  cursor no longer leaks that cursor when the cancellation lands after acquisition has already
+  completed. Acquisition runs as an independent future, so `await` and `async with` could raise
+  `CancelledError` while that future held a fully created cursor with no owner: the raising `await`
+  binds nothing and a failed `__aenter__` is never exited, so nothing was left to close it. The
+  stranded cursor is now closed best-effort through the same discard policy, the `CancelledError` is
+  never suppressed, and a cursor another task is concurrently awaiting is never closed. A wrapper
+  that closed its resource this way — on a cancelled acquisition or on a failed `__aenter__`, which
+  share one policy — is spent, and a later `await` or `async with` on it raises `RuntimeError`
+  instead of handing the closed cursor out again. This does **not** fix the same race for
+  `connect_async()`, which still strands its connection: `connect_async()` resolves to a
+  `CommandsAsync`, and `CommandsAsync` exposes no `close()`, so pydapper has nothing it can close
+  there. A wrapper that closed nothing is deliberately never marked spent, so awaiting a cancelled
+  `connect_async()` wrapper again still returns the live `CommandsAsync` — that is the only remaining
+  way to reach the open connection and close it.
 * feat: add reusable adapter conformance suite and capability profiles. PR [#565](https://github.com/zschumacher/pydapper/pull/565) by [@zschumacher](https://github.com/zschumacher).
 * v1: a reusable adapter conformance suite now ships in the installed distribution at
   `pydapper.testing.adapter_conformance`. Adapter authors implement a typed `SyncAdapterHarness` /

--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -21,8 +21,9 @@ _AwaitResultT = TypeVar("_AwaitResultT")
 _EnterResultT = TypeVar("_EnterResultT")
 _UNRESOLVED = object()
 _DISCARDED_RESOLUTION_MESSAGE = (
-    "the resource this wrapper acquired was closed when the only task awaiting it was cancelled after "
-    "acquisition had already completed; the wrapper is spent and cannot resolve again"
+    "the resource this wrapper acquired was closed once the caller could no longer reach it -- either the "
+    "only task awaiting it was cancelled after acquisition had already completed, or its __aenter__ "
+    "raised; the wrapper is spent and cannot resolve again"
 )
 
 
@@ -56,22 +57,33 @@ def _log_discarded_cleanup_error(cleanup_error: Exception) -> None:
     )
 
 
-def _close_quietly(obj: Any) -> None:
-    """Best-effort ``close()`` of a pydapper-owned resource, discarding an ordinary failure."""
+def _owned_close(obj: Any) -> Any:
+    """Resolve ``obj``'s callable ``close``, or ``None`` when it exposes none.
+
+    A pydapper-owned resource is not required to have a ``close()``: ``connect_async()`` resolves to
+    a ``CommandsAsync``, which has none. Every caller asks this one question both to decide whether a
+    close can be attempted at all and to know afterwards whether anything was actually closed, so the
+    two answers cannot disagree -- see :meth:`_AwaitableAsyncContextManager._discard_owned_object`.
+
+    Attribute access can itself fail, since ``close`` may be a descriptor that raises. That is a
+    cleanup failure like any other and may not replace the error already on its way out, so it is
+    recorded and reported here as "nothing to close".
+    """
     try:
         close = getattr(obj, "close", None)
-        if callable(close):
-            close()
     except Exception as cleanup_error:
         _log_discarded_cleanup_error(cleanup_error)
+        return None
+    return close if callable(close) else None
 
 
-async def _close_quietly_async(obj: Any) -> None:
-    """Async twin of :func:`_close_quietly`; an awaitable ``close()`` result is awaited."""
+def _close_quietly(obj: Any) -> None:
+    """Best-effort ``close()`` of a pydapper-owned resource, discarding an ordinary failure."""
+    close = _owned_close(obj)
+    if close is None:
+        return
     try:
-        close = getattr(obj, "close", None)
-        if callable(close):
-            await _await_if_needed(close())
+        close()
     except Exception as cleanup_error:
         _log_discarded_cleanup_error(cleanup_error)
 
@@ -133,15 +145,41 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
           to be handed would trade this leak for a use-after-close, which is worse. ``_obj`` is checked
           for the same reason, since a concurrent awaiter may already have resumed and taken ownership.
 
-        Closing makes the wrapper spent rather than merely unresolved: ``_resolution`` stays a completed
-        future holding the now-closed object, so ``_discarded`` is set -- before the close is awaited --
-        to stop a later ``_resolve`` from handing that object out as if it were healthy.
+        What the close itself does to the wrapper is :meth:`_discard_owned_object`'s decision, shared
+        with the other discard path.
         """
         if self._awaiting or self._obj is not _UNRESOLVED:
             return
         if resolution.done() and not resolution.cancelled() and resolution.exception() is None:
-            self._discarded = True
-            await _close_quietly_async(resolution.result())
+            await self._discard_owned_object(resolution.result())
+
+    async def _discard_owned_object(self, obj: Any) -> None:
+        """Close a pydapper-owned resource the caller can no longer reach, and spend the wrapper.
+
+        The one discard policy for both paths that strand an already-acquired object -- an awaiter
+        cancelled after acquisition completed, and an ``__aenter__`` that raised -- so the two cannot
+        drift apart. The object is closed best-effort, a cleanup failure never replaces the error on
+        its way out, and the wrapper is marked spent so a later ``_resolve`` cannot hand the closed
+        object out as if it were healthy: ``_resolution`` stays a completed future still holding it.
+
+        Being spent is tied to a close actually being attempted, because the two consequences only make
+        sense together. A resource exposing no callable ``close()`` -- ``connect_async()`` resolves to a
+        ``CommandsAsync``, which has none -- cannot be cleaned up here at all, and poisoning the wrapper
+        anyway would put a still-open resource permanently out of reach behind a ``RuntimeError`` that
+        claims it was closed. The wrapper therefore stays resolvable in that case and keeps handing the
+        live object back, which is the only remaining way for the caller to clean it up.
+
+        ``_discarded`` is set before the close is awaited: a ``close()`` that suspends would otherwise
+        leave a window in which a newly arriving awaiter resolves and takes the object out mid-close.
+        """
+        close = _owned_close(obj)
+        if close is None:
+            return
+        self._discarded = True
+        try:
+            await _await_if_needed(close())
+        except Exception as cleanup_error:
+            _log_discarded_cleanup_error(cleanup_error)
 
     def __await__(self) -> Generator[Any, None, _AwaitResultT]:
         return self._resolve().__await__()
@@ -160,7 +198,10 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
                 # context-manager semantics -- a manager that fails to enter is not exited -- govern a
                 # manager the caller supplied, which this never is. __aexit__ stays unbound, so the
                 # object is never cleaned up twice, and the close failure loses to the entry error.
-                await _close_quietly_async(obj)
+                # This strands an acquired object exactly as a cancelled awaiter does, so it takes the
+                # same discard policy: once closed, the wrapper is spent and will not hand the closed
+                # object to the next await or async with.
+                await self._discard_owned_object(obj)
                 raise
             self._aexit = aexit
             return cast(_EnterResultT, entered_obj)

--- a/pydapper/_context.py
+++ b/pydapper/_context.py
@@ -1,4 +1,12 @@
+"""Shared lifecycle helpers for resources pydapper creates and solely owns.
+
+Besides the awaitable/async-context wrapper, this module owns the one cleanup-discard
+policy used by both the sync cursor lifecycle in ``commands`` and the async wrapper
+below, so the two halves cannot drift apart.
+"""
+
 import asyncio
+import logging
 from collections.abc import Awaitable
 from inspect import isawaitable
 from typing import Any
@@ -7,19 +15,71 @@ from typing import Generic
 from typing import TypeVar
 from typing import cast
 
+logger = logging.getLogger(__name__)
+
 _AwaitResultT = TypeVar("_AwaitResultT")
 _EnterResultT = TypeVar("_EnterResultT")
 _UNRESOLVED = object()
+_DISCARDED_RESOLUTION_MESSAGE = (
+    "the resource this wrapper acquired was closed when the only task awaiting it was cancelled after "
+    "acquisition had already completed; the wrapper is spent and cannot resolve again"
+)
 
 
 async def _await_if_needed(value: Any) -> Any:
     return await value if isawaitable(value) else value
 
 
+def _log_discarded_cleanup_error(cleanup_error: Exception) -> None:
+    """Record a cleanup failure that is being discarded to preserve the active error.
+
+    Cleaning up a pydapper-owned resource may not replace the error that is already
+    propagating, so the cleanup exception is dropped rather than raised or chained --
+    the active error must be re-raised as the same object. Dropping it silently makes a
+    co-occurring driver failure undiagnosable, so it is recorded at ``DEBUG`` (off by
+    default, never used for control flow) with its traceback attached.
+
+    Only an ``Exception`` is ever discarded. A ``BaseException`` that is not an
+    ``Exception`` -- ``KeyboardInterrupt``, ``SystemExit``, ``asyncio.CancelledError``, or
+    ``GeneratorExit`` -- is not a resource problem: the first two are interpreter-level
+    requests to stop and the last two are the runtime unwinding this code on purpose.
+    Swallowing any of them is worse than losing the command error -- a dropped Ctrl-C is
+    unrecoverable, and a dropped ``CancelledError`` breaks ``asyncio.timeout`` and task
+    cancellation by making the task look like it ignored the cancel. Callers therefore
+    deliberately let all of them propagate and beat the active error, which is not lost
+    either: it survives as the propagating exception's implicit ``__context__``.
+    """
+    logger.debug(
+        "Discarding %s raised while cleaning up a pydapper-owned resource",
+        type(cleanup_error).__name__,
+        exc_info=cleanup_error,
+    )
+
+
+def _close_quietly(obj: Any) -> None:
+    """Best-effort ``close()`` of a pydapper-owned resource, discarding an ordinary failure."""
+    try:
+        close = getattr(obj, "close", None)
+        if callable(close):
+            close()
+    except Exception as cleanup_error:
+        _log_discarded_cleanup_error(cleanup_error)
+
+
+async def _close_quietly_async(obj: Any) -> None:
+    """Async twin of :func:`_close_quietly`; an awaitable ``close()`` result is awaited."""
+    try:
+        close = getattr(obj, "close", None)
+        if callable(close):
+            await _await_if_needed(close())
+    except Exception as cleanup_error:
+        _log_discarded_cleanup_error(cleanup_error)
+
+
 class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
     """Wrap an awaitable resource for use with ``await`` or ``async with``."""
 
-    __slots__ = ("_awaitable", "_resolution", "_obj", "_aexit", "_preserve_active_error")
+    __slots__ = ("_awaitable", "_resolution", "_obj", "_aexit", "_preserve_active_error", "_awaiting", "_discarded")
 
     def __init__(self, awaitable: Awaitable[_AwaitResultT], *, preserve_active_error: bool = False):
         self._awaitable = awaitable
@@ -27,13 +87,61 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
         self._obj: _AwaitResultT | object = _UNRESOLVED
         self._aexit = None
         self._preserve_active_error = preserve_active_error
+        self._awaiting = 0
+        self._discarded = False
 
     async def _resolve(self) -> _AwaitResultT:
+        if self._discarded:
+            raise RuntimeError(_DISCARDED_RESOLUTION_MESSAGE)
         if self._resolution is _UNRESOLVED:
             self._resolution = asyncio.ensure_future(self._awaitable)
         if self._obj is _UNRESOLVED:
-            self._obj = await cast(asyncio.Future[_AwaitResultT], self._resolution)
+            resolution = cast(asyncio.Future[_AwaitResultT], self._resolution)
+            self._awaiting += 1
+            try:
+                self._obj = await resolution
+            except BaseException:
+                # acquisition runs as an independent future, so it can finish in the window between the
+                # awaiting task being cancelled and this await being resumed with the CancelledError. The
+                # object then exists with no owner and nothing left to close it -- see
+                # _discard_abandoned_resolution. The cancellation is never suppressed; the close is
+                # best-effort cleanup on the way out.
+                self._awaiting -= 1
+                await self._discard_abandoned_resolution(resolution)
+                raise
+            self._awaiting -= 1
         return cast(_AwaitResultT, self._obj)
+
+    async def _discard_abandoned_resolution(self, resolution: "asyncio.Future[_AwaitResultT]") -> None:
+        """Close a pydapper-owned resource whose acquisition completed with no awaiter left to own it.
+
+        ``_resolve`` awaits an ``asyncio`` future, so the acquisition it drives is not cancelled by the
+        awaiting task raising: cancelling a task whose awaited future has *already* completed cannot
+        cancel that future, and the runtime instead throws ``CancelledError`` in at the resume point.
+        The future then holds a live resource -- typically a cursor -- that the caller never received,
+        because a raising ``await`` binds nothing, and that no ``__aexit__`` will ever reach, because a
+        failed ``__aenter__`` is not exited. Closing it here is the only thing standing between that
+        window and a leaked cursor for the lifetime of the connection.
+
+        The resource is closed only when it demonstrably exists and is demonstrably unowned:
+
+        * ``done() and not cancelled() and exception() is None`` -- otherwise ``result()`` would raise
+          rather than hand back an object. A pending future has acquired nothing yet, a cancelled one had
+          its acquisition cancelled with it, and a failed one never produced a resource to close.
+        * no other awaiter -- ``_resolve`` may be awaited concurrently, and only the cancelled awaiter
+          fails while the others still resume with the result. Closing a resource another task is about
+          to be handed would trade this leak for a use-after-close, which is worse. ``_obj`` is checked
+          for the same reason, since a concurrent awaiter may already have resumed and taken ownership.
+
+        Closing makes the wrapper spent rather than merely unresolved: ``_resolution`` stays a completed
+        future holding the now-closed object, so ``_discarded`` is set -- before the close is awaited --
+        to stop a later ``_resolve`` from handing that object out as if it were healthy.
+        """
+        if self._awaiting or self._obj is not _UNRESOLVED:
+            return
+        if resolution.done() and not resolution.cancelled() and resolution.exception() is None:
+            self._discarded = True
+            await _close_quietly_async(resolution.result())
 
     def __await__(self) -> Generator[Any, None, _AwaitResultT]:
         return self._resolve().__await__()
@@ -44,7 +152,16 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
         aexit = getattr(type(obj), "__aexit__", None)
         self._aexit = None
         if callable(enter) and callable(aexit):
-            entered_obj = await _await_if_needed(enter(obj))
+            try:
+                entered_obj = await _await_if_needed(enter(obj))
+            except BaseException:
+                # the wrapped object was created by pydapper and is solely owned by it, so a failed
+                # __aenter__ must not leak it: the object exists and still exposes close(). Standard
+                # context-manager semantics -- a manager that fails to enter is not exited -- govern a
+                # manager the caller supplied, which this never is. __aexit__ stays unbound, so the
+                # object is never cleaned up twice, and the close failure loses to the entry error.
+                await _close_quietly_async(obj)
+                raise
             self._aexit = aexit
             return cast(_EnterResultT, entered_obj)
         return cast(_EnterResultT, obj)
@@ -63,7 +180,11 @@ class _AwaitableAsyncContextManager(Generic[_AwaitResultT, _EnterResultT]):
             close = getattr(obj, "close", None)
             if callable(close):
                 await _await_if_needed(close())
-        except BaseException:
+        except Exception as cleanup_error:
             if self._preserve_active_error and exc_type is not None:
+                # only an ordinary exception is discarded here; a BaseException that is not an Exception
+                # (KeyboardInterrupt, SystemExit, asyncio.CancelledError, GeneratorExit) is not caught at
+                # all and propagates past the active error -- see _log_discarded_cleanup_error
+                _log_discarded_cleanup_error(cleanup_error)
                 return False
             raise

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -25,6 +25,8 @@ from typing import cast
 from typing import overload
 
 from ._context import _AwaitableAsyncContextManager
+from ._context import _close_quietly
+from ._context import _log_discarded_cleanup_error
 from ._sql_placeholders import PlaceholderSpan
 from ._sql_placeholders import scan_placeholder_spans
 from .capabilities import AdapterCapability
@@ -372,7 +374,16 @@ class Commands(BaseCommands, ABC):
         exit = getattr(type(cursor), "__exit__", None)
 
         if callable(enter) and callable(exit):
-            entered_cursor = enter(cursor)
+            try:
+                entered_cursor = enter(cursor)
+            except BaseException:
+                # this cursor was created by the line above and is solely command-owned, so a failed
+                # __enter__ must not leak it: the object exists and still exposes close(). Standard
+                # context-manager semantics -- a manager that fails to enter is not exited -- govern a
+                # manager the caller supplied, which this never is. __exit__ is deliberately not called
+                # for a failed entry, and the close failure loses to the entry error.
+                _close_quietly(cursor)
+                raise
             try:
                 yield entered_cursor
             except BaseException:
@@ -381,8 +392,12 @@ class Commands(BaseCommands, ABC):
                 exc_type, exc_val, exc_tb = sys.exc_info()
                 try:
                     exit(cursor, exc_type, exc_val, exc_tb)
-                except BaseException:
-                    pass
+                except Exception as cleanup_error:
+                    # only an ordinary exception is discarded here; a BaseException that is not an
+                    # Exception (KeyboardInterrupt, SystemExit, asyncio.CancelledError, GeneratorExit) is
+                    # not caught at all and propagates past the command error -- see the rationale on
+                    # _log_discarded_cleanup_error
+                    _log_discarded_cleanup_error(cleanup_error)
                 raise
             else:
                 exit(cursor, None, None, None)
@@ -391,12 +406,7 @@ class Commands(BaseCommands, ABC):
         try:
             yield cursor
         except BaseException:
-            try:
-                close = getattr(cursor, "close", None)
-                if callable(close):
-                    close()
-            except BaseException:
-                pass
+            _close_quietly(cursor)
             raise
         else:
             close = getattr(cursor, "close", None)
@@ -1836,6 +1846,20 @@ class CommandsAsync(BaseCommands, ABC):
     async def _on_duplicate_columns_async(self, cursor: "AsyncCursorType") -> None:
         pass
 
+    async def _on_query_single_more_than_one_result_async(self, cursor: "AsyncCursorType") -> None:
+        # async twin of Commands._on_query_single_more_than_one_result, invoked at the same point of
+        # query_single_async. No first-party async adapter needs it, so the default is a no-op, but an
+        # async driver that cannot close a cursor with unread rows buffered (the async counterpart of
+        # mysql-connector-python) needs this drain seam to exist for the exception timing to match sync.
+        #
+        # Deliberate deferral: unlike the _prepare_* hooks, the four _on_* drain seams stay private and
+        # undocumented for now. docs/compatibility.md names only _prepare_cursor/_prepare_command and
+        # their _async twins as the exception to the underscore rule, so promoting the drain seams to a
+        # documented, compatibility-sensitive extension point is a surface decision for the v1 export
+        # and typing audit (#484), not for this lifecycle fix. Until then a third-party adapter may
+        # override them, but their names and signatures are not covered by the compatibility policy.
+        pass
+
     @overload
     async def query_async(
         self,
@@ -2789,6 +2813,7 @@ class CommandsAsync(BaseCommands, ABC):
             if num_records == 0:
                 raise NoResultException("Expected exactly one record, got zero")
             elif num_records > 1:
+                await self._on_query_single_more_than_one_result_async(cursor)
                 raise MoreThanOneResultException("Expected exactly one record, got at least two")
 
             if not maps_raw_row:

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -423,11 +423,17 @@ class Commands(BaseCommands, ABC):
             try:
                 yield
             except BaseException:
-                # the active error wins over a rollback failure (same precedence as _cursor_context_proxy)
+                # the active error wins over a rollback failure (same precedence as
+                # _cursor_context_proxy): only an ordinary Exception is discarded, and it is
+                # recorded rather than dropped silently. A BaseException that is not an
+                # Exception -- KeyboardInterrupt, SystemExit, CancelledError -- is an
+                # interpreter-level request to stop, so it propagates and beats the block's
+                # error, which survives as its implicit __context__. Losing a Ctrl-C raised
+                # inside the driver's rollback is worse than reporting it instead.
                 try:
                     self.rollback()
-                except BaseException:
-                    pass
+                except Exception as rollback_error:
+                    _log_discarded_cleanup_error(rollback_error)
                 raise
             else:
                 self.commit()

--- a/tests/test_adapter_seam_parity.py
+++ b/tests/test_adapter_seam_parity.py
@@ -1,0 +1,100 @@
+"""Structural guard that every adapter-author seam on ``Commands`` has an async twin.
+
+A seam added to one mode and forgotten in the other is invisible to behavior tests: no
+first-party async adapter overrides the missing hook, so nothing fails until a third-party
+async adapter needs it and discovers that async exception timing differs from sync. #541
+requires matching sync/async first/single/scalar timing, so the pairing is asserted
+structurally here -- a new sync seam without an ``_async`` twin, or an async seam with no
+sync original, fails this file even when no behavior test covers it.
+
+The seams are the protected ``_prepare_*`` preparation hooks and the ``_on_*`` drain hooks
+that let an adapter react to an in-flight command error (an unread-result drain, for
+example) before the error propagates and the cursor is cleaned up.
+"""
+
+import inspect
+
+import pytest
+
+from pydapper.command_options import CommandOptions
+from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
+from tests.mocks import MockAsyncCommands
+from tests.mocks import MockCommands
+
+pytestmark = pytest.mark.core
+
+_SEAM_PREFIXES = ("_on_", "_prepare_")
+
+# spelled out rather than derived so that adding or removing a seam is a deliberate edit here
+EXPECTED_SYNC_SEAMS = frozenset(
+    {
+        "_on_duplicate_columns",
+        "_on_query_single_more_than_one_result",
+        "_prepare_command",
+        "_prepare_cursor",
+    }
+)
+
+
+def _seam_names(command_class):
+    return frozenset(
+        name
+        for name in dir(command_class)
+        if name.startswith(_SEAM_PREFIXES) and inspect.isfunction(getattr(command_class, name))
+    )
+
+
+def test_sync_seam_inventory_is_the_expected_set():
+    assert _seam_names(Commands) == EXPECTED_SYNC_SEAMS
+
+
+def test_every_sync_seam_has_an_async_twin_and_no_async_seam_is_orphaned():
+    assert _seam_names(CommandsAsync) == frozenset(f"{name}_async" for name in _seam_names(Commands))
+
+
+def test_sync_seams_are_plain_functions_and_async_seams_are_coroutine_functions():
+    for name in _seam_names(Commands):
+        assert not inspect.iscoroutinefunction(getattr(Commands, name)), name
+    for name in _seam_names(CommandsAsync):
+        assert inspect.iscoroutinefunction(getattr(CommandsAsync, name)), name
+
+
+def test_paired_seams_take_the_same_parameters():
+    for name in _seam_names(Commands):
+        sync_parameters = inspect.signature(getattr(Commands, name)).parameters
+        async_parameters = inspect.signature(getattr(CommandsAsync, f"{name}_async")).parameters
+        assert list(sync_parameters) == list(async_parameters), name
+        assert [parameter.kind for parameter in sync_parameters.values()] == [
+            parameter.kind for parameter in async_parameters.values()
+        ], name
+
+
+def _seam_arguments(parameters):
+    """Build sentinel arguments for a seam from its signature, skipping ``self``.
+
+    Every argument except ``options`` is a bare ``object()``: a default implementation that
+    is not inert would touch it and raise ``AttributeError`` instead of returning ``None``.
+    """
+    positional = []
+    keywords = {}
+    for parameter in list(parameters.values())[1:]:
+        value = CommandOptions() if parameter.name == "options" else object()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+            keywords[parameter.name] = value
+        else:
+            positional.append(value)
+    return positional, keywords
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", sorted(EXPECTED_SYNC_SEAMS))
+async def test_both_modes_default_to_an_inert_no_op(name):
+    # the base implementations must stay inert so an adapter that overrides neither mode gets no
+    # behavior of its own, and the async default of a seam only sync adapters need stays harmless
+    sync_seam = getattr(Commands, name)
+    async_seam = getattr(CommandsAsync, f"{name}_async")
+    positional, keywords = _seam_arguments(inspect.signature(sync_seam).parameters)
+
+    assert sync_seam(MockCommands(object()), *positional, **keywords) is None
+    assert await async_seam(MockAsyncCommands(object()), *positional, **keywords) is None

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -3988,6 +3988,40 @@ class TestCommandsAsync:
         assert connection.exit_calls == 1
 
     @pytest.mark.asyncio
+    async def test_a_cancelled_connect_async_awaiter_leaves_the_commands_object_reachable(self):
+        # connect_async() resolves to a CommandsAsync, which exposes no close(), so the wrapper's
+        # discard policy has nothing it can clean up when the awaiting task is cancelled after
+        # acquisition completed. It must not mark itself spent in that case: handing the live commands
+        # object back is the caller's only remaining route to the open connection.
+        connection = MockAsyncConnection()
+        # a bare future stands in for the pending connect_async() coroutine so the test, not the
+        # scheduler, decides when acquisition completes and when the cancellation lands
+        acquisition = asyncio.get_running_loop().create_future()
+        # mirrors CommandFactory.from_dsn_async, which wraps the connection without preserve_active_error
+        wrapper = _AwaitableAsyncContextManager(acquisition)
+
+        async def consume():
+            return await wrapper
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        acquisition.set_result(MockAsyncCommands(connection))  # acquisition completes...
+        task.cancel()  # ...and only then is its awaiter cancelled
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        commands = await wrapper
+        assert commands.connection is connection
+        assert connection.closed == 0
+
+        async with commands:
+            pass
+        assert connection.closed == 1
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "params, exception_type",
         [

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -5891,6 +5891,32 @@ class TestTransactions:
                 raise error
         assert exc_info.value is error
 
+    def test_an_interrupt_raised_during_rollback_is_not_swallowed(self, connection):
+        """A Ctrl-C landing inside the driver's rollback must not be lost.
+
+        Only an ordinary ``Exception`` from rollback loses to the block's error. A
+        ``BaseException`` that is not an ``Exception`` is an interpreter-level request to
+        stop, so it propagates and beats the block's error, which survives as its
+        implicit ``__context__``.
+        """
+
+        class RollbackInterruptedCommands(MockCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        commands = RollbackInterruptedCommands(connection)
+
+        def _interrupted_rollback():
+            # raised here rather than thrown into a generator, so implicit chaining records
+            # the block's error as this interrupt's __context__ the way a real driver would
+            raise KeyboardInterrupt("ctrl-c during rollback")
+
+        connection.rollback = _interrupted_rollback
+        block_error = _TransactionBlockError("boom")
+        with pytest.raises(KeyboardInterrupt) as exc_info:
+            with commands.transaction():
+                raise block_error
+        assert exc_info.value.__context__ is block_error, "the block's error must survive as __context__"
+
     def test_commit_failure_on_clean_exit_propagates_without_rollback(self, commands, connection):
         commit_error = RuntimeError("commit boom")
         connection.commit = lambda: (_ for _ in ()).throw(commit_error)

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from collections import UserDict
 from dataclasses import FrozenInstanceError
 from dataclasses import asdict
@@ -29,6 +31,16 @@ from tests.mocks import MockCursor
 from tests.mocks import MockParamHandler
 
 pytestmark = pytest.mark.core
+
+
+def _debug_records(caplog):
+    return [record for record in caplog.records if record.levelno == logging.DEBUG]
+
+
+# a cleanup failure that is a BaseException but not an Exception is never discarded by the shared
+# cursor lifecycle: KeyboardInterrupt/SystemExit are interpreter-level requests to stop and
+# CancelledError/GeneratorExit are the runtime unwinding the command on purpose
+_NON_EXCEPTION_CLEANUP_FAILURES = [KeyboardInterrupt, SystemExit, asyncio.CancelledError, GeneratorExit]
 
 
 class FalsyRow(tuple):
@@ -1365,6 +1377,125 @@ class TestCommands:
             with MockCommands(_CursorConnection(FailingExitCursor()))._cursor_context_proxy():
                 raise ValueError("query failed")
 
+    def test_cursor_context_proxy_closes_the_cursor_when_entry_fails(self):
+        class FailingEnterCursor:
+            def __init__(self):
+                self.close_calls = 0
+                self.exit_calls = 0
+
+            def __enter__(self):
+                raise RuntimeError("entry failed")
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+
+            def close(self):
+                self.close_calls += 1
+
+        cursor = FailingEnterCursor()
+
+        with pytest.raises(RuntimeError, match="entry failed"):
+            with MockCommands(_CursorConnection(cursor))._cursor_context_proxy():
+                raise AssertionError("the body must not run")
+
+        # the command created and solely owns this cursor, so a failed __enter__ closes it exactly
+        # once instead of leaking it, and never exits a cursor that never entered
+        assert cursor.close_calls == 1
+        assert cursor.exit_calls == 0
+
+    def test_cursor_context_proxy_entry_error_survives_a_failing_close(self, caplog):
+        entry_error = RuntimeError("entry failed")
+
+        class FailingEnterAndCloseCursor:
+            def __enter__(self):
+                raise entry_error
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                raise AssertionError("__exit__ must not run for a cursor that never entered")
+
+            def close(self):
+                raise ValueError("close failed")
+
+        with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+            with pytest.raises(RuntimeError) as exc_info:
+                with MockCommands(_CursorConnection(FailingEnterAndCloseCursor()))._cursor_context_proxy():
+                    raise AssertionError("the body must not run")
+
+        assert exc_info.value is entry_error
+        assert [record.getMessage() for record in _debug_records(caplog)] == [
+            "Discarding ValueError raised while cleaning up a pydapper-owned resource"
+        ]
+
+    def test_cursor_context_proxy_entry_failure_without_close_propagates(self):
+        class FailingEnterCursorWithoutClose:
+            def __enter__(self):
+                raise RuntimeError("entry failed")
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                raise AssertionError("__exit__ must not run for a cursor that never entered")
+
+        with pytest.raises(RuntimeError, match="entry failed"):
+            with MockCommands(_CursorConnection(FailingEnterCursorWithoutClose()))._cursor_context_proxy():
+                raise AssertionError("the body must not run")
+
+    @pytest.mark.parametrize("base_error", _NON_EXCEPTION_CLEANUP_FAILURES)
+    def test_cursor_exit_non_exception_during_cleanup_beats_the_command_error(self, base_error):
+        command_error = ValueError("query failed")
+
+        class InterruptingExitCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                raise base_error()
+
+        with pytest.raises(base_error) as exc_info:
+            with MockCommands(_CursorConnection(InterruptingExitCursor()))._cursor_context_proxy():
+                raise command_error
+
+        # a BaseException that is not an Exception is never a resource problem, so it is never
+        # discarded; the command error survives as its implicit context
+        assert exc_info.value.__context__ is command_error
+
+    @pytest.mark.parametrize("base_error", _NON_EXCEPTION_CLEANUP_FAILURES)
+    def test_plain_cursor_close_non_exception_during_cleanup_beats_the_command_error(self, base_error):
+        command_error = ValueError("query failed")
+        cursor = _PlainQueryCursor()
+        cursor.close_error = base_error()
+
+        with pytest.raises(base_error) as exc_info:
+            with MockCommands(_CursorConnection(cursor))._cursor_context_proxy():
+                raise command_error
+
+        assert exc_info.value.__context__ is command_error
+        assert cursor.close_calls == 1
+
+    def test_discarded_cursor_exit_error_is_recorded_at_debug(self, caplog):
+        command_error = ValueError("query failed")
+        cleanup_error = RuntimeError("cleanup failed")
+
+        class FailingExitCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                raise cleanup_error
+
+        with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+            with pytest.raises(ValueError) as exc_info:
+                with MockCommands(_CursorConnection(FailingExitCursor()))._cursor_context_proxy():
+                    raise command_error
+
+        # the command error is re-raised as the same object and is never chained to the cleanup
+        # failure, so the debug record is the only place the discarded error survives
+        assert exc_info.value is command_error
+        assert exc_info.value.__context__ is None
+        records = _debug_records(caplog)
+        assert [record.getMessage() for record in records] == [
+            "Discarding RuntimeError raised while cleaning up a pydapper-owned resource"
+        ]
+        assert records[0].exc_info[1] is cleanup_error
+
     def test_execute_error_wins_over_native_cursor_exit_error(self):
         command_error = ValueError("execute failed")
 
@@ -2267,10 +2398,15 @@ class TestCommands:
 
     def test_cursor_context_error_is_not_mistaken_for_plain_cursor(self):
         class FailingContextCursor(_PlainQueryCursor):
+            def __init__(self):
+                super().__init__()
+                self.exit_calls = 0
+
             def __enter__(self):
                 raise AttributeError("query context failed")
 
             def __exit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
                 self.close()
 
         cursor = FailingContextCursor()
@@ -2278,7 +2414,11 @@ class TestCommands:
         with pytest.raises(AttributeError, match="query context failed"):
             MockCommands(_CursorConnection(cursor)).query("select id, name from some_table")
 
-        assert cursor.close_calls == 0
+        # the entry failure propagates instead of falling through to the plain-cursor branch, so the
+        # command body never runs and __exit__ is never called for a cursor that never entered; the
+        # command-owned cursor is still closed exactly once by the best-effort entry cleanup
+        assert cursor.exit_calls == 0
+        assert cursor.close_calls == 1
 
     def test_query_rejects_model_and_mapper(self, connection):
         with MockCommands(connection) as commands:
@@ -5154,6 +5294,142 @@ class TestCommandsAsync:
         assert cursor.enter_calls == 1
         assert cursor.exit_calls == 1
         assert cursor.fetchmany_calls == [2]
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_calls_more_than_one_hook_before_raising(self):
+        # async twin of TestCommands.test_query_single_calls_more_than_one_hook_before_raising: an
+        # async adapter that must drain unread rows gets the same drain seam, at the same point
+        calls = []
+
+        class HookedAsyncCommands(MockAsyncCommands):
+            async def _on_query_single_more_than_one_result_async(self, cursor):
+                calls.append(cursor)
+
+        connection = _AsyncQuerySingleConnection(_AsyncQuerySingleFetchOneCursor([(1, "Zach"), (2, "Bob")]))
+
+        with pytest.raises(MoreThanOneResultException):
+            await HookedAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert calls == [connection.cursor_instance]
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_more_than_one_hook_runs_before_the_cursor_exits(self):
+        calls = []
+
+        class RecordingExitAsyncCursor(_AsyncQuerySingleFetchOneCursor):
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                calls.append("exit")
+
+        class HookedAsyncCommands(MockAsyncCommands):
+            async def _on_query_single_more_than_one_result_async(self, cursor):
+                calls.append("drain")
+
+        connection = _AsyncQuerySingleConnection(RecordingExitAsyncCursor([(1, "Zach"), (2, "Bob")]))
+
+        with pytest.raises(MoreThanOneResultException):
+            await HookedAsyncCommands(connection).query_single_async("select * from some_table")
+
+        assert calls == ["drain", "exit"]
+
+    @pytest.mark.asyncio
+    async def test_query_single_async_more_than_one_hook_is_not_called_for_other_outcomes(self):
+        calls = []
+
+        class HookedAsyncCommands(MockAsyncCommands):
+            async def _on_query_single_more_than_one_result_async(self, cursor):
+                calls.append(cursor)
+
+        connection = _AsyncQuerySingleConnection(_AsyncQuerySingleFetchOneCursor([]))
+
+        with pytest.raises(NoResultException):
+            await HookedAsyncCommands(connection).query_single_async("select * from some_table")
+
+        record = await HookedAsyncCommands(
+            _AsyncQuerySingleConnection(_AsyncQuerySingleFetchOneCursor([(1, "Zach")]))
+        ).query_single_async("select * from some_table")
+
+        assert record == {"id": 1, "name": "Zach"}
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_async_cursor_entry_failure_closes_the_command_owned_cursor(self):
+        class FailingEnterAsyncCursor:
+            def __init__(self):
+                self.close_calls = 0
+                self.exit_calls = 0
+
+            async def __aenter__(self):
+                raise RuntimeError("entry failed")
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                self.exit_calls += 1
+
+            async def close(self):
+                self.close_calls += 1
+
+        cursor = FailingEnterAsyncCursor()
+
+        with pytest.raises(RuntimeError, match="entry failed"):
+            await MockAsyncCommands(_PlainAsyncQueryConnection(cursor)).query_async("select id, name from some_table")
+
+        assert cursor.close_calls == 1
+        assert cursor.exit_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_async_cursor_entry_error_survives_a_failing_close(self, caplog):
+        entry_error = RuntimeError("entry failed")
+
+        class FailingEnterAndCloseAsyncCursor:
+            async def __aenter__(self):
+                raise entry_error
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                raise AssertionError("__aexit__ must not run for a cursor that never entered")
+
+            async def close(self):
+                raise ValueError("close failed")
+
+        with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+            with pytest.raises(RuntimeError) as exc_info:
+                await MockAsyncCommands(_PlainAsyncQueryConnection(FailingEnterAndCloseAsyncCursor())).execute_async(
+                    "insert into some_table values (1)"
+                )
+
+        assert exc_info.value is entry_error
+        assert [record.getMessage() for record in _debug_records(caplog)] == [
+            "Discarding ValueError raised while cleaning up a pydapper-owned resource"
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("base_error", _NON_EXCEPTION_CLEANUP_FAILURES)
+    async def test_async_cursor_exit_non_exception_during_cleanup_beats_the_command_error(self, base_error):
+        command_error = ValueError("mapper failed")
+
+        class InterruptingExitAsyncCursor:
+            rowcount = 0
+            description = ("id", "int"), ("name", "text")
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                raise base_error()
+
+            async def execute(self, sql, parameters=None):
+                pass
+
+            async def fetchall(self):
+                return ((1, "Zach"),)
+
+        def mapper(row):
+            raise command_error
+
+        with pytest.raises(base_error) as exc_info:
+            await MockAsyncCommands(_PlainAsyncQueryConnection(InterruptingExitAsyncCursor())).query_async(
+                "select id, name from some_table", mapper=mapper
+            )
+
+        assert exc_info.value.__context__ is command_error
 
     @pytest.mark.asyncio
     async def test_query_single_or_default(self, connection, set_fetchone_to_return_none):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,10 +1,15 @@
 import asyncio
+import logging
 
 import pytest
 
 from pydapper._context import _AwaitableAsyncContextManager
 
 pytestmark = pytest.mark.core
+
+
+def debug_records(caplog):
+    return [record for record in caplog.records if record.levelno == logging.DEBUG]
 
 
 class ContextObject:
@@ -273,3 +278,275 @@ async def test_context_entry_failure_is_not_swallowed():
     with pytest.raises(RuntimeError, match="entry"):
         async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=FailingEntry())):
             pass
+
+
+class FailingEntryObject:
+    """A pydapper-owned resource whose ``__aenter__`` fails after the object already exists."""
+
+    def __init__(self, close_error=None, awaitable_close=False):
+        self.close_calls = 0
+        self.exit_calls = 0
+        self.close_error = close_error
+        self.awaitable_close = awaitable_close
+
+    async def __aenter__(self):
+        raise RuntimeError("entry")
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.exit_calls += 1
+
+    def close(self):
+        self.close_calls += 1
+        if self.close_error:
+            raise self.close_error
+        return asyncio.sleep(0) if self.awaitable_close else None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("awaitable_close", [False, True])
+@pytest.mark.parametrize("preserve", [False, True])
+async def test_entry_failure_closes_the_owned_object_without_exiting_it(awaitable_close, preserve):
+    # pydapper created the wrapped object, so a failed __aenter__ may not leak it; __aexit__ stays
+    # unbound for an object that never entered, so it is cleaned up exactly once
+    obj = FailingEntryObject(awaitable_close=awaitable_close)
+
+    with pytest.raises(RuntimeError, match="entry"):
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=preserve):
+            raise AssertionError("body must not run")
+
+    assert obj.close_calls == 1
+    assert obj.exit_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_entry_failure_survives_a_failing_close(caplog):
+    obj = FailingEntryObject(close_error=ValueError("close failed"))
+
+    with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+        with pytest.raises(RuntimeError, match="entry"):
+            async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True):
+                raise AssertionError("body must not run")
+
+    assert obj.close_calls == 1
+    records = debug_records(caplog)
+    assert [record.getMessage() for record in records] == [
+        "Discarding ValueError raised while cleaning up a pydapper-owned resource"
+    ]
+    assert records[0].exc_info[1] is obj.close_error
+
+
+@pytest.mark.asyncio
+async def test_entry_failure_of_an_object_without_close_is_a_no_op():
+    class FailingEntryWithoutClose:
+        async def __aenter__(self):
+            raise RuntimeError("entry")
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            raise AssertionError("exit should not run")
+
+    with pytest.raises(RuntimeError, match="entry"):
+        async with _AwaitableAsyncContextManager(
+            asyncio.sleep(0, result=FailingEntryWithoutClose()), preserve_active_error=True
+        ):
+            raise AssertionError("body must not run")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("base_error", [KeyboardInterrupt, SystemExit, asyncio.CancelledError, GeneratorExit])
+@pytest.mark.parametrize("native_aexit", [False, True])
+async def test_non_exception_cleanup_failure_is_never_discarded(base_error, native_aexit):
+    # a BaseException that is not an Exception is not a resource problem: KeyboardInterrupt/SystemExit
+    # are interpreter-level requests to stop and CancelledError/GeneratorExit are the runtime unwinding
+    # this code on purpose. Swallowing a Ctrl-C loses it forever and swallowing a CancelledError breaks
+    # asyncio.timeout and task cancellation, so all four outrank the active command error, which is not
+    # lost either -- it survives as the propagating exception's __context__.
+    body_error = ValueError("body")
+    obj = ContextObject(exit_error=base_error()) if native_aexit else PlainObject(close_error=base_error())
+
+    with pytest.raises(base_error) as exc_info:
+        async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True):
+            raise body_error
+
+    assert exc_info.value.__context__ is body_error
+
+
+async def acquire_via(wrapper, path):
+    """Consume ``wrapper`` through the path under test; both routes resolve through ``_resolve``."""
+    if path == "await":
+        return await wrapper
+    async with wrapper as entered:
+        return entered
+
+
+async def parked_on_acquisition(wrapper, path="await"):
+    """Start consuming ``wrapper`` and return with the task parked on the pending acquisition.
+
+    Driving acquisition through a future the test completes itself is what makes the
+    cancel-after-acquisition window deterministic: the task provably suspends on a pending future
+    here, so the test -- not the scheduler -- decides when acquisition finishes and when the cancel
+    lands. Nothing depends on how many event loop ticks a given Python version needs.
+    """
+    task = asyncio.create_task(acquire_via(wrapper, path))
+    await asyncio.sleep(0)
+    assert not task.done()
+    return task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["await", "async with"])
+async def test_cancel_after_acquisition_completes_closes_the_abandoned_object(path):
+    # acquisition runs as an independent future, so cancelling the awaiting task once that future has
+    # already completed cannot cancel the acquisition: asyncio cannot cancel a completed future and
+    # throws CancelledError in at the resume point instead. The object is therefore fully created and
+    # nothing else refers to it -- the raising await binds nothing in the caller and a failed __aenter__
+    # is never exited -- so without a best-effort close it leaks for the life of the connection.
+    # __await__ shares _resolve with __aenter__, so both paths are exposed and both are covered here.
+    obj = PlainObject()
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper, path)
+
+    acquisition.set_result(obj)  # acquisition completes...
+    task.cancel()  # ...and only then is its awaiter cancelled
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # the cancellation still wins, and the object it stranded is closed exactly once
+    assert acquisition.result() is obj
+    assert obj.closed == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["await", "async with"])
+async def test_a_discarded_wrapper_never_hands_the_closed_object_out_again(path):
+    # the resolution future still holds the closed object, so the wrapper has to refuse to resolve
+    # again rather than serve a closed cursor to the next caller
+    obj = PlainObject()
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper)
+
+    acquisition.set_result(obj)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert obj.closed == 1
+
+    with pytest.raises(RuntimeError, match="spent and cannot resolve again"):
+        await acquire_via(wrapper, path)
+    assert obj.closed == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_first", [True, False])
+async def test_a_cancelled_awaiter_leaves_a_concurrently_awaited_object_alone(cancel_first):
+    # _resolve may be awaited concurrently and only the cancelled awaiter fails, so closing on cancel
+    # would trade the leak for a use-after-close. Both resume orders are covered: cancelling the first
+    # awaiter leaves the second still pending, and cancelling the second means the first has already
+    # resumed and taken ownership.
+    obj = PlainObject()
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition)
+    first = asyncio.create_task(acquire_via(wrapper, "await"))
+    second = asyncio.create_task(acquire_via(wrapper, "await"))
+    await asyncio.sleep(0)
+    assert not first.done() and not second.done()
+
+    acquisition.set_result(obj)
+    cancelled, survivor = (first, second) if cancel_first else (second, first)
+    cancelled.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+    assert await survivor is obj
+    assert obj.closed == 0
+    assert await wrapper is obj
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_acquisition_completes_cancels_the_acquisition_itself():
+    # nothing was acquired, so there is nothing to close and the wrapper is not spent; the cancelled
+    # acquisition future keeps reporting the cancellation to any later caller
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert acquisition.cancelled()
+    with pytest.raises(asyncio.CancelledError):
+        await wrapper
+
+
+@pytest.mark.asyncio
+async def test_discarding_an_abandoned_object_awaits_an_awaitable_close():
+    closed = False
+
+    async def close():
+        nonlocal closed
+        await asyncio.sleep(0)
+        closed = True
+
+    obj = PlainObject(close_result=close())
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper)
+
+    acquisition.set_result(obj)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # the cancellation was already delivered, so a close that suspends still runs to completion before
+    # the CancelledError is re-raised
+    assert obj.closed == 1
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_discarding_an_abandoned_object_survives_a_failing_close(caplog):
+    close_error = ValueError("close failed")
+    obj = PlainObject(close_error=close_error)
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper)
+
+    acquisition.set_result(obj)
+    task.cancel()
+    with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # cleanup goes through the shared discard policy, so a failing close loses to the cancellation and
+    # is recorded at DEBUG instead of vanishing
+    assert obj.closed == 1
+    records = debug_records(caplog)
+    assert [record.getMessage() for record in records] == [
+        "Discarding ValueError raised while cleaning up a pydapper-owned resource"
+    ]
+    assert records[0].exc_info[1] is close_error
+
+
+@pytest.mark.asyncio
+async def test_discarded_cleanup_error_is_recorded_at_debug(caplog):
+    body_error = ValueError("body")
+    cleanup_error = RuntimeError("cleanup")
+    obj = ContextObject(exit_error=cleanup_error)
+
+    with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+        with pytest.raises(ValueError) as exc_info:
+            async with _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True):
+                raise body_error
+
+    # the command error is re-raised as the same object, so the cleanup failure is neither chained
+    # onto it nor raised; the debug record is the only place it survives
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is None
+    records = debug_records(caplog)
+    assert [record.getMessage() for record in records] == [
+        "Discarding RuntimeError raised while cleaning up a pydapper-owned resource"
+    ]
+    assert records[0].exc_info[1] is cleanup_error

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -344,11 +344,35 @@ async def test_entry_failure_of_an_object_without_close_is_a_no_op():
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             raise AssertionError("exit should not run")
 
+    obj = FailingEntryWithoutClose()
+    wrapper = _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True)
+
     with pytest.raises(RuntimeError, match="entry"):
-        async with _AwaitableAsyncContextManager(
-            asyncio.sleep(0, result=FailingEntryWithoutClose()), preserve_active_error=True
-        ):
+        async with wrapper:
             raise AssertionError("body must not run")
+
+    # nothing was closed, so the wrapper is not spent: it still hands the live object back
+    assert await wrapper is obj
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["await", "async with"])
+async def test_entry_failure_spends_the_wrapper_it_closed(path):
+    # a failed __aenter__ strands an acquired object exactly as a cancelled awaiter does, so both
+    # discard paths take the same policy: the object is closed once and the wrapper never hands the
+    # closed object to the next caller
+    obj = FailingEntryObject()
+    wrapper = _AwaitableAsyncContextManager(asyncio.sleep(0, result=obj), preserve_active_error=True)
+
+    with pytest.raises(RuntimeError, match="entry"):
+        async with wrapper:
+            raise AssertionError("body must not run")
+
+    with pytest.raises(RuntimeError, match="spent and cannot resolve again"):
+        await acquire_via(wrapper, path)
+
+    assert obj.close_calls == 1
+    assert obj.exit_calls == 0
 
 
 @pytest.mark.asyncio
@@ -436,6 +460,85 @@ async def test_a_discarded_wrapper_never_hands_the_closed_object_out_again(path)
     with pytest.raises(RuntimeError, match="spent and cannot resolve again"):
         await acquire_via(wrapper, path)
     assert obj.closed == 1
+
+
+class CloselessObject:
+    """The ``connect_async()`` shape: an owned resource pydapper has no way to close.
+
+    ``CommandsAsync`` exposes ``__aenter__``/``__aexit__`` and no ``close()``, so the discard policy
+    cannot clean it up at all.
+    """
+
+    def __init__(self):
+        self.enter_calls = 0
+        self.exit_calls = 0
+
+    async def __aenter__(self):
+        self.enter_calls += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.exit_calls += 1
+        return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["await", "async with"])
+async def test_a_stranded_object_that_cannot_be_closed_stays_reachable(path):
+    # the discard closed nothing here, so marking the wrapper spent would strand a still-open resource
+    # behind a RuntimeError claiming it was closed -- permanently unreachable instead of merely leaked,
+    # which is worse than the leak the discard exists to prevent. Handing the live object back is the
+    # caller's only remaining route to it.
+    obj = CloselessObject()
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition)
+    task = await parked_on_acquisition(wrapper, path)
+
+    acquisition.set_result(obj)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert await wrapper is obj
+    async with wrapper as entered:
+        assert entered is obj
+    assert obj.enter_calls == 1
+    assert obj.exit_calls == 1
+
+
+class RaisingCloseAttributeObject:
+    """A resource whose ``close`` attribute access itself fails."""
+
+    def __init__(self, error):
+        self.error = error
+
+    @property
+    def close(self):
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_a_close_attribute_that_raises_closes_nothing_and_leaves_the_wrapper_usable(caplog):
+    error = ValueError("close attribute failed")
+    obj = RaisingCloseAttributeObject(error)
+    acquisition = asyncio.get_running_loop().create_future()
+    wrapper = _AwaitableAsyncContextManager(acquisition, preserve_active_error=True)
+    task = await parked_on_acquisition(wrapper)
+
+    acquisition.set_result(obj)
+    task.cancel()
+    with caplog.at_level(logging.DEBUG, logger="pydapper._context"):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # failing to even resolve close() is a cleanup failure like any other: it loses to the cancellation
+    # and is recorded at DEBUG. Nothing was closed, so the wrapper is not spent.
+    records = debug_records(caplog)
+    assert [record.getMessage() for record in records] == [
+        "Discarding ValueError raised while cleaning up a pydapper-owned resource"
+    ]
+    assert records[0].exc_info[1] is error
+    assert await wrapper is obj
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -260,6 +260,52 @@ def test_duplicate_registration_is_rejected_without_mutating_the_original(adapte
     assert adapter_registry["duplicate"] is original_registration
 
 
+@pytest.mark.parametrize(
+    ("registered_kwargs", "second_kwargs", "absent_attribute", "factory", "connection_class", "mode"),
+    [
+        pytest.param(
+            {"commands": MockCommands},
+            {"async_commands": MockAsyncCommands},
+            "async_commands",
+            pydapper.using_async,
+            MockAsyncConnection,
+            "async",
+            id="sync-only-then-async-only",
+        ),
+        pytest.param(
+            {"async_commands": MockAsyncCommands},
+            {"commands": MockCommands},
+            "commands",
+            pydapper.using,
+            MockConnection,
+            "sync",
+            id="async-only-then-sync-only",
+        ),
+    ],
+)
+def test_duplicate_registration_never_merges_the_missing_mode(
+    adapter_registry, registered_kwargs, second_kwargs, absent_attribute, factory, connection_class, mode
+):
+    # registration is one-way: a duplicate name may never overwrite *or merge*. Re-registering the
+    # same name supplying only the mode the record lacks is still a duplicate, not a helpful
+    # completion of a half-registered adapter, so the absent mode must stay absent afterwards.
+    pydapper.register_adapter("half-registered", using_connection_predicate=never_matches, **registered_kwargs)
+    original_registration = adapter_registry["half-registered"]
+    before = adapter_registry.copy()
+    assert getattr(original_registration, absent_attribute) is None
+
+    with pytest.raises(ValueError, match="already registered"):
+        pydapper.register_adapter("half-registered", using_connection_predicate=never_matches, **second_kwargs)
+
+    assert adapter_registry == before
+    assert adapter_registry["half-registered"] is original_registration
+    assert getattr(adapter_registry["half-registered"], absent_attribute) is None
+
+    # and the rejected mode is still unreachable through the public API, not silently usable
+    with pytest.raises(ValueError, match=f"does not support {mode} mode"):
+        factory(connection_class(), adapter="half-registered")
+
+
 def test_duplicate_name_is_rejected_before_validating_a_second_payload(adapter_registry):
     pydapper.register_adapter("duplicate", commands=MockCommands, using_connection_predicate=never_matches)
 


### PR DESCRIPTION
Found by an audit of the completed **v1 M2** milestone. Four minor audit items, plus a resource leak discovered while reviewing them.

Every one of these sits on the **third-party adapter-author surface** — which the audit found was M2's least-verified area, despite the milestone being named "Adapter protocol and discovery".

## 1. Registration merge guard (#466)

#466 required a test that duplicate adapter names *"never overwrite **or merge**"*. Only the overwrite half was covered — no test registered a name sync-only and then attempted async-only.

**Why it mattered:** a mutant that "helpfully" filled in the missing mode on re-registration passed all 408 adapter tests *and* the entire 1392-test core suite. Behavior was correct; nothing guarded it. Adds regression tests for both directions, verified to kill that mutant.

## 2. Sync/async drain-seam parity (#541)

Sync exposed `_on_query_single_more_than_one_result` (overridden by MySQL to drain unread results); async had **no counterpart**, so a third-party async driver needing the drain had no seam. #541 required "sync and async ... matching exception timing".

Adds the async seam plus a **structural parity test**, so this class of bug cannot recur.

## 3. Cleanup-failure discard policy (#541)

A bare `except BaseException: pass` swallowed a `KeyboardInterrupt`/`SystemExit` raised *during* cursor cleanup — **a lost Ctrl-C**.

Narrowed to `except Exception`, so an interrupt propagates and beats the active command error (which survives as its implicit `__context__`). Ordinary cleanup failures are still discarded — the spec requires the command error be re-raised as *the same object*, so chaining isn't available — but are now logged at DEBUG with traceback instead of vanishing.

The success path stays unprotected **on purpose**: there, a broken `close()` is the only signal and must surface (e.g. mysql-connector's `InternalError: Unread result found`).

## 4. Best-effort close when entry fails (#541)

`enter(cursor)` was evaluated outside the `try`, so a native `__enter__` that raised leaked the cursor.

PEP 343's "no `__exit__` if `__enter__` raises" allocates responsibility to whoever *acquired* the resource — that rule governs a manager the **caller** supplied. Here pydapper called `connection.cursor()` itself one line earlier and solely owns it, so it now closes best-effort without letting the close error replace the entry error. Sync and async. (Precedent: CPython's own `_pyio.open()` and `socket.create_connection` do exactly this.)

## 5. Acquisition/cancellation leak — new, not previously known

If the awaiting task was cancelled **after** the inner acquisition future completed but **before** the `await` resumed, the completed future held a live cursor nothing would ever close. Reproduced deterministically.

The cancelled awaiter now closes the abandoned object best-effort before re-raising — **but only if it is the last awaiter out.** `_resolve` supports concurrent awaiters, and closing unconditionally would hand a closed cursor to a live sibling task, trading a leak for a use-after-close. Both resume orders are tested. The wrapper then poisons itself so a discarded resource can never be served again. Cancellation is never suppressed.

The regression test forces the exact race deterministically (park the consumer on a pending future, resolve it, then cancel) rather than depending on a magic number of `sleep(0)` calls.

## Known remaining gap

`connect_async()` still leaks its connection on the same race, because `CommandsAsync` exposes no `close()`. Giving it a cleanup entry point is a compatibility-sensitive API decision and belongs in its own issue — flagging rather than smuggling it in here.

## Verification

Full suite with all seven backends live: **1664 passed, 100% coverage** (0 missed lines, 0 partial branches). `pytest -m postgresql` (91 passed), `mypy pydapper`, `mypy tests/type_tests.py`, `black --check`, `isort --check`, `mkdocs build --strict` — all clean.

## Notes

- No public API change; no dependencies; `poetry.lock` untouched.
- Touches `docs/release_notes.md`, so expect a trivial conflict with the sibling audit PRs (#574, #575) depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)