### PR TITLE
feat: add async commit, rollback, and transaction APIs

### DIFF
--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -45,8 +45,8 @@ inferred from return values).
 
 Optional behaviors are independent profiles keyed to `pydapper.AdapterCapability` members — there is no linear
 "better adapter" tier, and no adapter is required to support any optional capability. The production catalog is
-returned by `capability_profiles()` and currently ships one profile: `transactions`, covering the sync
-[transaction APIs](transactions.md). The runners automatically append the profile cases for every capability the
+returned by `capability_profiles()` and currently ships one profile: `transactions`, covering the
+[transaction APIs](transactions.md) in both modes. The runners automatically append the profile cases for every capability the
 command class under test declares, so a declaring adapter is exercised against its capability profiles in the
 same `run_core_sync()` / `run_core_async()` call as the core inventory — there is no separate capability runner
 to invoke. The framework enforces honesty in both directions:
@@ -66,11 +66,11 @@ feature must fail loudly rather than silently execute as if supported.
 
 ### The `transactions` profile
 
-Nine sync cases pin the sync `commit()` / `rollback()` / `transaction()` contract for every declaring adapter.
+Nine cases per mode pin the `commit()` / `rollback()` / `transaction()` contract for every declaring adapter —
+the sync and async inventories share the same case ids, order, and kinds, so both modes are held to one
+contract (the async cases exercise `async with commands.transaction():` and the awaited coroutine twins).
 Every live case first commits the harness baseline (`create_commands()` then `commit()`), so scenarios start
-from a durable, transaction-free state even when a harness seeds inside an open transaction. The profile has no
-async cases yet — the async transaction APIs are a separate feature — so an async command class may not declare
-`TRANSACTIONS` until they land.
+from a durable, transaction-free state even when a harness seeds inside an open transaction.
 
 | Case id | Kind | Pins |
 |---|---|---|
@@ -310,8 +310,8 @@ service or emulator is available.
 | `sqlite3` | `Sqlite3Commands` | sync | `transactions` | `tests/test_sqlite/test_conformance.py` | live, service-free (runs in the core and sqlite suites) | [SQLite](database_support/sqlite.md) |
 | `psycopg2` | `Psycopg2Commands` | sync | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
 | `psycopg` | `Psycopg3Commands` | sync | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
-| `psycopg` | `Psycopg3CommandsAsync` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage (including its synchronous cursor-factory normalization); live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
-| `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute`; its connection-level commit/rollback raise, so `transactions` is not declared (the async transaction APIs are a separate feature) |
+| `psycopg` | `Psycopg3CommandsAsync` | async | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage (including its synchronous cursor-factory normalization); live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md) |
+| `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute`; its connection-level commit/rollback raise, so `transactions` is not declared even though the async APIs exist |
 | `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes |
 | `pymssql` | `PymssqlCommands` | sync | `transactions` | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md) |
 | `oracledb` | `OracledbCommands` | sync | `transactions` | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`) |

--- a/docs/adapter_registration.md
+++ b/docs/adapter_registration.md
@@ -260,10 +260,10 @@ unrelated objects are all invalid. Arbitrary strings are not an extension mechan
 the enum by pydapper when the corresponding feature ships.
 
 Declare a capability only when the command class actually implements and tests the behavior. Native driver
-potential is not sufficient. The first implemented capability is `TRANSACTIONS` — the sync
-[transaction APIs](transactions.md) — declared by every first-party sync adapter except BigQuery, whose DBAPI
-cannot support it. The feature tickets that implement the remaining optional behaviors (async transactions,
-timeouts, and so on) own enabling their flags.
+potential is not sufficient. The first implemented capability is `TRANSACTIONS` — the
+[transaction APIs](transactions.md) in both modes — declared by every first-party adapter except BigQuery,
+whose DBAPI cannot support it, and aiopg, which is autocommit-only. The feature tickets that implement the
+remaining optional behaviors (timeouts, list expansion, and so on) own enabling their flags.
 
 Users inspect a selected command object with `supports()`:
 
@@ -285,7 +285,7 @@ registrations.
 | `sqlite3` | `Sqlite3Commands` | sync | `transactions` |
 | `psycopg2` | `Psycopg2Commands` | sync | `transactions` |
 | `psycopg` | `Psycopg3Commands` | sync | `transactions` |
-| `psycopg` | `Psycopg3CommandsAsync` | async | *(empty)* |
+| `psycopg` | `Psycopg3CommandsAsync` | async | `transactions` |
 | `aiopg` | `AiopgCommands` | async | *(empty)* |
 | `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` |
 | `pymssql` | `PymssqlCommands` | sync | `transactions` |
@@ -294,8 +294,8 @@ registrations.
 
 Empty sets are honest: they mean the class does not implement the optional capability, not necessarily that the
 underlying database lacks the feature. `GoogleBigqueryClientCommands` stays empty because the BigQuery DBAPI's
-`commit()` is a no-op and it has no `rollback()` at all; the async classes stay empty because the async
-transaction APIs have not landed yet.
+`commit()` is a no-op and it has no `rollback()` at all; `AiopgCommands` stays empty because aiopg always runs
+in autocommit mode and its connection-level `commit()`/`rollback()` raise.
 
 Adapters prove these contracts — the mandatory per-mode core behavior and, once implemented, each declared
 capability — with the reusable conformance suite; see [Adapter conformance](adapter_conformance.md).

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,20 @@
 ## Latest Changes
 
+* v1: `CommandsAsync` now exposes the async transaction APIs — `commit()`, `rollback()`, and a
+  `transaction()` async context manager — with semantics identical to the sync APIs: commit on clean exit;
+  rollback then re-raise on any exception (including `KeyboardInterrupt`) with the block's error winning over
+  an ordinary rollback failure (a `BaseException` such as a task cancellation raised during the rollback is
+  never swallowed and propagates in its place); a failed exit commit propagates unchanged with no rollback
+  attempt; no SQL on enter; and
+  `RuntimeError` on nested blocks on the same instance. The methods are deliberately unsuffixed — the class is
+  async-only, so an `_async` suffix would be redundant — and all three are gated behind
+  `AdapterCapability.TRANSACTIONS`, raising `UnsupportedFeatureError` for adapters that do not declare it.
+  `Psycopg3CommandsAsync` declares the capability; `AiopgCommands` does not, because aiopg always runs in
+  autocommit mode and its connection-level `commit()`/`rollback()` raise. The `transactions` conformance
+  profile now ships nine async cases mirroring the sync inventory case-for-case, the runners exercise every
+  declaring async adapter automatically, and the repository's fake async driver gained snapshot
+  transactionality so the async profile has service-free live coverage. See
+  [Transactions](transactions.md).
 * fix: close five gaps in the owned-resource and adapter-registration contracts. PR [#576](https://github.com/zschumacher/pydapper/pull/576) by [@zschumacher](https://github.com/zschumacher).
 * fix: identify connections by type, not repr, in selection errors. PR [#575](https://github.com/zschumacher/pydapper/pull/575) by [@zschumacher](https://github.com/zschumacher).
 * fix: verify preparation-hook ordering on the conformance query paths. PR [#573](https://github.com/zschumacher/pydapper/pull/573) by [@zschumacher](https://github.com/zschumacher).

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,9 +3,9 @@
 * v1: `CommandsAsync` now exposes the async transaction APIs — `commit()`, `rollback()`, and a
   `transaction()` async context manager — with semantics identical to the sync APIs: commit on clean exit;
   rollback then re-raise on any exception (including `KeyboardInterrupt`) with the block's error winning over
-  an ordinary rollback failure (a `BaseException` such as a task cancellation raised during the rollback is
-  never swallowed and propagates in its place); a failed exit commit propagates unchanged with no rollback
-  attempt; no SQL on enter; and
+  an ordinary rollback failure (a `BaseException` that is not an `Exception` — such as a task cancellation —
+  raised during the rollback is never swallowed and propagates in its place); a failed exit commit propagates
+  unchanged with no rollback attempt; no SQL on enter; and
   `RuntimeError` on nested blocks on the same instance. The methods are deliberately unsuffixed — the class is
   async-only, so an `_async` suffix would be redundant — and all three are gated behind
   `AdapterCapability.TRANSACTIONS`, raising `UnsupportedFeatureError` for adapters that do not declare it.

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,11 +1,13 @@
 # Transactions
 
-pydapper's synchronous command classes expose explicit transaction handling: `commit()`, `rollback()`, and a
-`transaction()` context manager. Transactions are deliberately boring — pydapper never emits `BEGIN` for you,
-never toggles autocommit itself, and delegates directly to the DBAPI connection.
+pydapper's command classes expose explicit transaction handling in both modes: `commit()`, `rollback()`, and a
+`transaction()` context manager on `Commands`, and the same names on `CommandsAsync` — `commit()`/`rollback()`
+as coroutines and `transaction()` as an async context manager. Transactions are deliberately boring — pydapper
+never emits `BEGIN` for you, never toggles autocommit itself, and delegates directly to the DBAPI connection.
 
 All three methods are gated behind `AdapterCapability.TRANSACTIONS`. An adapter that does not declare the
-capability raises `UnsupportedFeatureError` immediately, before the connection is touched:
+capability raises `UnsupportedFeatureError` before the connection is touched — at call time for
+`transaction()`, and when the call is awaited for the async `commit()`/`rollback()` coroutines:
 
 ```python
 import pydapper
@@ -14,16 +16,19 @@ with pydapper.connect("sqlite://pydapper.db") as commands:
     commands.supports(pydapper.AdapterCapability.TRANSACTIONS)  # True
 ```
 
-Every first-party sync adapter except BigQuery declares the capability — see the
-[first-party adapter table](adapter_registration.md#first-party-adapters). BigQuery does not, because its DBAPI
-has no connection-level transactions (`commit()` is a no-op and there is no `rollback()`). The async transaction
-APIs are a separate upcoming feature; async command classes do not declare the capability yet.
+Every first-party adapter declares the capability except two — see the
+[first-party adapter table](adapter_registration.md#first-party-adapters):
+
+* **BigQuery** — its DBAPI has no connection-level transactions (`commit()` is a no-op and there is no
+  `rollback()`).
+* **aiopg** — it always runs in autocommit mode, and its connection-level `commit()`/`rollback()` raise.
 
 !!! note "`with pydapper.connect(...)` delegates exit behavior to the driver"
-    `Commands.__enter__`/`__exit__` delegate to the driver connection's own context manager. Some drivers'
-    connection context managers commit on clean exit (for example `sqlite3` and `psycopg2`), so leaving the
-    `with connect(...)` block can itself commit outstanding work. The transaction APIs below operate on the
-    same single connection-level transaction that behavior applies to.
+    `Commands.__enter__`/`__exit__` (and the `CommandsAsync` async equivalents) delegate to the driver
+    connection's own context manager. Some drivers' connection context managers commit on clean exit (for
+    example `sqlite3` and `psycopg2`), so leaving the `with connect(...)` block can itself commit outstanding
+    work. The transaction APIs below operate on the same single connection-level transaction that behavior
+    applies to.
 
 ## `commit()` and `rollback()`
 
@@ -32,6 +37,13 @@ contract, a transaction starts implicitly with your first statement — there is
 
 ```python
 {!docs/../docs_src/transactions/commit_rollback.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+On `CommandsAsync` they are coroutines with the same names — await them:
+
+```python
+{!docs/../docs_src/transactions/commit_rollback_async.py!}
 ```
 (*This script is complete, it should run "as is"*)
 
@@ -45,32 +57,47 @@ contract, a transaction starts implicitly with your first statement — there is
 ```
 (*This script is complete, it should run "as is"*)
 
-The exact semantics:
+On `CommandsAsync`, use `async with`:
+
+```python
+{!docs/../docs_src/transactions/transaction_context_async.py!}
+```
+(*This script is complete, it should run "as is"*)
+
+The exact semantics, identical in both modes:
 
 * **Entering the block emits no SQL.** The DBAPI's implicit transaction start is the contract; work done before
   the block on the same connection belongs to the same connection-level transaction.
 * **Clean exit commits.** If the commit itself fails, the error propagates unchanged and no rollback is
   attempted — connection state after a failed commit is driver-defined.
-* **An exception rolls back and re-raises.** The original exception always wins: if the rollback also fails,
-  the rollback failure is suppressed and the block's exception propagates.
-* **Blocks cannot be nested on the same `Commands` instance.** Re-entry raises `RuntimeError`. The guard is
-  per instance, not per connection: a second `Commands` object over the same connection (for example from a
-  second `using()` call) shares the same single connection-level transaction, and a `transaction()` block on
-  one instance is not protected against `commit()`/`rollback()`/`transaction()` calls made through another.
-  Use one `Commands` instance per connection when working with transactions. Savepoint-based nesting may
-  arrive later as a separate, adapter-gated feature.
+* **An exception rolls back and re-raises.** If the rollback also fails with an ordinary `Exception`, that
+  failure is suppressed (recorded at `DEBUG`) and the block's exception propagates. A `BaseException` that is
+  not an `Exception` — `KeyboardInterrupt`, `SystemExit`, a task cancellation — raised during the rollback is
+  never swallowed: it propagates in place of the block's exception, which survives as its `__context__` (the
+  same policy as command-owned cursor cleanup).
+* **Blocks cannot be nested on the same command instance.** Re-entry raises `RuntimeError`. The guard is per
+  `Commands`/`CommandsAsync` instance, not per connection: a second instance over the same connection (for
+  example from a second `using()`/`using_async()` call) shares the same single connection-level transaction,
+  and a `transaction()` block on one instance is not protected against `commit()`/`rollback()`/`transaction()`
+  calls made through another. Use one command instance per connection when working with transactions.
+  Savepoint-based nesting may arrive later as a separate, adapter-gated feature.
 * **Explicit `commit()` / `rollback()` inside a block is allowed.** They operate on the same single
   connection-level transaction: an inner `commit()` makes the work so far durable, and the block's exit commit
   covers the remainder.
 
+!!! note "Naming"
+    The transaction methods are deliberately unsuffixed on `CommandsAsync` — the class itself is async-only, so
+    an `_async` suffix would be redundant (`cursor()` and `supports()` are likewise unsuffixed). The execute
+    and query command methods currently keep their historical `_async` suffixes.
+
 ## Driver notes
 
-Transaction behavior is pinned for every declaring adapter by the
+Transaction behavior is pinned for every declaring adapter in both modes by the
 [`transactions` conformance profile](adapter_conformance.md#the-transactions-profile), and per-driver limits
 are recorded in the driver-limits column of the
 [first-party conformance matrix](adapter_conformance.md#first-party-driver-conformance-matrix). Driver-level
 transaction defaults still apply beneath these APIs — for example `mysql-connector-python` connects with
 `autocommit=False` (so no DML is durable until you commit, though MySQL still implicitly commits every DDL
-statement), and `sqlite3`'s legacy `isolation_level` mode
-opens implicit transactions for DML but not DDL, which means a rolled-back block can leave a `CREATE TABLE`
-behind. Consult your driver's own documentation for its autocommit and isolation semantics.
+statement), and `sqlite3`'s legacy `isolation_level` mode opens implicit transactions for DML but not DDL,
+which means a rolled-back block can leave a `CREATE TABLE` behind. Consult your driver's own documentation for
+its autocommit and isolation semantics.

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -88,7 +88,8 @@ The exact semantics, identical in both modes:
 !!! note "Naming"
     The transaction methods are deliberately unsuffixed on `CommandsAsync` — the class itself is async-only, so
     an `_async` suffix would be redundant (`cursor()` and `supports()` are likewise unsuffixed). The execute
-    and query command methods currently keep their historical `_async` suffixes.
+    and query command methods currently keep their historical `_async` suffixes, and `connect_async` keeps its
+    suffix on purpose: it disambiguates mode at the package boundary, next to the sync `connect`.
 
 ## Driver notes
 

--- a/docs_src/transactions/commit_rollback_async.py
+++ b/docs_src/transactions/commit_rollback_async.py
@@ -1,0 +1,24 @@
+import asyncio
+import datetime
+
+from pydapper import connect_async
+
+
+async def main():
+    async with connect_async() as commands:
+        await commands.execute_async(
+            "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+            params={"description": "A rollback example", "due_date": datetime.date.today(), "owner_id": 1},
+        )
+        # discard the uncommitted insert
+        await commands.rollback()
+
+        await commands.execute_async(
+            "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+            params={"description": "A commit example", "due_date": datetime.date.today(), "owner_id": 1},
+        )
+        # make the insert durable
+        await commands.commit()
+
+
+asyncio.run(main())

--- a/docs_src/transactions/transaction_context_async.py
+++ b/docs_src/transactions/transaction_context_async.py
@@ -1,0 +1,21 @@
+import asyncio
+import datetime
+
+from pydapper import connect_async
+
+
+async def main():
+    async with connect_async() as commands:
+        async with commands.transaction():
+            await commands.execute_async(
+                "insert into task (description, due_date, owner_id) values (?description?, ?due_date?, ?owner_id?)",
+                params={"description": "A transaction example", "due_date": datetime.date.today(), "owner_id": 1},
+            )
+            await commands.execute_async(
+                "update task set description = ?description? where id = ?id?",
+                params={"id": 1, "description": "Updated in the same transaction"},
+            )
+        # the block exited cleanly, so both statements are committed together
+
+
+asyncio.run(main())

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -3,12 +3,14 @@ import typing
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Mapping
+from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from dataclasses import is_dataclass
 from functools import cached_property
 from inspect import signature
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import AsyncContextManager
 from typing import AsyncGenerator
 from typing import Callable
 from typing import ClassVar
@@ -49,6 +51,7 @@ if TYPE_CHECKING:
     from .dsn_parser import PydapperParseResult
     from .types import AsyncConnectionType
     from .types import AsyncCursorType
+    from .types import AsyncTransactionalConnectionType
     from .types import ConnectionType
     from .types import CursorType
     from .types import ListParamType
@@ -399,8 +402,11 @@ class Commands(BaseCommands, ABC):
         ``UnsupportedFeatureError`` at call time, before the returned context manager is entered.
         Entering the block emits no SQL — the DBAPI's implicit transaction start is the contract.
         On a clean exit the block commits; on any exception (``BaseException`` included) it rolls
-        back and re-raises, with a rollback failure losing to the active exception. A commit
-        failure on clean exit propagates unchanged and no rollback is attempted, because
+        back and re-raises, with an ordinary ``Exception`` from the rollback losing to the active
+        exception (recorded at ``DEBUG``, never raised); a ``BaseException`` that is not an
+        ``Exception`` — ``KeyboardInterrupt``, ``SystemExit``, a cancellation — propagates in its
+        place with the block's error as its ``__context__``. A commit failure on clean exit
+        propagates unchanged and no rollback is attempted, because
         connection state after a failed commit is driver-defined. Blocks cannot be nested on the
         same instance; re-entry raises ``RuntimeError``. The guard is per ``Commands`` instance:
         a second instance over the same connection (for example from a second ``using()`` call)
@@ -1795,6 +1801,10 @@ class Commands(BaseCommands, ABC):
 
 
 class CommandsAsync(BaseCommands, ABC):
+    # class-level default so a subclass that overrides __init__ without calling super() still
+    # gets a working transaction guard; entering a block shadows it per instance
+    _in_transaction: bool = False
+
     def __init__(self, connection: "AsyncConnectionType"):
         self.connection = connection
 
@@ -1808,6 +1818,79 @@ class CommandsAsync(BaseCommands, ABC):
     @classmethod
     @abstractmethod
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync": ...
+
+    async def commit(self) -> None:
+        """Commit the connection's current transaction.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` before the connection is touched. Because this is a coroutine,
+        the gate fires when the call is awaited. May be called inside an open ``transaction()``
+        block: there is only the single connection-level PEP 249 transaction, so this commits the
+        work so far and the block's exit commit covers the remainder.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        await cast("AsyncTransactionalConnectionType", self.connection).commit()
+
+    async def rollback(self) -> None:
+        """Roll back the connection's current transaction.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` before the connection is touched. Because this is a coroutine,
+        the gate fires when the call is awaited.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        await cast("AsyncTransactionalConnectionType", self.connection).rollback()
+
+    def transaction(self) -> AsyncContextManager[None]:
+        """Return an async context manager that commits on normal exit and rolls back on exception.
+
+        Requires ``AdapterCapability.TRANSACTIONS``; an adapter that does not declare it raises
+        ``UnsupportedFeatureError`` at call time, before the returned context manager is entered.
+        Entering the block emits no SQL — the DBAPI's implicit transaction start is the contract.
+        On a clean exit the block commits; on any exception (``BaseException`` included) it rolls
+        back and re-raises, with an ordinary ``Exception`` from the rollback losing to the active
+        exception (recorded at ``DEBUG``, never raised); a ``BaseException`` that is not an
+        ``Exception`` — ``KeyboardInterrupt``, ``SystemExit``, a cancellation — propagates in its
+        place with the block's error as its ``__context__``. A commit failure on clean exit
+        propagates unchanged and no rollback is attempted, because
+        connection state after a failed commit is driver-defined. Blocks cannot be nested on the
+        same instance; re-entry raises ``RuntimeError``. The guard is per ``CommandsAsync``
+        instance: a second instance over the same connection (for example from a second
+        ``using_async()`` call) shares the same single connection-level transaction and is not
+        guarded against. Entering the returned context manager manually without exiting it leaves
+        the rollback to async-generator finalization at a nondeterministic time — and unlike the
+        sync twin, if the event loop is closed before that finalization runs, the rollback never
+        happens and the nesting guard stays set on this instance. Always use ``async with``.
+        """
+        self._require_capability(AdapterCapability.TRANSACTIONS)
+        return self._transaction_proxy()
+
+    @asynccontextmanager
+    async def _transaction_proxy(self) -> AsyncGenerator[None, None]:
+        if self._in_transaction:
+            raise RuntimeError(
+                "transaction() blocks cannot be nested; a transaction block is already active on this "
+                "CommandsAsync instance"
+            )
+        self._in_transaction = True
+        try:
+            try:
+                yield
+            except BaseException:
+                # the active block error wins over an ordinary rollback failure; a BaseException
+                # that is not an Exception (KeyboardInterrupt, SystemExit, asyncio.CancelledError,
+                # GeneratorExit) is not caught at all and propagates past it — a cancellation
+                # landing inside the rollback await must never be swallowed. Same cleanup policy
+                # as the sync proxy and command-owned cursor cleanup, see _log_discarded_cleanup_error
+                try:
+                    await self.rollback()
+                except Exception as rollback_error:
+                    _log_discarded_cleanup_error(rollback_error)
+                raise
+            else:
+                await self.commit()
+        finally:
+            self._in_transaction = False
 
     def cursor(self, *args, **kwargs) -> "_AwaitableAsyncContextManager[AsyncCursorType, AsyncCursorType]":
         return _AwaitableAsyncContextManager(self.connection.cursor(*args, **kwargs), preserve_active_error=True)

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -354,6 +354,66 @@ class BaseCommands(ABC):
         return options
 
 
+_TRANSACTION_CONTEXT_REUSED = "transaction() context managers are single-use; call transaction() again for a new block"
+_TRANSACTION_CONTEXT_NOT_ACTIVE = (
+    "transaction() context manager is not active; it was never entered or has already exited"
+)
+
+
+class _TransactionContext:
+    """Single-use wrapper enforcing enter-before-exit for sync ``transaction()`` blocks.
+
+    Without it, ``__exit__`` on a never-entered context manager would start the underlying
+    generator — setting the nesting guard as a side effect — and reusing an exhausted one
+    would surface as contextlib's bare ``AttributeError`` instead of a clear error.
+    """
+
+    __slots__ = ("_inner", "_state")
+
+    def __init__(self, inner: ContextManager[None]) -> None:
+        self._inner = inner
+        self._state = "new"
+
+    def __enter__(self) -> None:
+        if self._state != "new":
+            raise RuntimeError(_TRANSACTION_CONTEXT_REUSED)
+        self._state = "entered"
+        return self._inner.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
+        if self._state != "entered":
+            raise RuntimeError(_TRANSACTION_CONTEXT_NOT_ACTIVE)
+        self._state = "exited"
+        return self._inner.__exit__(exc_type, exc_val, exc_tb)
+
+
+class _AsyncTransactionContext:
+    """The async twin of :class:`_TransactionContext`; see its rationale.
+
+    The never-entered ``__aexit__`` misuse is worse in async mode: on Python 3.10 the
+    started-but-abandoned generator leaves the nesting guard set until finalization runs,
+    which may be arbitrarily late or never.
+    """
+
+    __slots__ = ("_inner", "_state")
+
+    def __init__(self, inner: AsyncContextManager[None]) -> None:
+        self._inner = inner
+        self._state = "new"
+
+    async def __aenter__(self) -> None:
+        if self._state != "new":
+            raise RuntimeError(_TRANSACTION_CONTEXT_REUSED)
+        self._state = "entered"
+        return await self._inner.__aenter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
+        if self._state != "entered":
+            raise RuntimeError(_TRANSACTION_CONTEXT_NOT_ACTIVE)
+        self._state = "exited"
+        return await self._inner.__aexit__(exc_type, exc_val, exc_tb)
+
+
 class Commands(BaseCommands, ABC):
     # class-level default so a subclass that overrides __init__ without calling super() still
     # gets a working transaction guard; entering a block shadows it per instance
@@ -410,12 +470,13 @@ class Commands(BaseCommands, ABC):
         connection state after a failed commit is driver-defined. Blocks cannot be nested on the
         same instance; re-entry raises ``RuntimeError``. The guard is per ``Commands`` instance:
         a second instance over the same connection (for example from a second ``using()`` call)
-        shares the same single connection-level transaction and is not guarded against. Entering
-        the returned context manager manually without exiting it leaves the rollback to generator
-        finalization at a nondeterministic time; always use ``with``.
+        shares the same single connection-level transaction and is not guarded against. The
+        returned context manager is single-use and must be entered before it is exited; misuse
+        raises ``RuntimeError``. Entering it manually without exiting it leaves the rollback to
+        generator finalization at a nondeterministic time; always use ``with``.
         """
         self._require_capability(AdapterCapability.TRANSACTIONS)
-        return self._transaction_proxy()
+        return _TransactionContext(self._transaction_proxy())
 
     @contextmanager
     def _transaction_proxy(self) -> Generator[None, None, None]:
@@ -1857,13 +1918,17 @@ class CommandsAsync(BaseCommands, ABC):
         same instance; re-entry raises ``RuntimeError``. The guard is per ``CommandsAsync``
         instance: a second instance over the same connection (for example from a second
         ``using_async()`` call) shares the same single connection-level transaction and is not
-        guarded against. Entering the returned context manager manually without exiting it leaves
+        guarded against. The returned context manager is single-use and must be entered before it
+        is exited; misuse raises ``RuntimeError``. Entering it manually without exiting it leaves
         the rollback to async-generator finalization at a nondeterministic time — and unlike the
         sync twin, if the event loop is closed before that finalization runs, the rollback never
-        happens and the nesting guard stays set on this instance. Always use ``async with``.
+        happens and the nesting guard stays set on this instance; if the surrounding connection
+        context manager exits first, a driver whose connection commits on clean exit (for example
+        psycopg) commits the abandoned block's work before finalization can roll it back. Always
+        use ``async with``.
         """
         self._require_capability(AdapterCapability.TRANSACTIONS)
-        return self._transaction_proxy()
+        return _AsyncTransactionContext(self._transaction_proxy())
 
     @asynccontextmanager
     async def _transaction_proxy(self) -> AsyncGenerator[None, None]:

--- a/pydapper/postgresql/psycopg3.py
+++ b/pydapper/postgresql/psycopg3.py
@@ -31,7 +31,7 @@ class Psycopg3Commands(Commands):
 
 
 class Psycopg3CommandsAsync(CommandsAsync):
-    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset()
+    capabilities: ClassVar[frozenset[AdapterCapability]] = frozenset({AdapterCapability.TRANSACTIONS})
 
     @classmethod
     async def connect_async(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "CommandsAsync":

--- a/pydapper/testing/adapter_conformance/_cases_transactions_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_transactions_async.py
@@ -1,39 +1,38 @@
-"""The ``transactions`` capability profile's sync case inventory.
+"""The ``transactions`` capability profile's async case inventory.
 
-These cases run only for command classes that declare
+The async twin of ``_cases_transactions`` — same nine case ids, order, and kinds, so
+sync and async declaring adapters are held to one contract. These cases run only for
+async command classes that declare
 :attr:`~pydapper.capabilities.AdapterCapability.TRANSACTIONS`. Every ``live`` case
 first commits the harness baseline (``create_commands()`` then ``commit()``) so the
 scenario starts from a durable, transaction-free state regardless of whether the
 harness seeded inside an open transaction. ``instrumented`` cases observe delegation,
 ordering, and error precedence directly through recording connections.
-
-The async inventory lives in ``_cases_transactions_async`` with the same case ids.
 """
 
-from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import List
 from typing import Tuple
 
-from pydapper.commands import Commands
+from pydapper.commands import CommandsAsync
 
-from ._checks import SyncCaseContext
-from ._profiles import SyncCase
+from ._cases_transactions import _TX_ROW
+from ._checks import AsyncCaseContext
+from ._profiles import AsyncCase
 
-_CASES: List[SyncCase] = []
+_CASES: List[AsyncCase] = []
 
 
-def _case(case_id: str, description: str, kind: str) -> Callable[[Callable[[SyncCaseContext], None]], Callable]:
-    def register(fn: Callable[[SyncCaseContext], None]) -> Callable[[SyncCaseContext], None]:
-        _CASES.append(SyncCase(case_id=case_id, description=description, kind=kind, run=fn))
+def _case(case_id: str, description: str, kind: str) -> Callable[[Callable], Callable]:
+    def register(fn: Callable) -> Callable:
+        _CASES.append(AsyncCase(case_id=case_id, description=description, kind=kind, run=fn))
         return fn
 
     return register
 
 
-def transactions_sync_cases() -> Tuple[SyncCase, ...]:
-    """Return the full, ordered, immutable ``transactions`` sync case inventory."""
+def transactions_async_cases() -> Tuple[AsyncCase, ...]:
+    """Return the full, ordered, immutable async ``transactions`` case inventory."""
     return _FROZEN_CASES
 
 
@@ -45,11 +44,8 @@ class _InjectedTransactionCleanupFault(Exception):
     """Framework-injected connection commit/rollback failure."""
 
 
-_TX_ROW: Dict[str, Any] = {"id": 100, "label": "tx", "score": 7, "note": "tx-note"}
-
-
-def _row_count(ctx: SyncCaseContext, commands: Commands, row_id: int) -> int:
-    return len(commands.query(ctx.sql("select_by_id"), params={"id": row_id}))
+async def _row_count(ctx: AsyncCaseContext, commands: CommandsAsync, row_id: int) -> int:
+    return len(await commands.query_async(ctx.sql("select_by_id"), params={"id": row_id}))
 
 
 @_case(
@@ -57,14 +53,14 @@ def _row_count(ctx: SyncCaseContext, commands: Commands, row_id: int) -> int:
     "commit() makes a write durable: a later rollback() cannot remove it",
     "live",
 )
-def _transactions_commit_persists(ctx: SyncCaseContext) -> None:
-    commands = ctx.create_commands()
-    commands.commit()
-    commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
-    commands.commit()
-    commands.rollback()
+async def _transactions_commit_persists(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    await commands.commit()
+    await commands.execute_async(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    await commands.commit()
+    await commands.rollback()
     ctx.check(
-        _row_count(ctx, commands, _TX_ROW["id"]) == 1,
+        await _row_count(ctx, commands, _TX_ROW["id"]) == 1,
         "a committed insert must survive a subsequent rollback()",
     )
 
@@ -74,16 +70,16 @@ def _transactions_commit_persists(ctx: SyncCaseContext) -> None:
     "rollback() discards uncommitted work and leaves committed rows intact",
     "live",
 )
-def _transactions_rollback_discards(ctx: SyncCaseContext) -> None:
-    commands = ctx.create_commands()
-    commands.commit()
-    commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
-    commands.rollback()
+async def _transactions_rollback_discards(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    await commands.commit()
+    await commands.execute_async(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    await commands.rollback()
     ctx.check(
-        _row_count(ctx, commands, _TX_ROW["id"]) == 0,
+        await _row_count(ctx, commands, _TX_ROW["id"]) == 0,
         "rollback() must discard the uncommitted insert",
     )
-    rows = commands.query(ctx.sql("select_all"))
+    rows = await commands.query_async(ctx.sql("select_all"))
     ctx.check(
         len(rows) == len(ctx.seeded_rows()),
         f"rollback() must leave the {len(ctx.seeded_rows())} committed baseline rows intact, saw {len(rows)}",
@@ -95,14 +91,14 @@ def _transactions_rollback_discards(ctx: SyncCaseContext) -> None:
     "A transaction() block commits on clean exit",
     "live",
 )
-def _transactions_context_commits(ctx: SyncCaseContext) -> None:
-    commands = ctx.create_commands()
-    commands.commit()
-    with commands.transaction():
-        commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
-    commands.rollback()
+async def _transactions_context_commits(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    await commands.commit()
+    async with commands.transaction():
+        await commands.execute_async(ctx.sql("insert_row"), params=dict(_TX_ROW))
+    await commands.rollback()
     ctx.check(
-        _row_count(ctx, commands, _TX_ROW["id"]) == 1,
+        await _row_count(ctx, commands, _TX_ROW["id"]) == 1,
         "a clean transaction() exit must commit; a later rollback() cannot remove the insert",
     )
 
@@ -112,21 +108,21 @@ def _transactions_context_commits(ctx: SyncCaseContext) -> None:
     "A transaction() block rolls back on exception and re-raises the same exception",
     "live",
 )
-def _transactions_context_rolls_back(ctx: SyncCaseContext) -> None:
-    commands = ctx.create_commands()
-    commands.commit()
+async def _transactions_context_rolls_back(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    await commands.commit()
     fault = _InjectedTransactionFault("boom")
     with ctx.expect_raises(_InjectedTransactionFault) as caught:
-        with commands.transaction():
-            commands.execute(ctx.sql("insert_row"), params=dict(_TX_ROW))
+        async with commands.transaction():
+            await commands.execute_async(ctx.sql("insert_row"), params=dict(_TX_ROW))
             raise fault
     ctx.check(caught.exception is fault, "the block's exception must propagate as the same exception object")
     ctx.check(
-        _row_count(ctx, commands, _TX_ROW["id"]) == 0,
+        await _row_count(ctx, commands, _TX_ROW["id"]) == 0,
         "a transaction() block that raised must roll its insert back",
     )
     # recover runs last so a harness recovery step can never repair the state under test
-    ctx.recover(commands)
+    await ctx.recover(commands)
 
 
 @_case(
@@ -134,11 +130,11 @@ def _transactions_context_rolls_back(ctx: SyncCaseContext) -> None:
     "commit() delegates to the connection exactly once, acquires no cursor, and its failure propagates",
     "instrumented",
 )
-def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
+async def _transactions_commit_delegates(ctx: AsyncCaseContext) -> None:
     connection = ctx.recording_connection()
     commands = ctx.instrumented_commands(connection)
     # a third-party override may return a value; the contract pins None
-    result = commands.commit()  # type: ignore[func-returns-value]
+    result = await commands.commit()  # type: ignore[func-returns-value]
     ctx.check(result is None, f"commit() must return None, got {result!r}")
     ctx.check(connection.commit_calls == 1, f"expected exactly one connection commit, saw {connection.commit_calls}")
     ctx.check(connection.rollback_calls == 0, "commit() must not roll back")
@@ -149,7 +145,7 @@ def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
     failing = ctx.recording_connection(commit_error=fault)
     commands = ctx.instrumented_commands(failing)
     with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
-        commands.commit()
+        await commands.commit()
     ctx.check(caught.exception is fault, "a connection commit failure must propagate from commit() unchanged")
     ctx.check(failing.commit_calls == 1, f"expected exactly one commit attempt, saw {failing.commit_calls}")
     ctx.check(failing.rollback_calls == 0, "a failed commit() must not trigger a rollback")
@@ -160,11 +156,11 @@ def _transactions_commit_delegates(ctx: SyncCaseContext) -> None:
     "rollback() delegates to the connection exactly once, acquires no cursor, and its failure propagates",
     "instrumented",
 )
-def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
+async def _transactions_rollback_delegates(ctx: AsyncCaseContext) -> None:
     connection = ctx.recording_connection()
     commands = ctx.instrumented_commands(connection)
     # a third-party override may return a value; the contract pins None
-    result = commands.rollback()  # type: ignore[func-returns-value]
+    result = await commands.rollback()  # type: ignore[func-returns-value]
     ctx.check(result is None, f"rollback() must return None, got {result!r}")
     ctx.check(
         connection.rollback_calls == 1, f"expected exactly one connection rollback, saw {connection.rollback_calls}"
@@ -177,7 +173,7 @@ def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
     failing = ctx.recording_connection(rollback_error=fault)
     commands = ctx.instrumented_commands(failing)
     with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
-        commands.rollback()
+        await commands.rollback()
     ctx.check(caught.exception is fault, "a connection rollback failure must propagate from rollback() unchanged")
     ctx.check(failing.rollback_calls == 1, f"expected exactly one rollback attempt, saw {failing.rollback_calls}")
     ctx.check(failing.commit_calls == 0, "a failed rollback() must not trigger a commit")
@@ -188,11 +184,11 @@ def _transactions_rollback_delegates(ctx: SyncCaseContext) -> None:
     "A clean transaction() block commits exactly once, after the command's cursor lifecycle",
     "instrumented",
 )
-def _transactions_context_lifecycle(ctx: SyncCaseContext) -> None:
+async def _transactions_context_lifecycle(ctx: AsyncCaseContext) -> None:
     connection = ctx.recording_connection()
     commands = ctx.instrumented_commands(connection)
-    with commands.transaction():
-        commands.execute("UPDATE t SET label = 'x'")
+    async with commands.transaction():
+        await commands.execute_async("UPDATE t SET label = 'x'")
     ctx.check(connection.commit_calls == 1, f"expected exactly one commit, saw {connection.commit_calls}")
     ctx.check(connection.rollback_calls == 0, "a clean transaction() block must not roll back")
     ctx.check_event_order(connection.log, ("cursor", "enter", "execute", "exit", "commit"))
@@ -203,12 +199,12 @@ def _transactions_context_lifecycle(ctx: SyncCaseContext) -> None:
     "A transaction() block rolls back on error, re-raises it, and the error wins over a rollback failure",
     "instrumented",
 )
-def _transactions_context_error_precedence(ctx: SyncCaseContext) -> None:
+async def _transactions_context_error_precedence(ctx: AsyncCaseContext) -> None:
     fault = _InjectedTransactionFault("boom")
     connection = ctx.recording_connection()
     commands = ctx.instrumented_commands(connection)
     with ctx.expect_raises(_InjectedTransactionFault) as caught:
-        with commands.transaction():
+        async with commands.transaction():
             raise fault
     ctx.check(caught.exception is fault, "the block's exception must propagate as the same exception object")
     ctx.check(
@@ -220,7 +216,7 @@ def _transactions_context_error_precedence(ctx: SyncCaseContext) -> None:
     failing = ctx.recording_connection(rollback_error=rollback_fault)
     commands = ctx.instrumented_commands(failing)
     with ctx.expect_raises(_InjectedTransactionFault) as caught_again:
-        with commands.transaction():
+        async with commands.transaction():
             raise fault
     ctx.check(caught_again.exception is fault, "the block's exception must win over a rollback failure")
     ctx.check(failing.rollback_calls == 1, f"expected exactly one rollback attempt, saw {failing.rollback_calls}")
@@ -231,12 +227,12 @@ def _transactions_context_error_precedence(ctx: SyncCaseContext) -> None:
     "A commit failure on clean transaction() exit propagates unchanged with no rollback attempt",
     "instrumented",
 )
-def _transactions_commit_failure(ctx: SyncCaseContext) -> None:
+async def _transactions_commit_failure(ctx: AsyncCaseContext) -> None:
     commit_fault = _InjectedTransactionCleanupFault("commit")
     connection = ctx.recording_connection(commit_error=commit_fault)
     commands = ctx.instrumented_commands(connection)
     with ctx.expect_raises(_InjectedTransactionCleanupFault) as caught:
-        with commands.transaction():
+        async with commands.transaction():
             pass
     ctx.check(caught.exception is commit_fault, "the commit failure must propagate as the same exception object")
     ctx.check(connection.commit_calls == 1, f"expected exactly one commit attempt, saw {connection.commit_calls}")
@@ -245,4 +241,4 @@ def _transactions_commit_failure(ctx: SyncCaseContext) -> None:
 
 #: The production inventory is frozen once at import; later mutation of the private
 #: registration list cannot alter what the runner executes.
-_FROZEN_CASES: Tuple[SyncCase, ...] = tuple(_CASES)
+_FROZEN_CASES: Tuple[AsyncCase, ...] = tuple(_CASES)

--- a/pydapper/testing/adapter_conformance/_checks.py
+++ b/pydapper/testing/adapter_conformance/_checks.py
@@ -279,12 +279,24 @@ class AsyncCaseContext(_BaseCaseContext):
         scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
         cursor_style: str = "context",
         close_style: str = "sync",
+        commit_error: Optional[BaseException] = None,
+        rollback_error: Optional[BaseException] = None,
     ) -> RecordingAsyncConnection:
         if self.harness.cursor_factory_style == "synchronous":
             return SynchronousCursorRecordingAsyncConnection(
-                scripts, cursor_style=cursor_style, close_style=close_style
+                scripts,
+                cursor_style=cursor_style,
+                close_style=close_style,
+                commit_error=commit_error,
+                rollback_error=rollback_error,
             )
-        return RecordingAsyncConnection(scripts, cursor_style=cursor_style, close_style=close_style)
+        return RecordingAsyncConnection(
+            scripts,
+            cursor_style=cursor_style,
+            close_style=close_style,
+            commit_error=commit_error,
+            rollback_error=rollback_error,
+        )
 
     def instrumented_commands(self, connection: RecordingAsyncConnection) -> CommandsAsync:
         return self.command_class(cast("AsyncConnectionType", connection))  # type: ignore[abstract]

--- a/pydapper/testing/adapter_conformance/_instrumentation.py
+++ b/pydapper/testing/adapter_conformance/_instrumentation.py
@@ -406,7 +406,8 @@ class RecordingAsyncConnection:
     """An async connection whose ``cursor()`` returns an awaitable (the base contract).
 
     ``cursor_style`` is ``"context"`` or ``"plain"``; ``close_style`` selects sync vs
-    awaitable ``close()`` for plain cursors.
+    awaitable ``close()`` for plain cursors. ``commit_error``/``rollback_error`` inject a
+    failure at the named connection-level transaction interaction.
     """
 
     def __init__(
@@ -414,6 +415,8 @@ class RecordingAsyncConnection:
         scripts: Union[CursorScript, Sequence[CursorScript], None] = None,
         cursor_style: str = "context",
         close_style: str = "sync",
+        commit_error: Optional[BaseException] = None,
+        rollback_error: Optional[BaseException] = None,
     ) -> None:
         if scripts is None:
             scripts = CursorScript()
@@ -422,10 +425,26 @@ class RecordingAsyncConnection:
         self._scripts = list(scripts)
         self._cursor_style = cursor_style
         self._close_style = close_style
+        self._commit_error = commit_error
+        self._rollback_error = rollback_error
         self.log = RecordingLog()
         self.cursor_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
         self.recorders: List[CursorRecorder] = []
         self.cursors: List[_AsyncCursorFacade] = []
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+        self.log.add(RecordedEvent(kind="commit"))
+        if self._commit_error is not None:
+            raise self._commit_error
+
+    async def rollback(self) -> None:
+        self.rollback_calls += 1
+        self.log.add(RecordedEvent(kind="rollback"))
+        if self._rollback_error is not None:
+            raise self._rollback_error
 
     def _build_cursor(self) -> _AsyncCursorFacade:
         self.cursor_calls += 1

--- a/pydapper/testing/adapter_conformance/_profiles.py
+++ b/pydapper/testing/adapter_conformance/_profiles.py
@@ -12,6 +12,7 @@ The capability surface (:class:`ConformanceProfile`, :class:`SyncCase`,
 mandatory core profiles.
 """
 
+import inspect
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -79,6 +80,15 @@ def _validate_cases(profile_id: str, cases: Tuple[Any, ...], mode: str) -> None:
         if case.case_id in seen:
             raise ProfileDefinitionError(profile_id, f"duplicate {mode} case id {case.case_id!r}")
         seen.add(case.case_id)
+        # a mode/run mismatch would otherwise surface only at run time, as a confusing
+        # TypeError from awaiting None (or a sync body silently executing its side effects)
+        is_coroutine = inspect.iscoroutinefunction(case.run)
+        if mode == "async" and not is_coroutine:
+            raise ProfileDefinitionError(profile_id, f"{mode} case {case.case_id!r} run must be a coroutine function")
+        if mode == "sync" and is_coroutine:
+            raise ProfileDefinitionError(
+                profile_id, f"{mode} case {case.case_id!r} run must not be a coroutine function"
+            )
 
 
 @dataclass(frozen=True)

--- a/pydapper/testing/adapter_conformance/_profiles.py
+++ b/pydapper/testing/adapter_conformance/_profiles.py
@@ -127,17 +127,17 @@ def core_async_profile() -> ConformanceProfile:
 def transactions_profile() -> ConformanceProfile:
     """Build the optional ``transactions`` capability profile.
 
-    Sync cases only: the async transaction APIs are a separate feature, and the async
-    inventory ships with them. Until then an async command class may not declare
-    :attr:`AdapterCapability.TRANSACTIONS` — ``capabilities.declared-profile-populated``
-    rejects a declaration with no cases for its mode.
+    Both modes ship the same nine case ids in the same order, so sync and async
+    declaring adapters are held to one contract.
     """
     from ._cases_transactions import transactions_sync_cases
+    from ._cases_transactions_async import transactions_async_cases
 
     return ConformanceProfile(
         profile_id=TRANSACTIONS_PROFILE,
         capability=AdapterCapability.TRANSACTIONS,
         sync_cases=transactions_sync_cases(),
+        async_cases=transactions_async_cases(),
     )
 
 

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -61,10 +61,11 @@ class AsyncConnectionType(Protocol):
 class AsyncTransactionalConnectionType(Protocol):
     """Async connections usable by the capability-gated transaction APIs.
 
-    Deliberately not part of ``AsyncConnectionType``: not every async driver can support
-    connection-level transactions (e.g. aiopg is autocommit-only and its ``commit()``/``rollback()``
-    raise), so requiring these members on every async connection would structurally break
-    connections that cannot support them. Command classes gate access behind
+    Deliberately not part of ``AsyncConnectionType``: not every async driver can honor
+    connection-level transactions at runtime — aiopg is autocommit-only, and although its
+    ``commit()``/``rollback()`` exist (structurally satisfying this protocol), they raise — and a
+    driver may omit the members entirely. Folding them into the base protocol would imply every
+    async connection supports transactions; command classes gate access behind
     ``AdapterCapability.TRANSACTIONS`` instead.
     """
 

--- a/pydapper/types.py
+++ b/pydapper/types.py
@@ -58,6 +58,23 @@ class AsyncConnectionType(Protocol):
     async def cursor(self, *args: Optional[Any], **kwargs: Optional[Any]) -> "AsyncCursorType": ...
 
 
+class AsyncTransactionalConnectionType(Protocol):
+    """Async connections usable by the capability-gated transaction APIs.
+
+    Deliberately not part of ``AsyncConnectionType``: not every async driver can support
+    connection-level transactions (e.g. aiopg is autocommit-only and its ``commit()``/``rollback()``
+    raise), so requiring these members on every async connection would structurally break
+    connections that cannot support them. Command classes gate access behind
+    ``AdapterCapability.TRANSACTIONS`` instead.
+    """
+
+    @abstractmethod
+    async def commit(self) -> Any: ...
+
+    @abstractmethod
+    async def rollback(self) -> Any: ...
+
+
 class CursorType(Protocol):
     rowcount: int
 

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -105,7 +105,9 @@ class MiniDb:
         if match is None:
             raise MiniDbError(f"unsupported INSERT: {sql!r}")
         columns = tuple(part.strip() for part in match.group("cols").split(","))
-        self.rows.append(dict(zip(columns, params)))
+        # copy so a caller mutating its param objects after the insert cannot alias into
+        # rows (and, through a later commit, into the durable snapshot)
+        self.rows.append(copy.deepcopy(dict(zip(columns, params))))
         return 1
 
     def update(self, sql: str, params: Sequence[Any]) -> int:

--- a/tests/conformance_support.py
+++ b/tests/conformance_support.py
@@ -13,6 +13,7 @@ This module is test infrastructure, not part of the shipped helper. It provides:
   silently go stale.
 """
 
+import copy
 import re
 import sqlite3
 from dataclasses import dataclass
@@ -58,10 +59,23 @@ class MiniDbError(Exception):
 
 
 class MiniDb:
-    """A tiny pure-Python store understanding the conformance statement shapes."""
+    """A tiny pure-Python store understanding the conformance statement shapes.
+
+    Snapshot transactionality: ``commit()`` makes the current rows the durable state and
+    ``rollback()`` restores it, so the async transactions profile has a service-free live
+    backend. Reads never consult the snapshot — like the real drivers' default isolation,
+    uncommitted work is visible on the same connection until rolled back.
+    """
 
     def __init__(self, rows: Sequence[Tuple[Any, ...]] = ()) -> None:
         self.rows: List[Dict[str, Any]] = [dict(zip(_COLUMNS, row)) for row in rows]
+        self.committed: List[Dict[str, Any]] = copy.deepcopy(self.rows)
+
+    def commit(self) -> None:
+        self.committed = copy.deepcopy(self.rows)
+
+    def rollback(self) -> None:
+        self.rows = copy.deepcopy(self.committed)
 
     def _eval_where(self, where: Optional[str], row: Dict[str, Any], params: Sequence[Any]) -> bool:
         if where is None:
@@ -217,6 +231,12 @@ class FakeAsyncConnection:
 
     async def cursor(self, *args: Any, **kwargs: Any) -> FakeAsyncCursor:
         return FakeAsyncCursor(self.db)
+
+    async def commit(self) -> None:
+        self.db.commit()
+
+    async def rollback(self) -> None:
+        self.db.rollback()
 
     def close(self) -> None:
         self.closed = True

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -109,10 +109,10 @@ class MockAsyncConnection:
     async def cursor(self, *args, **kwargs):
         return MockAsyncCursor()
 
-    def commit(self):
+    async def commit(self):
         self.commits += 1
 
-    def rollback(self):
+    async def rollback(self):
         self.rollbacks += 1
 
     async def close(self):

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -1480,6 +1480,32 @@ def test_production_capability_catalog_ships_transactions_and_is_immutable():
         catalog[AdapterCapability.TRANSACTIONS] = None  # type: ignore[index]
 
 
+def test_sync_case_run_must_not_be_a_coroutine_function():
+    async def _async_body(ctx):
+        return None
+
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        ConformanceProfile(
+            profile_id="mode-mismatch",
+            capability=None,
+            sync_cases=(SyncCase("mismatch.sync", "d", "instrumented", _async_body),),
+        )
+    assert "must not be a coroutine function" in str(exc_info.value)
+
+
+def test_async_case_run_must_be_a_coroutine_function():
+    def _sync_body(ctx):
+        return None
+
+    with pytest.raises(ProfileDefinitionError) as exc_info:
+        ConformanceProfile(
+            profile_id="mode-mismatch",
+            capability=None,
+            async_cases=(AsyncCase("mismatch.async", "d", "instrumented", _sync_body),),
+        )
+    assert "must be a coroutine function" in str(exc_info.value)
+
+
 def test_zero_case_profile_is_rejected():
     with pytest.raises(ProfileDefinitionError) as exc_info:
         ConformanceProfile(profile_id="transactions", capability=AdapterCapability.TRANSACTIONS)
@@ -2808,10 +2834,11 @@ def test_core_sync_and_async_case_inventories_stay_in_parity():
 
 def test_transactions_profile_case_inventories_stay_in_parity():
     """The core parity guard above covers only the mandatory profiles; the transactions
-    capability profile promises the same nine case ids, order, and kinds in both modes."""
+    capability profile promises the same nine case ids, order, kinds, and descriptions in
+    both modes."""
     profile = capability_profiles()[AdapterCapability.TRANSACTIONS]
-    assert [(case.case_id, case.kind) for case in profile.sync_cases] == [
-        (case.case_id, case.kind) for case in profile.async_cases
+    assert [(case.case_id, case.kind, case.description) for case in profile.sync_cases] == [
+        (case.case_id, case.kind, case.description) for case in profile.async_cases
     ]
 
 

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -233,6 +233,17 @@ def test_non_declaring_adapter_is_never_run_against_the_transactions_profile(iso
     assert len(report.results) == len(core_sync_profile().sync_cases)
 
 
+@pytest.mark.asyncio
+async def test_async_non_declaring_adapter_is_never_run_against_the_transactions_profile(isolated_registry):
+    """The async twin of the exclusion proof above."""
+    _register_mock_async()
+    report = await run_core_async(MockAsyncConformanceHarness())
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    assert MockAsyncConformanceCommands.capabilities == frozenset()
+    assert [result for result in report.results if result.profile_id == "transactions"] == []
+    assert len(report.results) == len(core_async_profile().async_cases)
+
+
 def test_pass_fail_ordering_is_deterministic(isolated_registry):
     _register_mock_sync()
     first = run_core_sync(MockSyncConformanceHarness())
@@ -1463,8 +1474,7 @@ def test_production_capability_catalog_ships_transactions_and_is_immutable():
     assert profile.profile_id == "transactions"
     assert profile.capability is AdapterCapability.TRANSACTIONS
     assert profile.sync_cases, "the transactions profile must ship real sync cases"
-    # async transaction APIs have not landed; async cases arrive with that feature
-    assert profile.async_cases == ()
+    assert profile.async_cases, "the transactions profile must ship real async cases"
     validate_capability_catalog(catalog)
     with pytest.raises(TypeError):
         catalog[AdapterCapability.TRANSACTIONS] = None  # type: ignore[index]
@@ -2186,6 +2196,38 @@ def test_recording_connection_injects_commit_and_rollback_faults():
     assert connection.log.kinds() == ("commit", "rollback")
 
 
+@pytest.mark.asyncio
+async def test_recording_async_connection_records_commit_and_rollback():
+    connection = RecordingAsyncConnection()
+    assert connection.commit_calls == 0
+    assert connection.rollback_calls == 0
+
+    await connection.commit()
+    await connection.rollback()
+    await connection.rollback()
+    assert connection.commit_calls == 1
+    assert connection.rollback_calls == 2
+    assert connection.log.kinds() == ("commit", "rollback", "rollback")
+
+
+@pytest.mark.asyncio
+async def test_recording_async_connection_injects_commit_and_rollback_faults():
+    commit_fault = RuntimeError("commit boom")
+    rollback_fault = RuntimeError("rollback boom")
+    connection = RecordingAsyncConnection(commit_error=commit_fault, rollback_error=rollback_fault)
+
+    with pytest.raises(RuntimeError) as commit_info:
+        await connection.commit()
+    assert commit_info.value is commit_fault
+    with pytest.raises(RuntimeError) as rollback_info:
+        await connection.rollback()
+    assert rollback_info.value is rollback_fault
+    # the interaction is recorded even when it fails
+    assert connection.commit_calls == 1
+    assert connection.rollback_calls == 1
+    assert connection.log.kinds() == ("commit", "rollback")
+
+
 # ------------------------------------------------------------------ connect() cleanup tolerance
 
 
@@ -2664,10 +2706,11 @@ async def test_async_declared_capability_without_profile_fails_clearly(isolated_
 
 
 @pytest.mark.asyncio
-async def test_async_transactions_declaration_requires_async_cases(isolated_registry):
-    """Pins the #464 sequencing contract: the production transactions profile is
-    sync-only, so an async class may not declare TRANSACTIONS before the async
-    transaction APIs land with their async case inventory."""
+async def test_async_transactions_declaring_mock_harness_passes(isolated_registry):
+    """A TRANSACTIONS-declaring async adapter passes core conformance plus the production
+    transactions profile's async cases — the service-free live async coverage (MiniDb has
+    snapshot transactionality). The declared-with-no-cases-for-mode branch stays covered
+    capability-agnostically by the RAW_READER tests."""
     name = "conformance-mock-declared-txn-async"
     _register_mock_async(name=name, async_commands=_DeclaredTransactionsAsyncCommands)
 
@@ -2680,10 +2723,11 @@ async def test_async_transactions_declaration_requires_async_cases(isolated_regi
             return _DeclaredTransactionsAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
 
     report = await run_core_async(_Harness())
-    failed_ids = [failure.case_id for failure in report.failures]
-    assert failed_ids == ["capabilities.declared-profile-populated"], failed_ids
-    assert "has no async conformance cases" in report.failures[0].message
-    assert report.failures[0].profile_id == CORE_ASYNC
+    assert report.passed, [(f.case_id, f.message) for f in report.failures]
+    transaction_results = [result for result in report.results if result.profile_id == "transactions"]
+    expected_ids = [case.case_id for case in capability_profiles()[AdapterCapability.TRANSACTIONS].async_cases]
+    assert [result.case_id for result in transaction_results] == expected_ids
+    assert all(result.passed for result in transaction_results)
 
 
 @pytest.mark.asyncio
@@ -2760,6 +2804,15 @@ def test_core_sync_and_async_case_inventories_stay_in_parity():
         f"  documented sync-only ids no longer sync-only: {sorted(DOCUMENTED_SYNC_ONLY_CASE_IDS - sync_only)}\n"
         f"  documented async-only ids no longer async-only: {sorted(DOCUMENTED_ASYNC_ONLY_CASE_IDS - async_only)}"
     )
+
+
+def test_transactions_profile_case_inventories_stay_in_parity():
+    """The core parity guard above covers only the mandatory profiles; the transactions
+    capability profile promises the same nine case ids, order, and kinds in both modes."""
+    profile = capability_profiles()[AdapterCapability.TRANSACTIONS]
+    assert [(case.case_id, case.kind) for case in profile.sync_cases] == [
+        (case.case_id, case.kind) for case in profile.async_cases
+    ]
 
 
 # ------------------------------------------------------------------ case_ids filtering

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -5966,6 +5966,27 @@ class TestTransactions:
             with pytest.raises(RuntimeError, match="cannot be nested"):
                 second.__enter__()
 
+    def test_exiting_a_never_entered_context_manager_raises_without_touching_state(self, commands, connection):
+        # e.g. an ExitStack.push(...) where enter_context(...) was intended
+        cm = commands.transaction()
+        with pytest.raises(RuntimeError, match="never entered"):
+            cm.__exit__(None, None, None)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
+        # the guard was never touched, so a legitimate block still works
+        with commands.transaction():
+            pass
+        assert connection.commits == 1
+
+    def test_context_managers_are_single_use(self, commands, connection):
+        cm = commands.transaction()
+        with cm:
+            pass
+        with pytest.raises(RuntimeError, match="single-use"):
+            with cm:
+                pass  # pragma: no cover
+        assert connection.commits == 1
+
 
 class TestTransactionsAsync:
     @pytest.fixture
@@ -6171,3 +6192,27 @@ class TestTransactionsAsync:
         async with first:
             with pytest.raises(RuntimeError, match="cannot be nested"):
                 await second.__aenter__()
+
+    @pytest.mark.asyncio
+    async def test_exiting_a_never_entered_context_manager_raises_without_touching_state(self, commands, connection):
+        # e.g. an AsyncExitStack.push_async_exit(...) where enter_async_context(...) was
+        # intended — without the guard this would start the generator, set the nesting
+        # flag as a side effect, and (on 3.10) leave it stuck until finalization
+        cm = commands.transaction()
+        with pytest.raises(RuntimeError, match="never entered"):
+            await cm.__aexit__(None, None, None)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
+        async with commands.transaction():
+            pass
+        assert connection.commits == 1
+
+    @pytest.mark.asyncio
+    async def test_context_managers_are_single_use(self, commands, connection):
+        cm = commands.transaction()
+        async with cm:
+            pass
+        with pytest.raises(RuntimeError, match="single-use"):
+            async with cm:
+                pass  # pragma: no cover
+        assert connection.commits == 1

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -23,6 +23,7 @@ from pydapper.exceptions import NoResultException
 from pydapper.exceptions import PyDapperException
 from pydapper.exceptions import RowMappingException
 from pydapper.exceptions import UnsupportedFeatureError
+from pydapper.postgresql import AiopgCommands
 from tests.mocks import MockAsyncCommands
 from tests.mocks import MockAsyncConnection
 from tests.mocks import MockAsyncCursor
@@ -5964,3 +5965,209 @@ class TestTransactions:
         with first:
             with pytest.raises(RuntimeError, match="cannot be nested"):
                 second.__enter__()
+
+
+class TestTransactionsAsync:
+    @pytest.fixture
+    def connection(self):
+        return MockAsyncConnection()
+
+    @pytest.fixture
+    def undeclared_commands(self, connection):
+        return MockAsyncCommands(connection)
+
+    @pytest.fixture
+    def commands(self, connection):
+        class TransactionalCommandsAsync(MockAsyncCommands):
+            capabilities = frozenset({AdapterCapability.TRANSACTIONS})
+
+        return TransactionalCommandsAsync(connection)
+
+    # -- unsupported adapters -----------------------------------------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["commit", "rollback"])
+    async def test_undeclared_adapter_raises_on_await_before_touching_the_connection(
+        self, undeclared_commands, connection, method
+    ):
+        with pytest.raises(UnsupportedFeatureError) as exc_info:
+            await getattr(undeclared_commands, method)()
+        assert "transactions" in str(exc_info.value)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
+
+    def test_undeclared_adapter_transaction_raises_at_call_time_without_entering(self, undeclared_commands):
+        # the error comes from the bare call, before any context manager exists to enter
+        with pytest.raises(UnsupportedFeatureError):
+            undeclared_commands.transaction()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["commit", "rollback"])
+    async def test_aiopg_is_a_first_party_unsupported_adapter(self, connection, method):
+        # aiopg is autocommit-only (its connection commit/rollback raise), so its command
+        # class must reject the whole API before the connection is touched
+        commands = AiopgCommands(connection)
+        with pytest.raises(UnsupportedFeatureError) as exc_info:
+            await getattr(commands, method)()
+        assert "transactions" in str(exc_info.value)
+        assert connection.commits == 0
+        assert connection.rollbacks == 0
+
+    def test_aiopg_transaction_raises_at_call_time(self, connection):
+        with pytest.raises(UnsupportedFeatureError):
+            AiopgCommands(connection).transaction()
+
+    # -- commit / rollback delegation ---------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_commit_delegates_to_the_connection(self, commands, connection):
+        assert await commands.commit() is None
+        assert connection.commits == 1
+        assert connection.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_rollback_delegates_to_the_connection(self, commands, connection):
+        assert await commands.rollback() is None
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    # -- transaction() context manager ---------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_transaction_commits_on_clean_exit(self, commands, connection):
+        async with commands.transaction():
+            pass
+        assert connection.commits == 1
+        assert connection.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_transaction_yields_none(self, commands):
+        async with commands.transaction() as value:
+            assert value is None
+
+    @pytest.mark.asyncio
+    async def test_transaction_rolls_back_and_reraises_the_same_exception(self, commands, connection):
+        error = _TransactionBlockError("boom")
+        with pytest.raises(_TransactionBlockError) as exc_info:
+            async with commands.transaction():
+                raise error
+        assert exc_info.value is error
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    @pytest.mark.asyncio
+    async def test_transaction_rolls_back_on_base_exceptions(self, commands, connection):
+        with pytest.raises(KeyboardInterrupt):
+            async with commands.transaction():
+                raise KeyboardInterrupt
+        assert connection.rollbacks == 1
+        assert connection.commits == 0
+
+    @pytest.mark.asyncio
+    async def test_block_error_wins_over_a_rollback_failure(self, commands, connection):
+        async def failing_rollback():
+            raise RuntimeError("rollback boom")
+
+        connection.rollback = failing_rollback
+        error = _TransactionBlockError("boom")
+        with pytest.raises(_TransactionBlockError) as exc_info:
+            async with commands.transaction():
+                raise error
+        assert exc_info.value is error
+
+    @pytest.mark.asyncio
+    async def test_an_interrupt_raised_during_rollback_is_not_swallowed(self, commands, connection):
+        """The async twin of the sync policy: only an ordinary Exception from rollback
+        loses to the block's error; a BaseException propagates and beats it."""
+
+        async def interrupted_rollback():
+            raise KeyboardInterrupt("ctrl-c during rollback")
+
+        connection.rollback = interrupted_rollback
+        block_error = _TransactionBlockError("boom")
+        with pytest.raises(KeyboardInterrupt) as exc_info:
+            async with commands.transaction():
+                raise block_error
+        assert exc_info.value.__context__ is block_error, "the block's error must survive as __context__"
+
+    @pytest.mark.asyncio
+    async def test_a_cancellation_landing_during_rollback_is_not_swallowed(self, commands, connection):
+        """A task.cancel() that lands while the rollback await is suspended must cancel the
+        task — swallowing the CancelledError would make the task look like it ignored the
+        cancel and re-raise the block's error instead."""
+        rollback_started = asyncio.Event()
+
+        async def slow_rollback():
+            rollback_started.set()
+            await asyncio.sleep(10)
+
+        connection.rollback = slow_rollback
+
+        async def work():
+            async with commands.transaction():
+                raise _TransactionBlockError("boom")
+
+        task = asyncio.create_task(work())
+        await rollback_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled(), "the cancellation must win over the block's error"
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_on_clean_exit_propagates_without_rollback(self, commands, connection):
+        commit_error = RuntimeError("commit boom")
+
+        async def failing_commit():
+            raise commit_error
+
+        connection.commit = failing_commit
+        with pytest.raises(RuntimeError) as exc_info:
+            async with commands.transaction():
+                pass
+        assert exc_info.value is commit_error
+        assert connection.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_explicit_commit_inside_a_block_is_allowed(self, commands, connection):
+        async with commands.transaction():
+            await commands.commit()
+        assert connection.commits == 2
+
+    # -- nesting -------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_nested_transaction_blocks_raise(self, commands, connection):
+        with pytest.raises(RuntimeError, match="cannot be nested"):
+            async with commands.transaction():
+                async with commands.transaction():
+                    pass  # pragma: no cover
+        # the failed inner enter is not a block error: the outer block still rolls back
+        # because the RuntimeError propagates through it
+        assert connection.rollbacks == 1
+
+    @pytest.mark.asyncio
+    async def test_nesting_guard_resets_after_the_block_exits(self, commands, connection):
+        async with commands.transaction():
+            pass
+        async with commands.transaction():
+            pass
+        assert connection.commits == 2
+
+    @pytest.mark.asyncio
+    async def test_nesting_guard_resets_after_a_failed_block(self, commands, connection):
+        with pytest.raises(_TransactionBlockError):
+            async with commands.transaction():
+                raise _TransactionBlockError("boom")
+        async with commands.transaction():
+            pass
+        assert connection.commits == 1
+        assert connection.rollbacks == 1
+
+    @pytest.mark.asyncio
+    async def test_two_unentered_context_managers_cannot_both_enter(self, commands):
+        first = commands.transaction()
+        second = commands.transaction()
+        async with first:
+            with pytest.raises(RuntimeError, match="cannot be nested"):
+                await second.__aenter__()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -827,14 +827,14 @@ def test_connect_rejects_an_adapter_without_sync_support(adapter_registry):
     assert "sync" in str(exc_info.value)
 
 
-#: The exact capability set every first-party command class must declare. Sync classes
-#: implement the transaction APIs; the async transaction feature has not landed, and
-#: BigQuery's DBAPI cannot support transactions (commit() is a no-op, rollback() is absent).
+#: The exact capability set every first-party command class must declare. Sync classes and
+#: psycopg-async implement the transaction APIs; aiopg cannot (autocommit-only — its connection
+#: commit/rollback raise), and BigQuery's DBAPI cannot (commit() is a no-op, rollback() is absent).
 FIRST_PARTY_CAPABILITY_DECLARATIONS = {
     Sqlite3Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
     Psycopg2Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
     Psycopg3Commands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
-    Psycopg3CommandsAsync: frozenset(),
+    Psycopg3CommandsAsync: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
     AiopgCommands: frozenset(),
     MySqlConnectorPythonCommands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),
     PymssqlCommands: frozenset({pydapper.AdapterCapability.TRANSACTIONS}),

--- a/tests/test_postgresql/test_conformance.py
+++ b/tests/test_postgresql/test_conformance.py
@@ -143,7 +143,10 @@ def test_psycopg2_core_sync_conformance(server, db_port, database_name):
     harness = _Psycopg2ConformanceHarness(server, db_port, database_name)
     assert harness.adapter_name == entry.adapter_name
     assert harness.command_class is entry.command_class
-    run_core_sync(harness).raise_for_failures()
+    report = run_core_sync(harness)
+    report.raise_for_failures()
+    # profile planning is declaration-driven: prove the live run actually included it
+    assert any(result.profile_id == "transactions" for result in report.results)
 
 
 def test_psycopg3_core_sync_conformance(server, db_port, database_name):
@@ -151,7 +154,9 @@ def test_psycopg3_core_sync_conformance(server, db_port, database_name):
     harness = _Psycopg3SyncConformanceHarness(server, db_port, database_name)
     assert harness.adapter_name == entry.adapter_name
     assert harness.command_class is entry.command_class
-    run_core_sync(harness).raise_for_failures()
+    report = run_core_sync(harness)
+    report.raise_for_failures()
+    assert any(result.profile_id == "transactions" for result in report.results)
 
 
 @pytest.mark.asyncio
@@ -162,6 +167,7 @@ async def test_psycopg3_core_async_conformance(server, db_port, database_name):
     assert harness.command_class is entry.command_class
     report = await run_core_async(harness)
     report.raise_for_failures()
+    assert any(result.profile_id == "transactions" for result in report.results)
 
 
 @pytest.mark.asyncio

--- a/tests/test_postgresql/test_conformance.py
+++ b/tests/test_postgresql/test_conformance.py
@@ -104,6 +104,10 @@ class _Psycopg3AsyncConformanceHarness(AsyncAdapterHarness):
     async def teardown_commands(self, commands: CommandsAsync) -> None:
         try:
             await commands.connection.rollback()
+            # transaction-profile cases commit durable state; don't leave the table behind
+            with suppress(Exception):
+                await commands.execute_async(_DROP)
+                await commands.connection.commit()
         finally:
             await commands.connection.close()
 

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -2,6 +2,7 @@ import datetime
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
+from typing import AsyncContextManager
 from typing import AsyncGenerator
 from typing import ContextManager
 from typing import Dict
@@ -190,6 +191,15 @@ def transaction_api_types() -> None:
     assert_type(sync_commands.rollback(), None)
     assert_type(sync_commands.transaction(), ContextManager[None])
     with sync_commands.transaction() as handle:
+        assert_type(handle, None)
+
+
+async def transaction_api_async_types() -> None:
+    async_commands = cast(PydapperCommandsAsync, object())
+    assert_type(await async_commands.commit(), None)
+    assert_type(await async_commands.rollback(), None)
+    assert_type(async_commands.transaction(), AsyncContextManager[None])
+    async with async_commands.transaction() as handle:
         assert_type(handle, None)
 
 


### PR DESCRIPTION
## What changed and why

Implements #464 (milestone **v1 M3: Transactions**), the async mirror of #572: capability-gated transaction handling on `CommandsAsync`.

- **`CommandsAsync.commit()` / `rollback()`** are coroutines delegating to the connection's async `commit()`/`rollback()` (a new narrow `AsyncTransactionalConnectionType` protocol; `AsyncConnectionType` is unchanged because not every async driver can honor transactions at runtime — aiopg's commit/rollback exist but raise). **`transaction()`** is a plain method returning an async context manager (`@asynccontextmanager`), gated at call time; the coroutines gate when awaited — both before the connection is touched.
- **Naming**: the methods are deliberately **unsuffixed**, matching the issue's acceptance criteria and the in-class `cursor()`/`supports()` precedent. The mass rename of the remaining `*_async` methods (with deprecated 1.x aliases) is filed separately as #578.
- **Semantics are identical to sync**, including the cleanup policy #576 established: on a block exception the proxy rolls back and re-raises with an *ordinary* rollback `Exception` discarded and logged at `DEBUG`; a `BaseException` — notably an `asyncio.CancelledError` landing inside the rollback await — is never swallowed and propagates with the block error as its `__context__`. This exact hazard was caught by the adversarial review pass (details below).
- **Declarations**: `Psycopg3CommandsAsync` declares `TRANSACTIONS` (psycopg's async `commit`/`rollback` are coroutines). `AiopgCommands` stays undeclared — aiopg is autocommit-only and its connection-level `commit()`/`rollback()` raise — so it raises `UnsupportedFeatureError` before the connection is touched, honoring the roadmap's "aiopg autocommit belongs in its adapter, not the base class".
- **Conformance**: the `transactions` profile now ships **nine async cases mirroring the sync inventory case-for-case** (same ids, order, kinds — pinned by a new parity test). `RecordingAsyncConnection` gained async commit/rollback recording + fault injection. The repo's fake async driver (`MiniDb`) gained snapshot transactionality (`commit()` snapshots rows, `rollback()` restores), giving the async profile **service-free live coverage** under `-m core` via a declaring mock harness — there is no async sqlite, so psycopg-async would otherwise be the only (Docker-gated) coverage.
- The #463 sequencing sentinel ("an async class may not declare TRANSACTIONS before async cases exist") inverted by design and is replaced by the positive declaring-mock test; the declared-with-no-cases-for-mode branch stays covered by the capability-agnostic RAW_READER tests, and `test_every_declared_first_party_capability_has_a_populated_profile` now guards psycopg-async automatically.
- The psycopg3 async conformance harness teardown gained the durable-table cleanup its sync siblings got in #572 (live async cases commit durable state).

## Before / after

```python
# before: no transaction API on CommandsAsync — driver-specific, easy to get wrong
await commands.connection.commit()

# after: explicit, portable, honest about support
async with pydapper.connect_async(dsn) as db:
    async with db.transaction():
        await db.execute_async(insert_sql, params=task)
        await db.execute_async(update_sql, params=owner)   # commit together, roll back together

    await db.commit()      # explicit escape hatches
    await db.rollback()
# undeclared adapter (aiopg): UnsupportedFeatureError before the connection is touched
```

## Adversarial review

Two review rounds ran before pushing (same process as #572). Round 1 found one **critical** bug: the async proxy's rollback arm was `except BaseException: pass`, which swallowed a `task.cancel()` landing while the rollback await was suspended — the task completed with the block error instead of cancelling (`task.cancelled() == False`), breaking `wait_for`/`timeout`/TaskGroup semantics, and diverging from the sync proxy that #576 had just aligned with the cleanup policy. Fixed to mirror the sync arm exactly; two new unit tests pin the branch (`KeyboardInterrupt`-from-rollback with `__context__`, and a real `task.cancel()`-mid-rollback repro), verified to fail against the old code. Round 1 also surfaced docs wording issues (all fixed) and one documented asymmetry (an entered-but-abandoned async CM that escapes loop finalization leaves the nesting guard set — sync self-heals at GC; now stated in the docstring). Round 2 independently verified every finding closed, with zero flakes across 30 repeat runs of the new cancellation tests.

## Commands run

| Command | Result |
|---|---|
| `poetry run pytest -m core -W error::RuntimeWarning` | 1561 passed (includes service-free async profile coverage; no un-awaited coroutines) |
| `poetry run pytest -m sqlite` | 30 passed |
| `poetry run pytest -m postgresql` (live testcontainers) | 91 passed — psycopg-async runs the full nine-case async profile (4 live + 5 instrumented) against real Postgres; aiopg proves the non-declaring path |
| `poetry run mypy pydapper` / `poetry run mypy tests/type_tests.py` | clean |
| `poetry run black --check .` / `poetry run isort --check .` | clean |
| `poetry run mkdocs build --strict` | passes |

**Skipped**: `mysql` / `mssql` / `oracle` / `bigquery` markers — their command classes are sync-only or non-declaring, no adapter/harness file of theirs is touched, and the sync transaction cases they run are byte-identical.

## Public API / typing / docs impact

- New public methods `CommandsAsync.commit()`, `rollback()`, `transaction()`; type-test coverage added (`transaction_api_async_types`).
- New `AsyncTransactionalConnectionType` protocol (private-by-convention, like its sync twin; export audit is #484).
- Docs: `docs/transactions.md` reframed for both modes with two runnable async examples; capability tables in `docs/adapter_registration.md` / `docs/adapter_conformance.md` updated (psycopg-async → `transactions`; aiopg cell explains non-declaration); manual release-notes entry added.
- Follow-up filed: #578 (`*_async` mass rename with 1.x aliases, including the prepare-hook override trap).
- No new exports from the `pydapper` package root; no new dependencies.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
