### PR TITLE
feat: reject multi-statement SQL before it reaches the driver

### DIFF
--- a/docs/.multi_statement_sql.md
+++ b/docs/.multi_statement_sql.md
@@ -1,0 +1,42 @@
+## One Statement Per Call
+
+A pydapper command executes exactly one SQL statement. SQL containing more than one statement raises
+`MultipleStatementsError` before a cursor is acquired, so nothing reaches the driver — the refusal is the same on every
+adapter regardless of what that adapter's DBAPI would have done with the text.
+
+A single trailing `;` followed only by whitespace and comments terminates one statement and is accepted. Anything else
+after a top-level `;` — including a second `;` — is more than one statement and is refused.
+
+Detection is the same lexical scan pydapper already uses to find `?name?` placeholders, so a `;` inside single-quoted
+text, double-quoted text, a `--` line comment, or a `/* ... */` block comment is ordinary text and does not trip the
+guard. It is not a SQL parser and has no dialect awareness: a top-level `;` inside a PostgreSQL dollar-quoted body
+(`DO $$ ... ; ... $$`) or an Oracle anonymous PL/SQL block (`BEGIN ... ; ... END;`) is refused too.
+
+### Known limits
+
+Because it is a lexer and not a parser, the guard is not a security boundary on its own — it is a guard rail. It keys
+on a top-level `;`, and its notion of "literal" and "comment" is one fixed ANSI-flavored set rather than each server's
+own grammar. Two consequences worth knowing:
+
+* **A backslash before a closing quote currently hides a separator.** The scanner treats `\` as a string escape,
+  which is MySQL's rule but not PostgreSQL's, SQLite's, Oracle's, or SQL Server's. On those, `select 'a\'; drop table t`
+  is genuinely two statements and the guard **does not catch it**. This is the most important of the known gaps and is
+  the headline item of [#590](https://github.com/zschumacher/pydapper/issues/590).
+* **SQL Server does not need a `;` at all.** `select 1 as a insert into t values (1)` is two statements in one T-SQL
+  batch with no separator, and nothing lexical can see that. Detecting it needs a real parser, which pydapper
+  deliberately does not have.
+* **Dialect-specific literal forms are not recognized yet**, so a `;` inside a MySQL backtick identifier, a T-SQL
+  bracket identifier, a MySQL `#` comment, or some BigQuery triple-quoted strings is currently misread — in either
+  direction. Also tracked in [#590](https://github.com/zschumacher/pydapper/issues/590).
+
+Parameter binding, not this guard, is what actually protects you from injection: pydapper never formats a value into
+the SQL string.
+
+Run scripts, PL/SQL blocks, and anything else that genuinely needs more than one statement against the DBAPI connection
+directly:
+
+```python
+with pydapper.connect(dsn) as commands:
+    cursor = commands.connection.cursor()
+    cursor.execute(plsql_block)
+```

--- a/docs/adapter_conformance.md
+++ b/docs/adapter_conformance.md
@@ -27,7 +27,8 @@ Each profile covers registration and selection, the #541 cursor lifecycle (clean
 failure, error precedence, truthy-exit non-suppression, plain and context-manager cursors, unbuffered
 exhaustion and explicit `close()`/`aclose()`), parameter handling and execution, row mapping and `RawRow`
 mappers, zero/one/many cardinality, scalar semantics (no row vs SQL `NULL` vs falsey values), command options,
-preparation-hook ordering, and capability honesty. Hook ordering is checked on every distinct command path that
+preparation-hook ordering, the [one-statement-per-call guard](methods/query.md#one-statement-per-call), and
+capability honesty. Hook ordering is checked on every distinct command path that
 owns a cursor — `execute`, buffered `query`, unbuffered `query`, `query_first`/`query_single`/`execute_scalar`,
 and `query_multiple` — because each opens its own cursor block: `_prepare_cursor` must run exactly once per
 command-owned cursor and `_prepare_command` exactly once per executed handler, both on the *entered* cursor and
@@ -40,6 +41,18 @@ Cases are either **live** (they run through your real database resources) or **i
 real concrete command class around framework-owned recording and fault-injection connections, so cursor counts,
 call order, exception precedence, and "fails before driver work" guarantees are observed directly rather than
 inferred from return values).
+
+Four of these mandatory cases certify the one-statement-per-call guard. They are core cases, not a capability
+profile: every adapter gets them and none can opt out. The two accept cases are deliberately **instrumented**
+rather than live, because whether a *server* tolerates a trailing `;` is dialect-specific (Oracle rejects it) —
+they pin that pydapper does not refuse the SQL, never that the database accepts it.
+
+| Case id | Kind | Pins |
+|---|---|---|
+| `sql.multi-statement-rejected` | live | every command entry point raises `MultipleStatementsError`, and the connection is still usable for a normal query afterwards |
+| `sql.multi-statement-before-driver-work` | instrumented | the raise happens with zero recorded driver events — no cursor acquired, nothing executed |
+| `sql.trailing-semicolon-accepted` | instrumented | one trailing `;` plus trailing whitespace and comments is not multi-statement, and the SQL reaches the driver unchanged |
+| `sql.separator-in-text-accepted` | instrumented | a `;` inside single-quoted text, double-quoted text, a `--` comment, or a `/* */` comment does not trip the guard and reaches the driver unchanged |
 
 ## Optional capability profiles
 
@@ -314,7 +327,7 @@ service or emulator is available.
 | `psycopg` | `Psycopg3Commands` | sync | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); the connection context manager commits on clean exit, rolls back on error, and then closes the connection |
 | `psycopg` | `Psycopg3CommandsAsync` | async | `transactions` | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage (including its synchronous cursor-factory normalization); live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); the connection context manager commits on clean exit, rolls back on error, and then closes the connection |
 | `aiopg` | `AiopgCommands` | async | *(none)* | `tests/test_postgresql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `postgresql` marker when Docker is available | [PostgreSQL](database_support/postgresql.md); aiopg is autocommit-only and emulates `executemany` by looping `execute`; its connection-level commit/rollback raise, so `transactions` is not declared even though the async APIs exist; its async context manager closes on exit (everything was already durable) |
-| `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes; the connection context manager only closes — exit never commits, uncommitted DML is discarded, and MySQL implicitly commits DDL statements (temporary tables excepted) |
+| `mysql` | `MySqlConnectorPythonCommands` | sync | `transactions` | `tests/test_mysql/test_conformance.py` | service-free instrumented + mock coverage (including its `query_first` unread-result drain); live suite under the `mysql` marker when Docker is available | [MySQL](database_support/mysql.md); unread results must be drained before a cursor closes; the connection context manager only closes — exit never commits, uncommitted DML is discarded, and MySQL implicitly commits DDL statements (temporary tables excepted); the driver enables `CLIENT_MULTI_STATEMENTS` by default, so pydapper clears it at connect time on connections it opens |
 | `pymssql` | `PymssqlCommands` | sync | `transactions` | `tests/test_mssql/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `mssql` marker when Docker is available | [Microsoft SQL Server](database_support/mssql.md); non-autocommit connections hold an always-open `BEGIN TRAN`, the context manager only closes, and `close()` implicitly rolls back all uncommitted work |
 | `oracledb` | `OracledbCommands` | sync | `transactions` | `tests/test_oracle/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `oracle` marker when Docker is available | [Oracle](database_support/oracle.md); unquoted identifiers fold to uppercase (`column_case="upper"`), and `''` is stored as NULL (`supports_empty_strings=False`); the connection context manager rolls back uncommitted work and closes — exit never commits — and Oracle implicitly commits DDL statements |
 | `google` | `GoogleBigqueryClientCommands` | sync | *(none)* | `tests/test_bigquery/test_conformance.py` | service-free instrumented + mock coverage; live suite under the `bigquery` marker when the emulator is available | [Google BigQuery](database_support/bigquery.md); the emulator's DML rowcounts are unreliable (`strict_rowcounts=False`), and the DBAPI cannot bind an untyped `None`, so the harness seeds the canonical SQL `NULL` note through a sentinel and a literal `UPDATE`; the DBAPI's `commit()` is a no-op and there is no `rollback()`, so `transactions` is not declared; the DBAPI connection has no context manager, so with-block exit performs no driver call |

--- a/docs/async_methods/execute_async.md
+++ b/docs/async_methods/execute_async.md
@@ -20,6 +20,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_execute.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 ## Example - Execute Insert
 ### Single
 Execute the INSERT statement a single time.

--- a/docs/async_methods/execute_scalar_async.md
+++ b/docs/async_methods/execute_scalar_async.md
@@ -15,6 +15,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 ## Cardinality
 - 0 rows: raises `NoResultException`.
 - 1+ rows: returns the first column of the first row.

--- a/docs/async_methods/query_async.md
+++ b/docs/async_methods/query_async.md
@@ -16,6 +16,8 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## Cardinality

--- a/docs/async_methods/query_first_async.md
+++ b/docs/async_methods/query_first_async.md
@@ -15,6 +15,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/async_methods/query_first_or_default_async.md
+++ b/docs/async_methods/query_first_or_default_async.md
@@ -18,6 +18,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/async_methods/query_multiple_async.md
+++ b/docs/async_methods/query_multiple_async.md
@@ -17,6 +17,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## Batch validation and atomicity

--- a/docs/async_methods/query_single_async.md
+++ b/docs/async_methods/query_single_async.md
@@ -16,6 +16,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/async_methods/query_single_or_default_async.md
+++ b/docs/async_methods/query_single_or_default_async.md
@@ -18,6 +18,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/database_support/mysql.md
+++ b/docs/database_support/mysql.md
@@ -78,3 +78,45 @@ committed.
 
 See [Transactions](../transactions.md) and
 [Context manager semantics](intro.md#context-manager-semantics) for the cross-driver picture.
+
+### Multi-statement SQL
+
+`mysql-connector-python` negotiates `CLIENT_MULTI_STATEMENTS` by default, which lets the server execute a whole
+batch of statements from one `execute()` call. pydapper does not want that capability on the wire, so
+**connections pydapper opens clear the flag at connect time** — `pydapper.connect("mysql://...")` passes
+`client_flags` that unset `CLIENT_MULTI_STATEMENTS`. (There is no async MySQL adapter; `mysql` registers a
+sync command class only.)
+
+The flag is cleared even when you supply your own `client_flags`:
+
+```python
+from mysql.connector.constants import ClientFlag
+
+# your FOUND_ROWS is kept; MULTI_STATEMENTS is cleared regardless
+pydapper.connect(dsn, client_flags=[ClientFlag.FOUND_ROWS])
+```
+
+| Your `client_flags` | What pydapper sends |
+|---|---|
+| omitted, `None`, `0`, or `False` | `[-MULTI_STATEMENTS]` |
+| a `list` or `tuple` | your entries, with `-MULTI_STATEMENTS` appended last |
+| a `list` or `tuple` that is empty | `[-MULTI_STATEMENTS]` |
+| a **positive** `int` with other bits set | the same `int` with only that bit masked off |
+| exactly `MULTI_STATEMENTS` | `ValueError` |
+| any other falsy value (`''`, `set()`, `{}`) | `ValueError` |
+| a negative `int`, or any other truthy value | forwarded unchanged, so the driver raises its own error |
+
+Because pydapper always passes `client_flags`, it wins over a `client_flags` set in a `my.cnf` read through
+`option_files` — the driver applies an option-file value only when the key is absent from the connect arguments. If you
+keep flags in an option file, pass them to `connect()` instead; pydapper preserves them and appends only the denial.
+
+The two `ValueError` cases exist because the driver resolves this option as
+`config["client_flags"] or ClientFlag.get_default()`, and that default **has `MULTI_STATEMENTS` set**. Anything
+falsy therefore skips the driver's own validation and silently re-enables the flag, so pydapper refuses rather
+than sending a value it knows will be ignored. If you asked for `MULTI_STATEMENTS` and nothing else, there is no
+honest answer — pass other flags alongside it, or open the connection yourself and use `using()`.
+
+Connect-time denial covers only connections pydapper opens. A connection you build yourself and hand to
+[`using()`](#example-using) keeps whatever flags you negotiated — the
+[one-statement-per-call guard](../methods/query.md#one-statement-per-call) still applies to commands run through
+it, which is why both halves exist.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,13 @@ Why would I use *pydapper*?
   Why not use SQL instead?
 
 **Safe from SQL injection**
-: pydapper provides a consistent syntax for declaring query parameters and guarantees it is converted to the safest
-  possible parameter substitution for the dbapi to deter SQL injection
+: pydapper provides a consistent syntax for declaring query parameters, and guarantees that parameter values are handed
+  to the dbapi as parameters and are never formatted into the SQL string by pydapper. How a given dbapi then binds
+  those values — server-side parameters, or escaping and quoting them client-side — is the driver's own business.
+  On top of that, pydapper refuses SQL that contains more than one statement, raising `MultipleStatementsError` before
+  the SQL reaches the driver. That check is a lexical guard rail rather than a parser, so it is defense in depth and
+  not a substitute for parameter binding; see
+  [One statement per call](methods/query.md#one-statement-per-call) for what it does and does not catch.
   Parameter placeholders use the form `?name?`, where `name` starts with an ASCII letter or underscore and then contains
   only ASCII letters, numbers, or underscores. Placeholder-shaped text inside single-quoted text, double-quoted text,
   `--` line comments, and `/* ... */` block comments is ignored; PostgreSQL dollar-quoted strings are not special-cased

--- a/docs/methods/execute.md
+++ b/docs/methods/execute.md
@@ -22,6 +22,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_execute.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 ## Example - Execute Insert
 ### Single
 Execute the INSERT statement a single time.

--- a/docs/methods/execute_scalar.md
+++ b/docs/methods/execute_scalar.md
@@ -15,6 +15,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 ## Cardinality
 - 0 rows: raises `NoResultException`.
 - 1+ rows: returns the first column of the first row.

--- a/docs/methods/query.md
+++ b/docs/methods/query.md
@@ -16,6 +16,8 @@
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## Cardinality

--- a/docs/methods/query_first.md
+++ b/docs/methods/query_first.md
@@ -15,6 +15,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/methods/query_first_or_default.md
+++ b/docs/methods/query_first_or_default.md
@@ -18,6 +18,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/methods/query_multiple.md
+++ b/docs/methods/query_multiple.md
@@ -17,6 +17,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## Batch validation and atomicity

--- a/docs/methods/query_single.md
+++ b/docs/methods/query_single.md
@@ -16,6 +16,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/methods/query_single_or_default.md
+++ b/docs/methods/query_single_or_default.md
@@ -18,6 +18,8 @@ All command methods also accept keyword-only `options=`; see [Command options](.
 
 {!docs/.parameter_shapes_read.md!}
 
+{!docs/.multi_statement_sql.md!}
+
 {!docs/.row_mapping.md!}
 
 ## First, Single and Default

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,21 @@
 ## Latest Changes
 
+* v1: reject multi-statement SQL before it reaches the driver. A pydapper command now executes exactly
+  one SQL statement: SQL containing more than one raises the new `MultipleStatementsError` before a
+  cursor is acquired, so nothing reaches the DBAPI. Previously the outcome was whatever the driver
+  happened to do and no adapter raised — `psycopg2` returned the rows of the *last* statement,
+  `psycopg` the rows of the *first*, `mysql-connector-python` executed every statement including
+  appended DDL, and `sqlite3` raised a driver error whose type varies by Python version (on 3.10, a
+  `sqlite3.Warning`, which is not a `sqlite3.Error`). Detection is a
+  lexical scan sharing the placeholder scanner's skip set, not a SQL parser: a `;` inside single-quoted
+  text, double-quoted text, a `--` line comment, or a `/* ... */` block comment is ordinary text, and a
+  single trailing `;` followed only by whitespace and comments is still one statement. The guard runs
+  in `BaseSqlParamHandler.__init__`, so it covers every sync and async command entry point on every
+  first-party and third-party adapter, and it is certified by four new mandatory cases in the
+  `core-sync` and `core-async` conformance profiles (62 cases per mode, up from 58). MySQL additionally
+  denies the capability on the wire: connections pydapper opens now clear `CLIENT_MULTI_STATEMENTS` at
+  connect time. Scripts and PL/SQL blocks belong on the DBAPI connection directly — see
+  [One statement per call](methods/query.md#one-statement-per-call).
 * fix: close block-exit gaps in the transactions conformance profile. PR [#582](https://github.com/zschumacher/pydapper/pull/582) by [@zschumacher](https://github.com/zschumacher).
 * fix: close three block-exit gaps in the `transactions` conformance profile found by an adversarial
   sweep of the milestone. Each was confirmed by mutating the runtime and watching the suite stay
@@ -238,6 +254,45 @@
 
 ### Breaking Changes
 
+* Multi-statement SQL now raises `MultipleStatementsError` on every adapter instead of being handed to
+  the driver. SQL that previously "worked" by accident behaves differently everywhere: on `psycopg2`
+  and `aiopg` `db.query("select 1 as a; select 2 as b")` returned `[{'b': 2}]`, on `psycopg` it
+  returned `[{'a': 1}]`, on `mysql-connector-python` every appended statement executed, and on
+  `sqlite3` it raised a driver error whose type depends on the Python version — on 3.10 a
+  `sqlite3.Warning`, which `except sqlite3.Error` cannot catch. All of them now
+  raise before a cursor is acquired. Split the statements into separate calls, or run the script
+  against the DBAPI connection directly (`commands.connection.cursor()`).
+* `mysql-connector-python` connections opened by pydapper no longer negotiate `CLIENT_MULTI_STATEMENTS`.
+  `pydapper.connect("mysql://...")` now passes `client_flags` clearing that bit, and clears it even when
+  you supply your own: a list or tuple keeps your entries and has the denial appended, and a positive
+  `int` is passed through with only that bit masked off. Code that relied on sending a statement batch
+  through a pydapper-opened MySQL connection — including through a raw cursor taken off
+  `commands.connection` — now gets the server's own syntax error. Open your own connection and pass it to
+  `using()` to keep the flag. Two kinds of input now raise `ValueError` instead of connecting:
+  `client_flags` equal to exactly `CLIENT_MULTI_STATEMENTS`, and falsy values that are neither an integer,
+  `None`, nor an empty list or tuple (`''`, `set()`, `{}`). Both are cases where the driver resolves
+  `client_flags or ClientFlag.get_default()` and would silently restore a default that has the flag set,
+  so pydapper refuses rather than negotiating a capability it just denied. `None`, `0`, `False`, and an
+  empty list or tuple are all read as "use the default" and resolve to the denial. One consequence: because
+  pydapper always passes `client_flags`, a `client_flags` entry in a `my.cnf` loaded via `option_files` is
+  now ignored — the driver only applies option-file values for keys absent from the connect arguments. Pass
+  those flags to `connect()` instead and pydapper will preserve them.
+* The guard's notion of "literal" and "comment" is one fixed ANSI-flavored set, so SQL using
+  dialect-specific forms can now be refused even though it is a single statement. Confirmed cases: a `;`
+  inside a `mysql` backtick identifier (``select `a;b` from t``) or a `pymssql` bracket identifier
+  (`select [a;b] from t`), and a `mysql` `#` comment following a trailing semicolon
+  (`select 1 as a; # done`). Rewrite the identifier or comment, or use a `--` comment. Making the literal
+  forms per-adapter is tracked in [#590](https://github.com/zschumacher/pydapper/issues/590).
+* `sql` must now be a `str`. `bytes` and `bytearray` previously reached the driver — and, because the
+  scanner is a `str` lexer, bypassed the multi-statement guard entirely — and now raise `TypeError`
+  before any driver work. Decode the value before passing it.
+* A top-level `;` inside a PostgreSQL dollar-quoted body (`psycopg2`, `psycopg`) or an Oracle anonymous
+  PL/SQL block (`oracledb`) is now rejected. The guard is lexical and has no dialect awareness, so
+  `DO $$ ... ; ... $$` and `BEGIN ... ; ... END;` trip it even though they are one statement to the
+  server. This is deliberate: the alternative — exempting SQL by leading keyword — would let
+  `BEGIN; select 1; commit;` through on the default PostgreSQL adapter, which is the exact shape the
+  guard exists to stop. Run these blocks on the DBAPI connection directly:
+  `commands.connection.cursor().execute(plsql_block)`.
 * DSNs now follow the focused `<database>[+<adapter>]://...` v1 grammar. Incidental inherited conveniences such as
   `name=value` strings, constructor default injection, dict-like mutation, tuple-style iteration or indexing,
   environment helpers, and multiple hosts are intentionally not reproduced. Multi-plus input such as

--- a/pydapper/_sql_placeholders.py
+++ b/pydapper/_sql_placeholders.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 PlaceholderSpan = Tuple[int, int, str]
@@ -42,6 +43,35 @@ def _skip_block_comment(sql: str, start: int) -> int:
             return index + 2
         index += 1
     return len(sql)
+
+
+#: Whitespace allowed after a trailing ``;``. Deliberately much narrower than ``str.isspace()``:
+#: SQLite treats a trailing ``U+000B`` and every Unicode space as the start of a *second* statement,
+#: so counting those as whitespace would let one through. This is exactly SQLite's and PostgreSQL's
+#: set; MySQL additionally allows ``U+000B``, which is refused here. Erring narrow is the safe
+#: direction -- anything outside this set ends the continuation scan, i.e. refuses rather than admits.
+_SQL_WHITESPACE = " \t\n\r\f"
+
+
+def _skip_whitespace_and_comments(sql: str, start: int) -> int:
+    index = start
+    while index < len(sql):
+        char = sql[index]
+
+        if char in _SQL_WHITESPACE:
+            index += 1
+            continue
+
+        if char == "-" and index + 1 < len(sql) and sql[index + 1] == "-":
+            index = _skip_line_comment(sql, index)
+            continue
+
+        if char == "/" and index + 1 < len(sql) and sql[index + 1] == "*":
+            index = _skip_block_comment(sql, index)
+            continue
+
+        break
+    return index
 
 
 def _is_malformed_placeholder_boundary(char: str) -> bool:
@@ -131,3 +161,42 @@ def scan_placeholder_spans(sql: str) -> Tuple[PlaceholderSpan, ...]:
         index += 1
 
     return tuple(spans)
+
+
+def find_statement_separator(sql: str) -> Optional[int]:
+    """Return the index of the first statement separator that starts a second statement.
+
+    A single trailing ``;`` followed only by whitespace and comments terminates one statement and
+    returns ``None``. Semicolons inside quoted text or comments are ordinary characters, using the
+    same skip set as :func:`scan_placeholder_spans`.
+    """
+    index = 0
+    sql_length = len(sql)
+
+    while index < sql_length:
+        char = sql[index]
+
+        if char == "'":
+            index = _skip_quoted_sql_text(sql, index, "'")
+            continue
+
+        if char == '"':
+            index = _skip_quoted_sql_text(sql, index, '"')
+            continue
+
+        if char == "-" and index + 1 < sql_length and sql[index + 1] == "-":
+            index = _skip_line_comment(sql, index)
+            continue
+
+        if char == "/" and index + 1 < sql_length and sql[index + 1] == "*":
+            index = _skip_block_comment(sql, index)
+            continue
+
+        if char == ";":
+            if _skip_whitespace_and_comments(sql, index + 1) == sql_length:
+                return None
+            return index
+
+        index += 1
+
+    return None

--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -31,6 +31,7 @@ from ._context import _AwaitableAsyncContextManager
 from ._context import _close_quietly
 from ._context import _log_discarded_cleanup_error
 from ._sql_placeholders import PlaceholderSpan
+from ._sql_placeholders import find_statement_separator
 from ._sql_placeholders import scan_placeholder_spans
 from .capabilities import AdapterCapability
 from .command_options import CommandKind
@@ -39,6 +40,7 @@ from .exceptions import DuplicateColumnException
 from .exceptions import InvalidParameterShapeException
 from .exceptions import MissingParameterException
 from .exceptions import MoreThanOneResultException
+from .exceptions import MultipleStatementsError
 from .exceptions import NoResultException
 from .exceptions import UnsupportedFeatureError
 from .rows import RawRow
@@ -152,6 +154,17 @@ def _raise_if_list_params_for_read(param: Any) -> None:
         raise InvalidParameterShapeException("Top-level list params are only supported by execute and execute_async.")
 
 
+def _raise_if_multi_statement(sql: str) -> None:
+    # the scanner is a str lexer: indexing bytes yields ints, so every character comparison in it
+    # would silently be False and the guard would pass anything non-str straight to the driver
+    if not isinstance(sql, str):
+        raise TypeError(f"sql must be a str, got {type(sql).__name__}.")
+
+    separator_index = find_statement_separator(sql)
+    if separator_index is not None:
+        raise MultipleStatementsError(sql, separator_index)
+
+
 def _fetch_at_most_two_rows(cursor: "CursorType") -> Tuple[Any, ...]:
     fetchmany = getattr(cursor, "fetchmany", None)
     if callable(fetchmany):
@@ -233,6 +246,7 @@ def _get_param_value(param: Any, param_name: str) -> Any:
 
 class BaseSqlParamHandler(ABC):
     def __init__(self, sql: str, param: Union["ParamType", "ListParamType"] = None):
+        _raise_if_multi_statement(sql)
         self._sql = sql
         self._param = param
         self.ordered_param_values: Union[Tuple[Any, ...], List[Tuple[Any, ...]], Tuple] = (
@@ -604,10 +618,10 @@ class Commands(BaseCommands, ABC):
     def execute(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
         resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         if _is_empty_executemany_params(resolved_params):
             return 0
 
-        handler = self.SqlParamHandler(sql, resolved_params)
         with self._cursor_context_proxy() as cursor:
             self._prepare_cursor(cursor, options=resolved_options)
             self._prepare_command(cursor, handler, options=resolved_options)
@@ -2007,10 +2021,10 @@ class CommandsAsync(BaseCommands, ABC):
     async def execute_async(self, sql, params=_PARAM_ALIAS_UNSET, *, param=_PARAM_ALIAS_UNSET, options=None):
         resolved_options = self._resolve_options(options)
         resolved_params = self._resolve_params(param, params)
+        handler = self.SqlParamHandler(sql, resolved_params)
         if _is_empty_executemany_params(resolved_params):
             return 0
 
-        handler = self.SqlParamHandler(sql, resolved_params)
         async with self.cursor() as cursor:
             await self._prepare_cursor_async(cursor, options=resolved_options)
             await self._prepare_command_async(cursor, handler, options=resolved_options)

--- a/pydapper/exceptions.py
+++ b/pydapper/exceptions.py
@@ -1,4 +1,6 @@
 from collections.abc import Sequence
+from typing import Any
+from typing import Tuple
 
 
 class PyDapperException(Exception):
@@ -19,6 +21,23 @@ class MissingParameterException(PyDapperException):
 
 class InvalidParameterShapeException(PyDapperException):
     pass
+
+
+class MultipleStatementsError(PyDapperException):
+    def __init__(self, sql: str, separator_index: int) -> None:
+        self.sql = sql
+        self.separator_index = separator_index
+        super().__init__(
+            f"A command executes exactly one SQL statement, but a statement separator was found at "
+            f"character index {separator_index}. A single trailing ';' is allowed. Run scripts and "
+            "multi-statement blocks against the DBAPI connection directly."
+        )
+
+    def __reduce__(self) -> Tuple[Any, Tuple[Any, ...]]:
+        # the default Exception reduction replays __init__ with the built message as its only
+        # argument, which this two-argument signature rejects; without this the error cannot cross
+        # a process boundary (ProcessPoolExecutor, celery) or survive copy.copy/deepcopy
+        return (self.__class__, (self.sql, self.separator_index))
 
 
 class UnsupportedFeatureError(PyDapperException):

--- a/pydapper/mysql/mysql_connector_python.py
+++ b/pydapper/mysql/mysql_connector_python.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import ClassVar
 
 from pydapper.capabilities import AdapterCapability
@@ -18,6 +19,61 @@ from ..utils import validate_no_duplicate_columns
 if TYPE_CHECKING:
     from ..dsn_parser import PydapperParseResult
     from ..types import CursorType
+
+
+_UNSET = object()
+
+
+def _resolve_client_flags(mysql: Any, caller_value: Any) -> Any:
+    """Clear ``CLIENT_MULTI_STATEMENTS`` from the flags pydapper negotiates at connect time.
+
+    pydapper refuses multi-statement SQL before the driver is reached, so the capability is denied on
+    the wire too. The driver's setter treats a positive ``int`` as a wholesale replacement of its
+    default and a ``list``/``tuple`` as an ordered sequence applied over the current value, so an
+    ``int`` is masked rather than list-wrapped.
+
+    The critical constraint is that the result must never be **falsy**. ``MySQLConnectionAbstract.config``
+    resolves the option as ``config["client_flags"] or ClientFlag.get_default()``, and the default has
+    ``MULTI_STATEMENTS`` set, so any falsy value silently re-enables the very capability this denies --
+    and never reaches the setter that would otherwise have rejected it. The driver's own
+    ``DEFAULT_CONFIGURATION["client_flags"]`` is ``0``, so falsy values are not hypothetical.
+    """
+    multi_statements = mysql.constants.ClientFlag.MULTI_STATEMENTS
+
+    # `None` and `0` are both the driver's own spelling of "use the default"
+    if caller_value is _UNSET or caller_value is None:
+        return [-multi_statements]
+
+    if isinstance(caller_value, (list, tuple)):
+        return [*caller_value, -multi_statements]
+
+    if isinstance(caller_value, int):
+        if caller_value == 0:
+            return [-multi_statements]
+
+        if caller_value < 0:
+            # truthy, so it reaches the driver's setter, which rejects it; that error is the driver's
+            return caller_value
+
+        resolved = caller_value & ~multi_statements
+        if resolved == 0:
+            raise ValueError(
+                "client_flags requested CLIENT_MULTI_STATEMENTS and nothing else, which pydapper does "
+                "not negotiate. Clearing it would leave no flags, and mysql-connector-python reads an "
+                "empty client_flags as 'use the driver default', which enables it again. Pass other "
+                "flags alongside it, or open the connection yourself and use pydapper.using()."
+            )
+        return resolved
+
+    if not caller_value:
+        raise ValueError(
+            f"client_flags={caller_value!r} is not a supported value. mysql-connector-python reads a "
+            "falsy client_flags as 'use the driver default', which enables CLIENT_MULTI_STATEMENTS; "
+            "pydapper does not negotiate it. Pass an int, list, or tuple of ClientFlag values."
+        )
+
+    # truthy and unsupported: the driver raises its own ProgrammingError
+    return caller_value
 
 
 def _discard_unread_result(cursor: "CursorType") -> None:
@@ -60,6 +116,7 @@ class MySqlConnectorPythonCommands(Commands):
     @classmethod
     def connect(cls, parsed_dsn: "PydapperParseResult", **connect_kwargs) -> "Commands":
         mysql = import_dbapi_module("mysql.connector")
+        connect_kwargs["client_flags"] = _resolve_client_flags(mysql, connect_kwargs.get("client_flags", _UNSET))
         conn = mysql.connect(
             host=parsed_dsn.host,
             port=parsed_dsn.port if parsed_dsn else 3306,

--- a/pydapper/testing/adapter_conformance/_cases_async.py
+++ b/pydapper/testing/adapter_conformance/_cases_async.py
@@ -23,6 +23,7 @@ from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import MultipleStatementsError
 from pydapper.exceptions import NoResultException
 from pydapper.exceptions import UnsupportedFeatureError
 from pydapper.rows import RawRow
@@ -827,6 +828,119 @@ async def _execute_nested_list(ctx: AsyncCaseContext) -> None:
         len(bound) == 2 and bound[1] == [1, 2, 3],
         f"a nested list must bind as one value; driver saw {bound!r}",
     )
+
+
+# --------------------------------------------------------------------------------------
+# one statement per call
+# --------------------------------------------------------------------------------------
+
+
+_MULTI_STATEMENT_ENTRY_POINTS: Tuple[Tuple[str, Callable[[Any, str], Any]], ...] = (
+    ("execute_async", lambda commands, sql: commands.execute_async(sql)),
+    ("execute_async(params=[...])", lambda commands, sql: commands.execute_async(sql, params=[{"id": 1}])),
+    ("execute_async(params=[])", lambda commands, sql: commands.execute_async(sql, params=[])),
+    ("query_async", lambda commands, sql: commands.query_async(sql)),
+    ("query_async(buffered=False)", lambda commands, sql: commands.query_async(sql, buffered=False)),
+    ("query_first_async", lambda commands, sql: commands.query_first_async(sql)),
+    ("query_first_or_default_async", lambda commands, sql: commands.query_first_or_default_async(sql, None)),
+    ("query_single_async", lambda commands, sql: commands.query_single_async(sql)),
+    ("query_single_or_default_async", lambda commands, sql: commands.query_single_or_default_async(sql, None)),
+    ("execute_scalar_async", lambda commands, sql: commands.execute_scalar_async(sql)),
+    ("query_multiple_async", lambda commands, sql: commands.query_multiple_async((sql,))),
+)
+
+
+@_case(
+    "sql.multi-statement-rejected",
+    "Every command entry point refuses multi-statement SQL and the connection stays usable",
+    "live",
+)
+async def _sql_multi_statement_rejected(ctx: AsyncCaseContext) -> None:
+    commands = await ctx.create_commands()
+    select_all = ctx.sql("select_all")
+    multi_statement_sql = f"{select_all}; {select_all}"
+
+    for name, call in _MULTI_STATEMENT_ENTRY_POINTS:
+        with ctx.expect_raises(
+            MultipleStatementsError,
+            description=f"{name} must refuse multi-statement SQL",
+        ):
+            await call(commands, multi_statement_sql)
+
+    rows = await commands.query_async(select_all)
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"the connection must stay usable after a refusal; query returned {rows!r}")
+
+
+@_case(
+    "sql.multi-statement-before-driver-work",
+    "Multi-statement SQL is refused with zero driver work: no cursor acquired, nothing executed",
+    "instrumented",
+)
+async def _sql_multi_statement_before_driver_work(ctx: AsyncCaseContext) -> None:
+    for name, call in _MULTI_STATEMENT_ENTRY_POINTS:
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        with ctx.expect_raises(MultipleStatementsError, description=f"{name} must refuse multi-statement SQL"):
+            await call(commands, "SELECT id, label FROM t; DROP TABLE t")
+        ctx.check(
+            connection.cursor_calls == 0,
+            f"{name} must refuse before a cursor is acquired; saw {connection.cursor_calls} acquisitions",
+        )
+        ctx.check(
+            connection.log.events == [],
+            f"{name} must record no driver work; observed {connection.log.kinds()!r}",
+        )
+
+
+@_case(
+    "sql.trailing-semicolon-accepted",
+    "One trailing ';' with trailing whitespace and comments is not multi-statement and reaches the driver",
+    "instrumented",
+)
+async def _sql_trailing_semicolon_accepted(ctx: AsyncCaseContext) -> None:
+    # instrumented, not live: whether a *server* accepts a trailing ';' is dialect-specific (Oracle
+    # rejects it). This pins only that pydapper does not refuse the SQL and passes it through as written.
+    for sql in (
+        "SELECT id, label FROM t;",
+        "SELECT id, label FROM t;   \n\t",
+        "SELECT id, label FROM t; -- done",
+        "SELECT id, label FROM t; /* done */",
+    ):
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        await commands.query_async(sql)
+        execute_event = connection.log.first("execute")
+        if execute_event is None:
+            ctx.fail(f"a single trailing ';' must reach the driver; {sql!r} never executed")
+        ctx.check(
+            execute_event.sql == sql,
+            f"the guard must not rewrite SQL; driver saw {execute_event.sql!r}, expected {sql!r}",
+        )
+
+
+@_case(
+    "sql.separator-in-text-accepted",
+    "A ';' inside quoted text or a comment is ordinary text and reaches the driver unchanged",
+    "instrumented",
+)
+async def _sql_separator_in_text_accepted(ctx: AsyncCaseContext) -> None:
+    for sql in (
+        "SELECT ';' FROM t",
+        'SELECT ";" FROM t',
+        "SELECT id, label FROM t -- ; DROP TABLE t",
+        "SELECT id, label FROM t /* ; DROP TABLE t */",
+    ):
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        await commands.query_async(sql)
+        execute_event = connection.log.first("execute")
+        if execute_event is None:
+            ctx.fail(f"a ';' inside text or a comment must not trip the guard; {sql!r} never executed")
+        ctx.check(
+            execute_event.sql == sql,
+            f"the guard must not rewrite SQL; driver saw {execute_event.sql!r}, expected {sql!r}",
+        )
 
 
 # --------------------------------------------------------------------------------------

--- a/pydapper/testing/adapter_conformance/_cases_sync.py
+++ b/pydapper/testing/adapter_conformance/_cases_sync.py
@@ -22,6 +22,7 @@ from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import MultipleStatementsError
 from pydapper.exceptions import NoResultException
 from pydapper.exceptions import UnsupportedFeatureError
 from pydapper.rows import RawRow
@@ -780,6 +781,119 @@ def _execute_nested_list(ctx: SyncCaseContext) -> None:
         len(bound) == 2 and bound[1] == [1, 2, 3],
         f"a nested list must bind as one value; driver saw {bound!r}",
     )
+
+
+# --------------------------------------------------------------------------------------
+# one statement per call
+# --------------------------------------------------------------------------------------
+
+
+_MULTI_STATEMENT_ENTRY_POINTS: Tuple[Tuple[str, Callable[[Any, str], Any]], ...] = (
+    ("execute", lambda commands, sql: commands.execute(sql)),
+    ("execute(params=[...])", lambda commands, sql: commands.execute(sql, params=[{"id": 1}])),
+    ("execute(params=[])", lambda commands, sql: commands.execute(sql, params=[])),
+    ("query", lambda commands, sql: commands.query(sql)),
+    ("query(buffered=False)", lambda commands, sql: commands.query(sql, buffered=False)),
+    ("query_first", lambda commands, sql: commands.query_first(sql)),
+    ("query_first_or_default", lambda commands, sql: commands.query_first_or_default(sql, None)),
+    ("query_single", lambda commands, sql: commands.query_single(sql)),
+    ("query_single_or_default", lambda commands, sql: commands.query_single_or_default(sql, None)),
+    ("execute_scalar", lambda commands, sql: commands.execute_scalar(sql)),
+    ("query_multiple", lambda commands, sql: commands.query_multiple((sql,))),
+)
+
+
+@_case(
+    "sql.multi-statement-rejected",
+    "Every command entry point refuses multi-statement SQL and the connection stays usable",
+    "live",
+)
+def _sql_multi_statement_rejected(ctx: SyncCaseContext) -> None:
+    commands = ctx.create_commands()
+    select_all = ctx.sql("select_all")
+    multi_statement_sql = f"{select_all}; {select_all}"
+
+    for name, call in _MULTI_STATEMENT_ENTRY_POINTS:
+        with ctx.expect_raises(
+            MultipleStatementsError,
+            description=f"{name} must refuse multi-statement SQL",
+        ):
+            call(commands, multi_statement_sql)
+
+    rows = commands.query(select_all)
+    expected = [dict(ctx.expected_row(row)) for row in ctx.seeded_rows()]
+    ctx.check(rows == expected, f"the connection must stay usable after a refusal; query returned {rows!r}")
+
+
+@_case(
+    "sql.multi-statement-before-driver-work",
+    "Multi-statement SQL is refused with zero driver work: no cursor acquired, nothing executed",
+    "instrumented",
+)
+def _sql_multi_statement_before_driver_work(ctx: SyncCaseContext) -> None:
+    for name, call in _MULTI_STATEMENT_ENTRY_POINTS:
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        with ctx.expect_raises(MultipleStatementsError, description=f"{name} must refuse multi-statement SQL"):
+            call(commands, "SELECT id, label FROM t; DROP TABLE t")
+        ctx.check(
+            connection.cursor_calls == 0,
+            f"{name} must refuse before a cursor is acquired; saw {connection.cursor_calls} acquisitions",
+        )
+        ctx.check(
+            connection.log.events == [],
+            f"{name} must record no driver work; observed {connection.log.kinds()!r}",
+        )
+
+
+@_case(
+    "sql.trailing-semicolon-accepted",
+    "One trailing ';' with trailing whitespace and comments is not multi-statement and reaches the driver",
+    "instrumented",
+)
+def _sql_trailing_semicolon_accepted(ctx: SyncCaseContext) -> None:
+    # instrumented, not live: whether a *server* accepts a trailing ';' is dialect-specific (Oracle
+    # rejects it). This pins only that pydapper does not refuse the SQL and passes it through as written.
+    for sql in (
+        "SELECT id, label FROM t;",
+        "SELECT id, label FROM t;   \n\t",
+        "SELECT id, label FROM t; -- done",
+        "SELECT id, label FROM t; /* done */",
+    ):
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        commands.query(sql)
+        execute_event = connection.log.first("execute")
+        if execute_event is None:
+            ctx.fail(f"a single trailing ';' must reach the driver; {sql!r} never executed")
+        ctx.check(
+            execute_event.sql == sql,
+            f"the guard must not rewrite SQL; driver saw {execute_event.sql!r}, expected {sql!r}",
+        )
+
+
+@_case(
+    "sql.separator-in-text-accepted",
+    "A ';' inside quoted text or a comment is ordinary text and reaches the driver unchanged",
+    "instrumented",
+)
+def _sql_separator_in_text_accepted(ctx: SyncCaseContext) -> None:
+    for sql in (
+        "SELECT ';' FROM t",
+        'SELECT ";" FROM t',
+        "SELECT id, label FROM t -- ; DROP TABLE t",
+        "SELECT id, label FROM t /* ; DROP TABLE t */",
+    ):
+        connection = ctx.recording_connection()
+        commands = ctx.instrumented_commands(connection)
+        commands.query(sql)
+        execute_event = connection.log.first("execute")
+        if execute_event is None:
+            ctx.fail(f"a ';' inside text or a comment must not trip the guard; {sql!r} never executed")
+        ctx.check(
+            execute_event.sql == sql,
+            f"the guard must not rewrite SQL; driver saw {execute_event.sql!r}, expected {sql!r}",
+        )
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -31,6 +31,7 @@ from pydapper._context import _AwaitableAsyncContextManager as _RealAwaitableAsy
 from pydapper.bigquery import GoogleBigqueryClientCommands
 from pydapper.capabilities import AdapterCapability
 from pydapper.command_options import CommandOptions
+from pydapper.commands import BaseSqlParamHandler
 from pydapper.commands import Commands
 from pydapper.exceptions import MoreThanOneResultException
 from pydapper.mssql import PymssqlCommands
@@ -104,6 +105,50 @@ TRANSACTION_CASE_IDS = (
     "transactions.commit-failure-propagates",
     "transactions.context-base-exception-rollback",
     "transactions.context-not-reentrant",
+)
+
+#: The four mandatory core cases that certify the one-statement-per-call guard. Unlike the
+#: transactions block above these are not a capability profile: they ship in `core-sync` and
+#: `core-async` and every adapter gets them. The core parity guard compares only the *sets* of
+#: case ids across modes, so this literal is what pins their order, kinds, and descriptions.
+SQL_GUARD_CASE_IDS = (
+    "sql.multi-statement-rejected",
+    "sql.multi-statement-before-driver-work",
+    "sql.trailing-semicolon-accepted",
+    "sql.separator-in-text-accepted",
+)
+
+SQL_GUARD_CASE_KINDS = ("live", "instrumented", "instrumented", "instrumented")
+
+#: The command entry points the two `sql.multi-statement-*` cases sweep. The cases iterate a module-level
+#: table in `_cases_sync.py`/`_cases_async.py`, so deleting a row there would silently shrink what
+#: "every command entry point raises" certifies without failing anything. This literal is what stops that.
+SQL_GUARD_SYNC_ENTRY_POINTS = (
+    "execute",
+    "execute(params=[...])",
+    "execute(params=[])",
+    "query",
+    "query(buffered=False)",
+    "query_first",
+    "query_first_or_default",
+    "query_single",
+    "query_single_or_default",
+    "execute_scalar",
+    "query_multiple",
+)
+
+SQL_GUARD_ASYNC_ENTRY_POINTS = (
+    "execute_async",
+    "execute_async(params=[...])",
+    "execute_async(params=[])",
+    "query_async",
+    "query_async(buffered=False)",
+    "query_first_async",
+    "query_first_or_default_async",
+    "query_single_async",
+    "query_single_or_default_async",
+    "execute_scalar_async",
+    "query_multiple_async",
 )
 
 
@@ -1341,6 +1386,79 @@ def test_query_path_hook_ordering_mutant_fails_its_named_case(isolated_registry,
             return commands_class(FakeSyncConnection(seeded_mini_db()))
 
     _assert_only_the_named_hook_case_failed(run_core_sync(_Harness()), mutant)
+
+
+# ------------------------------------------------------------------ sql guard negative control
+#
+# `BaseSqlParamHandler.__init__` is the single guard site and no first-party handler overrides
+# it. This mutant is what happens if one starts to: the class is conformant in every other
+# respect, so it must be caught by the two `sql.*` refusal cases and by nothing else.
+
+
+class _UnguardedParamHandler(BaseSqlParamHandler):
+    """A handler that rebuilds ``__init__`` without the multi-statement guard."""
+
+    def __init__(self, sql, param=None):
+        self._sql = sql
+        self._param = param
+        self.ordered_param_values = self._resolve_ordered_param_values()
+
+    def get_param_placeholder(self, param_name: str) -> str:
+        return "%s"
+
+
+class _UnguardedSyncCommands(MockSyncConformanceCommands):
+    SqlParamHandler = _UnguardedParamHandler
+
+
+class _UnguardedAsyncCommands(MockAsyncConformanceCommands):
+    SqlParamHandler = _UnguardedParamHandler
+
+
+def _assert_only_the_sql_guard_cases_failed(report):
+    """The mutant runs the FULL core profile, so this proves narrowness as well as detection."""
+    failed = {failure.case_id for failure in report.failures}
+    assert failed == {"sql.multi-statement-rejected", "sql.multi-statement-before-driver-work"}, (
+        "swallowing the guard must be caught by both refusal cases and must not disturb the "
+        f"accept cases; failures were {sorted(failed)}"
+    )
+    passed = {result.case_id for result in report.results if result.passed}
+    assert {"sql.trailing-semicolon-accepted", "sql.separator-in-text-accepted"} <= passed
+    named = next(f for f in report.failures if f.case_id == "sql.multi-statement-before-driver-work")
+    # failing the right case on the wrong assertion would prove nothing about what it pins
+    assert "must refuse multi-statement SQL" in named.message
+    assert "nothing was raised" in named.message
+
+
+def test_a_command_class_that_swallows_the_sql_guard_fails_its_named_case(isolated_registry):
+    name = "conformance-mock-unguarded-sql"
+    _register_mock_sync(name=name, commands=_UnguardedSyncCommands)
+
+    class _Harness(MockSyncConformanceHarness):
+        adapter_name = name
+        command_class = _UnguardedSyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        def create_commands(self):
+            return _UnguardedSyncCommands(FakeSyncConnection(seeded_mini_db()))
+
+    _assert_only_the_sql_guard_cases_failed(run_core_sync(_Harness()))
+
+
+@pytest.mark.asyncio
+async def test_an_async_command_class_that_swallows_the_sql_guard_fails_its_named_case(isolated_registry):
+    name = "conformance-mock-unguarded-sql-async"
+    _register_mock_async(name=name, async_commands=_UnguardedAsyncCommands)
+
+    class _Harness(MockAsyncConformanceHarness):
+        adapter_name = name
+        command_class = _UnguardedAsyncCommands
+        connect_dsn = f"sqlite+{name}://mock"
+
+        async def create_commands(self):
+            return _UnguardedAsyncCommands(FakeAsyncConnection(seeded_mini_db()))
+
+    _assert_only_the_sql_guard_cases_failed(await run_core_async(_Harness()))
 
 
 @pytest.mark.asyncio
@@ -2865,6 +2983,54 @@ def test_documented_transactions_cases_match_the_shipped_profile():
     documented = tuple(re.findall(r"^\| `(transactions\.[a-z-]+)` \|", text, flags=re.MULTILINE))
     assert documented == TRANSACTION_CASE_IDS
     assert f"{len(TRANSACTION_CASE_IDS)} cases per mode" in text
+
+
+def test_sql_guard_cases_are_exactly_the_named_cases_in_both_core_profiles():
+    """The core parity guard compares only sets of ids, so order, kinds, and descriptions are
+    pinned here or nowhere. These are mandatory core cases, not a capability profile, so a
+    rename, reorder, or deletion has to fail here rather than quietly weaken the baseline.
+    """
+    modes = (("sync", core_sync_profile().sync_cases), ("async", core_async_profile().async_cases))
+    descriptions = {}
+    for mode, cases in modes:
+        guard_cases = tuple(case for case in cases if case.case_id.startswith("sql."))
+        assert tuple(case.case_id for case in guard_cases) == SQL_GUARD_CASE_IDS, mode
+        assert tuple(case.kind for case in guard_cases) == SQL_GUARD_CASE_KINDS, mode
+        assert all(case.description for case in guard_cases), mode
+        # the group sits between the execute.* and rows.* groups in both modes
+        ids = [case.case_id for case in cases]
+        start = ids.index(SQL_GUARD_CASE_IDS[0])
+        assert ids[start - 1] == "execute.nested-list-single-value", mode
+        assert ids[start + len(SQL_GUARD_CASE_IDS)] == "rows.query-buffered", mode
+        descriptions[mode] = tuple(case.description for case in guard_cases)
+    assert descriptions["sync"] == descriptions["async"]
+
+
+def test_sql_guard_entry_point_sweep_is_exactly_the_named_entry_points():
+    """The sweep table is what makes "every command entry point" true; pin it literally.
+
+    Without this, deleting a row from either table leaves the case passing while certifying less,
+    and the sync/async pair could drift apart one method at a time.
+    """
+    from pydapper.testing.adapter_conformance import _cases_async
+    from pydapper.testing.adapter_conformance import _cases_sync
+
+    sync_names = tuple(name for name, _ in _cases_sync._MULTI_STATEMENT_ENTRY_POINTS)
+    async_names = tuple(name for name, _ in _cases_async._MULTI_STATEMENT_ENTRY_POINTS)
+    assert sync_names == SQL_GUARD_SYNC_ENTRY_POINTS
+    assert async_names == SQL_GUARD_ASYNC_ENTRY_POINTS
+    # the two modes must stay method-for-method mirrored, in the same order
+    assert tuple(name.replace("_async", "") for name in async_names) == sync_names
+    # every public read/write command method must appear; nothing may be quietly dropped
+    for required in ("execute", "query", "query_first", "query_single", "execute_scalar", "query_multiple"):
+        assert any(name == required or name.startswith(f"{required}(") for name in sync_names), required
+
+
+def test_documented_sql_guard_cases_match_the_shipped_profiles():
+    """The docs table is the public contract; it may not drift from the shipped inventory."""
+    text = (REPO_ROOT / "docs" / "adapter_conformance.md").read_text(encoding="utf-8")
+    documented = tuple(re.findall(r"^\| `(sql\.[a-z-]+)` \|", text, flags=re.MULTILINE))
+    assert documented == SQL_GUARD_CASE_IDS
 
 
 def test_sync_case_run_must_not_be_a_coroutine_function():

--- a/tests/test_adapter_units.py
+++ b/tests/test_adapter_units.py
@@ -40,6 +40,17 @@ class RecordingAsyncDbApi:
         return self.connection
 
 
+# mysql-connector-python is an optional extra, so the constant is mirrored rather than imported.
+# tests/test_mysql/test_mysql_connector_python.py pins this against the installed driver.
+MULTI_STATEMENTS = 65536
+
+
+class RecordingMySqlDbApi(RecordingDbApi):
+    """A ``mysql.connector`` stand-in that exposes the ``ClientFlag`` constants ``connect`` reads."""
+
+    constants = SimpleNamespace(ClientFlag=SimpleNamespace(MULTI_STATEMENTS=MULTI_STATEMENTS))
+
+
 def parsed_dsn(**overrides):
     values = {
         "host": "db-host",
@@ -132,7 +143,7 @@ def test_pymssql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
 def test_network_adapters_preserve_driver_default_behavior_for_an_absent_port(
     monkeypatch, module, commands_class, dbapi_name, dsn
 ):
-    dbapi = RecordingDbApi()
+    dbapi = RecordingMySqlDbApi() if module is mysql_module else RecordingDbApi()
     patch_dbapi_import(monkeypatch, module, dbapi_name, dbapi)
 
     commands_class.connect(PydapperParseResult(dsn))
@@ -141,7 +152,7 @@ def test_network_adapters_preserve_driver_default_behavior_for_an_absent_port(
 
 
 def test_mysql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
-    dbapi = RecordingDbApi()
+    dbapi = RecordingMySqlDbApi()
     import_calls = patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
 
     commands = mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), charset="utf8mb4")
@@ -156,9 +167,128 @@ def test_mysql_connect_imports_dbapi_and_wraps_connection(monkeypatch):
             "password": "password",
             "database": "app",
             "charset": "utf8mb4",
+            "client_flags": [-MULTI_STATEMENTS],
         }
     ]
     assert import_calls == ["mysql.connector"]
+
+
+def test_mysql_connect_denies_multi_statements_when_the_caller_passes_no_client_flags(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn())
+
+    assert dbapi.calls[0]["client_flags"] == [-MULTI_STATEMENTS]
+
+
+@pytest.mark.parametrize("caller_value", [[], [1, 2], (1, 2)])
+def test_mysql_connect_appends_the_denial_after_a_caller_sequence(monkeypatch, caller_value):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=caller_value)
+
+    assert dbapi.calls[0]["client_flags"] == [*caller_value, -MULTI_STATEMENTS]
+
+
+def test_mysql_connect_masks_the_bit_out_of_a_caller_int_without_list_wrapping(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=3383821)
+
+    resolved = dbapi.calls[0]["client_flags"]
+    assert resolved == 3383821 & ~MULTI_STATEMENTS
+    assert isinstance(resolved, int)
+    assert not resolved & MULTI_STATEMENTS
+
+
+def test_mysql_connect_leaves_an_int_without_the_bit_untouched(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=1)
+
+    assert dbapi.calls[0]["client_flags"] == 1
+
+
+# The driver resolves the option as `config["client_flags"] or ClientFlag.get_default()`, and that
+# default has MULTI_STATEMENTS set. A falsy resolved value therefore never reaches the setter and
+# silently re-enables the flag, so "never emit something falsy" is the property that actually
+# matters -- pinning individual inputs is not enough. tests/test_mysql/ pins the upstream `or`.
+_FALSY_CLIENT_FLAGS = [None, 0, False]
+
+
+@pytest.mark.parametrize("caller_value", _FALSY_CLIENT_FLAGS)
+def test_mysql_connect_treats_a_falsy_client_flags_as_absent(monkeypatch, caller_value):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=caller_value)
+
+    assert dbapi.calls[0]["client_flags"] == [-MULTI_STATEMENTS]
+
+
+def test_mysql_connect_rejects_client_flags_that_asks_only_for_multi_statements(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    # masking the bit would leave 0, which the driver reads as "use the default" -- re-enabling it
+    with pytest.raises(ValueError, match="CLIENT_MULTI_STATEMENTS and nothing else"):
+        mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=MULTI_STATEMENTS)
+
+    assert dbapi.calls == []
+
+
+@pytest.mark.parametrize("caller_value", [set(), "", {}, frozenset()])
+def test_mysql_connect_rejects_a_falsy_unsupported_client_flags_type(monkeypatch, caller_value):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    # a truthy unsupported type is the driver's error to raise, but a falsy one never reaches it
+    with pytest.raises(ValueError, match="not a supported value"):
+        mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=caller_value)
+
+    assert dbapi.calls == []
+
+
+def test_mysql_connect_forwards_a_negative_int_for_the_driver_to_reject(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    # negative ints are truthy, so they do reach the driver's setter, which rejects them
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=-MULTI_STATEMENTS)
+
+    assert dbapi.calls[0]["client_flags"] == -MULTI_STATEMENTS
+
+
+@pytest.mark.parametrize(
+    "caller_value",
+    [None, 0, False, [], (), [MULTI_STATEMENTS], (MULTI_STATEMENTS,), MULTI_STATEMENTS | 1, 3383821, 1],
+)
+def test_mysql_connect_never_resolves_client_flags_to_a_falsy_value(monkeypatch, caller_value):
+    """The fail-open invariant: whatever pydapper hands the driver must be truthy."""
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags=caller_value)
+
+    resolved = dbapi.calls[0]["client_flags"]
+    assert resolved, f"a falsy client_flags ({resolved!r}) makes the driver fall back to its default"
+    if isinstance(resolved, int):
+        assert not resolved & MULTI_STATEMENTS
+    else:
+        assert -MULTI_STATEMENTS in resolved
+
+
+def test_mysql_connect_forwards_an_unsupported_client_flags_type_for_the_driver_to_reject(monkeypatch):
+    dbapi = RecordingMySqlDbApi()
+    patch_dbapi_import(monkeypatch, mysql_module, "mysql.connector", dbapi)
+
+    mysql_module.MySqlConnectorPythonCommands.connect(parsed_dsn(), client_flags="not-a-flag")
+
+    assert dbapi.calls[0]["client_flags"] == "not-a-flag"
 
 
 class MySqlLifecycleCursor:

--- a/tests/test_commands_interface.py
+++ b/tests/test_commands_interface.py
@@ -12,6 +12,8 @@ import pytest
 import pydapper
 from pydapper import RawRow
 from pydapper._context import _AwaitableAsyncContextManager
+from pydapper._sql_placeholders import find_statement_separator
+from pydapper._sql_placeholders import scan_placeholder_spans
 from pydapper.bigquery import GoogleBigqueryClientCommands
 from pydapper.capabilities import AdapterCapability
 from pydapper.command_options import CommandKind
@@ -19,11 +21,14 @@ from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import MultipleStatementsError
 from pydapper.exceptions import NoResultException
 from pydapper.exceptions import PyDapperException
 from pydapper.exceptions import RowMappingException
 from pydapper.exceptions import UnsupportedFeatureError
 from pydapper.postgresql import AiopgCommands
+from pydapper.testing.adapter_conformance._instrumentation import RecordingAsyncConnection
+from pydapper.testing.adapter_conformance._instrumentation import RecordingConnection
 from tests.mocks import MockAsyncCommands
 from tests.mocks import MockAsyncConnection
 from tests.mocks import MockAsyncCursor
@@ -6255,3 +6260,377 @@ class TestTransactionsAsync:
             async with cm:
                 pass  # pragma: no cover
         assert connection.commits == 1
+
+
+MULTI_STATEMENT_SQL = "select 1 as a; select 2 as b"
+MULTI_STATEMENT_SEPARATOR_INDEX = 13
+
+# every string the separator scanner is pinned against, reused by the placeholder-drift assertion
+_SINGLE_STATEMENT_CORPUS = (
+    "select 1",
+    "select 1;",
+    "select 1;   ",
+    "select 1; -- trailing",
+    "select 1; /* trailing */",
+    "select 1;\n\t ",
+    "select 1; /* a */ -- b",
+    "select ';' as a",
+    'select ";" as a',
+    "select 'it''s ; here' as a",
+    'select "a "" ; b" as a',
+    "select 1 as a -- ; drop table t",
+    "select 1 as a /* ; drop table t */",
+)
+
+_MULTI_STATEMENT_CORPUS = (
+    (MULTI_STATEMENT_SQL, MULTI_STATEMENT_SEPARATOR_INDEX),
+    ("select 1; select 2", 8),
+    ("select 1;;", 8),
+    ("; select 1", 0),
+    ("select 1 /* c */ ; select 2", 17),
+    ("select 1; -- a\nselect 2", 8),
+    ("select 1; /* a */ select 2", 8),
+)
+
+
+class TestFindStatementSeparator:
+    @pytest.mark.parametrize("sql", _SINGLE_STATEMENT_CORPUS)
+    def test_one_statement_has_no_separator(self, sql):
+        assert find_statement_separator(sql) is None
+
+    @pytest.mark.parametrize(("sql", "expected"), _MULTI_STATEMENT_CORPUS)
+    def test_returns_the_index_of_the_first_offending_separator(self, sql, expected):
+        assert find_statement_separator(sql) == expected
+        assert sql[expected] == ";"
+
+    @pytest.mark.parametrize("char", [" ", "\t", "\n", "\r", "\f"])
+    def test_real_sql_whitespace_after_a_trailing_semicolon_is_accepted(self, char):
+        assert find_statement_separator(f"select 1 as a;{char}") is None
+
+    @pytest.mark.parametrize(
+        "char",
+        ["\v", "\x1c", "\x1d", "\x1e", "\x1f", "\x85", "\xa0", " ", " ", " ", " ", "　"],
+    )
+    def test_unicode_whitespace_after_a_trailing_semicolon_is_not_whitespace(self, char):
+        """``str.isspace()`` is far wider than SQL whitespace and using it let a statement through.
+
+        SQLite treats every one of these as the start of a second statement and raises
+        ``sqlite3.Warning`` -- which is not a ``sqlite3.Error`` -- so scanning them as trailing
+        whitespace reintroduced the exact bug this guard exists to eliminate.
+        """
+        assert char.isspace()
+        assert find_statement_separator(f"select 1 as a;{char}") == 13
+
+    def test_no_isspace_character_is_treated_as_trailing_whitespace_unless_sqlite_agrees(self):
+        # exhaustive over Unicode: the guard must never accept a trailer sqlite3 rejects
+        import sqlite3
+
+        for code_point in range(0x110000):
+            char = chr(code_point)
+            if not char.isspace():
+                continue
+            sql = f"select 1 as a;{char}"
+            connection = sqlite3.connect(":memory:")
+            try:
+                connection.execute(sql)
+            except BaseException:
+                assert find_statement_separator(sql) == 13, f"U+{code_point:04X} must not count as whitespace"
+            else:
+                assert find_statement_separator(sql) is None, f"U+{code_point:04X} must count as whitespace"
+            finally:
+                connection.close()
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            r"select 'a\'; drop table t",
+            r'select "a\"; drop table t',
+            r"select 'it\'s ; here' as a",
+        ],
+    )
+    def test_backslash_before_a_quote_is_a_known_false_negative(self, sql):
+        """KNOWN DEFECT, tracked in #590 -- this pins current behavior, not correct behavior.
+
+        ``_skip_quoted_sql_text`` treats ``\\`` as a string escape unconditionally. That is MySQL
+        semantics; PostgreSQL (``standard_conforming_strings=on``, the default since 9.1), SQLite,
+        Oracle, and T-SQL all treat it as an ordinary character, so ``'a\\'`` is a *complete* literal
+        and the following ``;`` really does start a second statement. The scanner instead runs to
+        end-of-string inside a literal that already closed and reports nothing.
+
+        Verified live: this shape drops a real table through ``query()`` on psycopg2. It is the
+        headline defect of #590; when that lands, this test flips to asserting an index.
+        """
+        assert find_statement_separator(sql) is None
+
+    @pytest.mark.parametrize("sql", ["select ';", 'select ";', "select 1 /* ;", "select 1 --;"])
+    def test_unterminated_quotes_and_comments_swallow_the_separator(self, sql):
+        # the placeholder scanner runs to end-of-string on these too; the two must not diverge
+        assert find_statement_separator(sql) is None
+
+    @pytest.mark.parametrize("sql", _SINGLE_STATEMENT_CORPUS + tuple(s for s, _ in _MULTI_STATEMENT_CORPUS))
+    def test_the_separator_corpus_holds_no_placeholders(self, sql):
+        assert scan_placeholder_spans(sql) == ()
+
+    @pytest.mark.parametrize(
+        ("sql", "expected_spans"),
+        [
+            ("select ?id?;", ((7, 11, "id"),)),
+            ("select ?id?; select ?name?", ((7, 11, "id"), (20, 26, "name"))),
+            ("select '?ignored?' as a; select ?id?", ((32, 36, "id"),)),
+            ("select ?id? -- ; ?ignored?", ((7, 11, "id"),)),
+        ],
+    )
+    def test_placeholder_scanning_is_unchanged_around_separators(self, sql, expected_spans):
+        # the guard is a sibling of scan_placeholder_spans; they share helpers, not behavior
+        assert scan_placeholder_spans(sql) == expected_spans
+
+
+def _sync_entry_points(commands, sql):
+    return {
+        "execute": lambda: commands.execute(sql),
+        "execute_list_params": lambda: commands.execute(sql, params=[{"id": 1}]),
+        "execute_empty_list_params": lambda: commands.execute(sql, params=[]),
+        "query_buffered": lambda: commands.query(sql),
+        "query_unbuffered": lambda: commands.query(sql, buffered=False),
+        "query_first": lambda: commands.query_first(sql),
+        "query_first_or_default": lambda: commands.query_first_or_default(sql, None),
+        "query_single": lambda: commands.query_single(sql),
+        "query_single_or_default": lambda: commands.query_single_or_default(sql, None),
+        "execute_scalar": lambda: commands.execute_scalar(sql),
+        "query_multiple": lambda: commands.query_multiple((sql,)),
+    }
+
+
+def _async_entry_points(commands, sql):
+    return {
+        "execute_async": lambda: commands.execute_async(sql),
+        "execute_async_list_params": lambda: commands.execute_async(sql, params=[{"id": 1}]),
+        "execute_async_empty_list_params": lambda: commands.execute_async(sql, params=[]),
+        "query_async_buffered": lambda: commands.query_async(sql),
+        "query_async_unbuffered": lambda: commands.query_async(sql, buffered=False),
+        "query_first_async": lambda: commands.query_first_async(sql),
+        "query_first_or_default_async": lambda: commands.query_first_or_default_async(sql, None),
+        "query_single_async": lambda: commands.query_single_async(sql),
+        "query_single_or_default_async": lambda: commands.query_single_or_default_async(sql, None),
+        "execute_scalar_async": lambda: commands.execute_scalar_async(sql),
+        "query_multiple_async": lambda: commands.query_multiple_async((sql,)),
+    }
+
+
+# Pinned literally rather than derived from the dicts above: deriving the parametrize list from the
+# very table under test means deleting an entry point silently shrinks the sweep instead of failing.
+SYNC_ENTRY_POINTS = (
+    "execute",
+    "execute_list_params",
+    "execute_empty_list_params",
+    "query_buffered",
+    "query_unbuffered",
+    "query_first",
+    "query_first_or_default",
+    "query_single",
+    "query_single_or_default",
+    "execute_scalar",
+    "query_multiple",
+)
+
+ASYNC_ENTRY_POINTS = (
+    "execute_async",
+    "execute_async_list_params",
+    "execute_async_empty_list_params",
+    "query_async_buffered",
+    "query_async_unbuffered",
+    "query_first_async",
+    "query_first_or_default_async",
+    "query_single_async",
+    "query_single_or_default_async",
+    "execute_scalar_async",
+    "query_multiple_async",
+)
+
+
+def test_the_entry_point_sweeps_cover_exactly_the_pinned_methods():
+    assert tuple(_sync_entry_points(None, "").keys()) == SYNC_ENTRY_POINTS
+    assert tuple(_async_entry_points(None, "").keys()) == ASYNC_ENTRY_POINTS
+
+
+class TestMultipleStatementsError:
+    def test_is_a_pydapper_exception_but_not_a_capability_gap(self):
+        error = MultipleStatementsError(MULTI_STATEMENT_SQL, MULTI_STATEMENT_SEPARATOR_INDEX)
+        assert isinstance(error, PyDapperException)
+        # #480 separates "pydapper refused" from "this adapter cannot"; the split is by type alone
+        assert not isinstance(error, UnsupportedFeatureError)
+
+    def test_carries_the_sql_and_the_separator_index(self):
+        error = MultipleStatementsError(MULTI_STATEMENT_SQL, MULTI_STATEMENT_SEPARATOR_INDEX)
+        assert error.sql == MULTI_STATEMENT_SQL
+        assert error.separator_index == MULTI_STATEMENT_SEPARATOR_INDEX
+
+    def test_survives_pickling_and_copying(self):
+        # a two-argument __init__ breaks the default Exception reduction, so the error could not
+        # cross a process boundary (ProcessPoolExecutor, celery) without __reduce__
+        import copy
+        import pickle
+
+        error = MultipleStatementsError(MULTI_STATEMENT_SQL, MULTI_STATEMENT_SEPARATOR_INDEX)
+        for restored in (pickle.loads(pickle.dumps(error)), copy.copy(error), copy.deepcopy(error)):
+            assert isinstance(restored, MultipleStatementsError)
+            assert restored.sql == MULTI_STATEMENT_SQL
+            assert restored.separator_index == MULTI_STATEMENT_SEPARATOR_INDEX
+            assert str(restored) == str(error)
+
+    def test_the_message_names_the_index_without_echoing_the_sql(self):
+        message = str(MultipleStatementsError(MULTI_STATEMENT_SQL, MULTI_STATEMENT_SEPARATOR_INDEX))
+        assert str(MULTI_STATEMENT_SEPARATOR_INDEX) in message
+        assert MULTI_STATEMENT_SQL not in message
+        assert "trailing ';' is allowed" in message
+        assert "DBAPI connection" in message
+        # psycopg2's own nextset text claims PostgreSQL cannot do this; it can, and we do not repeat it
+        assert "does not support" not in message
+
+    def test_the_raised_error_reports_the_index_of_the_offending_separator(self):
+        commands = MockCommands(MockConnection())
+        with pytest.raises(MultipleStatementsError) as exc_info:
+            commands.query(MULTI_STATEMENT_SQL)
+        assert exc_info.value.sql == MULTI_STATEMENT_SQL
+        assert exc_info.value.separator_index == MULTI_STATEMENT_SEPARATOR_INDEX
+
+
+class TestMultiStatementGuardSync:
+    @pytest.fixture
+    def connection(self):
+        return RecordingConnection()
+
+    @pytest.fixture
+    def commands(self, connection):
+        return MockCommands(connection)
+
+    @pytest.mark.parametrize("entry_point", SYNC_ENTRY_POINTS)
+    def test_every_entry_point_refuses_with_zero_driver_work(self, commands, connection, entry_point):
+        call = _sync_entry_points(commands, MULTI_STATEMENT_SQL)[entry_point]
+        with pytest.raises(MultipleStatementsError):
+            call()
+        # no cursor acquired, nothing executed, nothing entered, exited, or closed
+        assert connection.log.events == []
+        assert connection.cursor_calls == 0
+
+    @pytest.mark.parametrize("sql", [sql for sql, _ in _MULTI_STATEMENT_CORPUS])
+    def test_every_multi_statement_shape_is_refused(self, commands, sql):
+        with pytest.raises(MultipleStatementsError):
+            commands.query(sql)
+
+    def test_query_multiple_refuses_when_any_query_is_multi_statement(self, commands, connection):
+        # all handlers construct before the cursor block, so the second query never runs a first query
+        with pytest.raises(MultipleStatementsError):
+            commands.query_multiple(("select 1 as a", MULTI_STATEMENT_SQL))
+        assert connection.log.events == []
+
+    @pytest.mark.parametrize("sql", _SINGLE_STATEMENT_CORPUS)
+    def test_single_statement_sql_still_reaches_the_driver_unchanged(self, commands, connection, sql):
+        commands.execute(sql)
+        assert connection.log.of_kind("execute")[0].sql == sql
+
+    @pytest.mark.parametrize("sql", _SINGLE_STATEMENT_CORPUS)
+    def test_single_statement_sql_also_reaches_the_driver_unchanged_through_query(self, commands, connection, sql):
+        # the execute path above is the write side; a ';' in a literal or comment must be just as
+        # ordinary on the read side, which is the path the injection shape actually targets
+        commands.query(sql)
+        assert connection.log.of_kind("execute")[0].sql == sql
+
+    @pytest.mark.parametrize("payload", [b"select 1 as a; drop table t", bytearray(b"select 1; drop t")])
+    def test_non_str_sql_is_refused_before_any_driver_work(self, commands, connection, payload):
+        """Indexing bytes yields ints, so every comparison in the str scanner would be False.
+
+        Without an explicit type check the guard silently passes the payload to the driver, which
+        happily executes both statements. `param` already runtime-rejects these types.
+        """
+        with pytest.raises(TypeError, match="sql must be a str"):
+            commands.execute(payload)
+        assert connection.log.events == []
+        assert connection.cursor_calls == 0
+
+    def test_a_trailing_semicolon_still_queries(self, commands):
+        assert commands.query("select 1 as a;") == [{"id": 1, "label": "alpha"}, {"id": 2, "label": "beta"}]
+
+    def test_empty_executemany_params_are_still_a_no_op_for_legal_sql(self, commands, connection):
+        assert commands.execute("select 1 as a;", params=[]) == 0
+        # the guard now runs first, but the short-circuit still keeps the driver out of it
+        assert connection.log.events == []
+
+
+class TestMultiStatementGuardAsync:
+    @pytest.fixture
+    def connection(self):
+        return RecordingAsyncConnection()
+
+    @pytest.fixture
+    def commands(self, connection):
+        return MockAsyncCommands(connection)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("entry_point", ASYNC_ENTRY_POINTS)
+    async def test_every_entry_point_refuses_with_zero_driver_work(self, commands, connection, entry_point):
+        call = _async_entry_points(commands, MULTI_STATEMENT_SQL)[entry_point]
+        with pytest.raises(MultipleStatementsError):
+            await call()
+        assert connection.log.events == []
+        assert connection.cursor_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_query_multiple_async_refuses_when_any_query_is_multi_statement(self, commands, connection):
+        with pytest.raises(MultipleStatementsError):
+            await commands.query_multiple_async(("select 1 as a", MULTI_STATEMENT_SQL))
+        assert connection.log.events == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("sql", _SINGLE_STATEMENT_CORPUS)
+    async def test_single_statement_sql_still_reaches_the_driver_unchanged(self, commands, connection, sql):
+        await commands.execute_async(sql)
+        assert connection.log.of_kind("execute")[0].sql == sql
+
+    @pytest.mark.asyncio
+    async def test_empty_executemany_params_are_still_a_no_op_for_legal_sql(self, commands, connection):
+        assert await commands.execute_async("select 1 as a;", params=[]) == 0
+        assert connection.log.events == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [b"select 1 as a; drop table t", bytearray(b"select 1; drop t")])
+    async def test_non_str_sql_is_refused_before_any_driver_work(self, commands, connection, payload):
+        with pytest.raises(TypeError, match="sql must be a str"):
+            await commands.execute_async(payload)
+        assert connection.log.events == []
+        assert connection.cursor_calls == 0
+
+
+class TestMultiStatementGuardPrecedence:
+    """Pins where the guard sits among the pre-driver checks (issue #583's precedence table)."""
+
+    @pytest.fixture
+    def connection(self):
+        return RecordingConnection()
+
+    @pytest.fixture
+    def commands(self, connection):
+        return MockCommands(connection)
+
+    def test_unsupported_options_win(self, commands, connection):
+        with pytest.raises(UnsupportedFeatureError):
+            commands.query(MULTI_STATEMENT_SQL, options=pydapper.CommandOptions(max_rows=1))
+        assert connection.log.events == []
+
+    def test_the_param_alias_conflict_wins(self, commands):
+        with pytest.raises(ValueError, match="not both"):
+            commands.query(MULTI_STATEMENT_SQL, param={"id": 1}, params={"id": 1})
+
+    def test_a_top_level_list_on_a_read_path_wins(self, commands):
+        with pytest.raises(InvalidParameterShapeException):
+            commands.query(MULTI_STATEMENT_SQL, params=[{"id": 1}])
+
+    def test_the_model_mapper_conflict_wins(self, commands):
+        with pytest.raises(ValueError, match="not both"):
+            commands.query(MULTI_STATEMENT_SQL, model=dict, mapper=lambda row: row)
+
+    def test_the_guard_wins_over_a_missing_parameter(self, commands, connection):
+        # both are pre-driver, but the SQL is refused before its placeholder values are resolved
+        with pytest.raises(MultipleStatementsError):
+            commands.query("select ?id?; drop table t")
+        assert connection.log.events == []

--- a/tests/test_mysql/test_mysql_connector_python.py
+++ b/tests/test_mysql/test_mysql_connector_python.py
@@ -1,8 +1,11 @@
 import pytest
+from mysql.connector import ProgrammingError
 
 from pydapper import connect
 from pydapper import using
+from pydapper.exceptions import MultipleStatementsError
 from pydapper.mysql import MySqlConnectorPythonCommands
+from tests.test_adapter_units import MULTI_STATEMENTS
 from tests.test_suites.commands import ExecuteScalarTestSuite
 from tests.test_suites.commands import ExecuteTestSuite
 from tests.test_suites.commands import QueryFirstOrDefaultTestSuite
@@ -38,6 +41,122 @@ def test_using(server, database_name, db_port):
 def test_connect(driver, database_name, server, db_port):
     with connect(f"{driver}://pydapper:pydapper@{server}:{db_port}/{database_name}") as commands:
         assert isinstance(commands, MySqlConnectorPythonCommands)
+
+
+@pytest.fixture()
+def dsn(database_name, server, db_port):
+    return f"mysql://pydapper:pydapper@{server}:{db_port}/{database_name}"
+
+
+def test_the_mirrored_multi_statements_constant_matches_the_installed_driver():
+    """tests/test_adapter_units.py mirrors this value so the core suite needs no mysql extra."""
+    import mysql.connector
+
+    assert mysql.connector.constants.ClientFlag.MULTI_STATEMENTS == MULTI_STATEMENTS
+
+
+def test_connect_clears_multi_statements_on_the_wire(dsn):
+    with connect(dsn) as commands:
+        assert not commands.connection._client_flags & MULTI_STATEMENTS
+
+
+def test_connect_clears_multi_statements_even_when_the_caller_passes_client_flags(dsn):
+    import mysql.connector
+
+    found_rows = mysql.connector.constants.ClientFlag.FOUND_ROWS
+    with connect(dsn, client_flags=[found_rows]) as commands:
+        assert commands.connection._client_flags & found_rows
+        assert not commands.connection._client_flags & MULTI_STATEMENTS
+
+
+def test_the_driver_falls_back_to_a_multi_statement_default_on_a_falsy_client_flags():
+    """Pins the upstream behavior the resolution is built around.
+
+    ``MySQLConnectionAbstract.config`` resolves the option as ``config["client_flags"] or default``,
+    and that default enables ``MULTI_STATEMENTS``. Any falsy value therefore skips the setter and
+    silently re-enables the flag, which is why ``_resolve_client_flags`` never emits one. If a future
+    driver release changes either fact, this test fails and the resolution should be revisited.
+    """
+    import inspect
+
+    import mysql.connector
+    import mysql.connector.abstracts as abstracts
+    from mysql.connector.constants import ClientFlag
+
+    source = inspect.getsource(abstracts.MySQLConnectionAbstract.config)
+    assert 'self.client_flags = config["client_flags"] or default' in source
+    assert ClientFlag.get_default() & ClientFlag.MULTI_STATEMENTS
+    # the driver's own default configuration uses a falsy value, so this is not a hypothetical input
+    assert not mysql.connector.constants.DEFAULT_CONFIGURATION["client_flags"]
+
+
+@pytest.mark.parametrize("caller_value", [None, 0, False, []])
+def test_connect_clears_multi_statements_for_a_falsy_client_flags(dsn, caller_value):
+    with connect(dsn, client_flags=caller_value) as commands:
+        assert not commands.connection._client_flags & MULTI_STATEMENTS
+
+
+def test_connect_refuses_client_flags_that_asks_only_for_multi_statements(dsn):
+    with pytest.raises(ValueError, match="CLIENT_MULTI_STATEMENTS and nothing else"):
+        connect(dsn, client_flags=MULTI_STATEMENTS)
+
+
+def test_a_raw_cursor_on_a_pydapper_connection_cannot_run_a_batch_for_any_client_flags(dsn):
+    """The connect-time denial must hold for every input shape, not just the default one."""
+    for caller_value in (None, 0, False, [], [MULTI_STATEMENTS], MULTI_STATEMENTS | 1):
+        with connect(dsn, client_flags=caller_value) as commands:
+            assert not commands.connection._client_flags & MULTI_STATEMENTS, caller_value
+            cursor = commands.connection.cursor()
+            try:
+                with pytest.raises(ProgrammingError) as exc_info:
+                    cursor.execute("select 1 as a; select 2 as b")
+                    cursor.fetchall()
+                assert "1064" in str(exc_info.value), caller_value
+            finally:
+                cursor.close()
+
+
+def test_using_keeps_the_callers_own_flags(server, database_name, db_port):
+    """Connect-time denial covers only connections pydapper opens; ``using()`` keeps the caller's."""
+    import mysql.connector
+
+    conn = mysql.connector.connect(
+        host=server, port=db_port, user="pydapper", password="pydapper", database=database_name
+    )
+    with using(conn) as commands:
+        assert commands.connection._client_flags & MULTI_STATEMENTS
+
+
+def test_appended_statement_never_executes(dsn):
+    victim_sql = "select 1 as a; drop table multi_statement_victim;"
+
+    with connect(dsn) as setup:
+        setup.execute("drop table if exists multi_statement_victim")
+        setup.execute("create table multi_statement_victim (id int)")
+        setup.commit()
+
+    try:
+        with connect(dsn) as commands:
+            with pytest.raises(MultipleStatementsError):
+                commands.query(victim_sql)
+
+            # The pydapper guard is only half the contract. Bypassing it with a raw cursor on a
+            # connection pydapper opened must still fail, at the server, without dropping anything.
+            cursor = commands.connection.cursor()
+            try:
+                with pytest.raises(ProgrammingError) as exc_info:
+                    cursor.execute(victim_sql)
+                    cursor.fetchall()
+                assert "1064" in str(exc_info.value)
+            finally:
+                cursor.close()
+
+        with connect(dsn) as verify:
+            assert verify.execute_scalar("show tables like 'multi_statement_victim'") == "multi_statement_victim"
+    finally:
+        with connect(dsn) as cleanup:
+            cleanup.execute("drop table if exists multi_statement_victim")
+            cleanup.commit()
 
 
 class TestExecute(ExecuteTestSuite): ...

--- a/tests/test_mysql/test_mysql_connector_python.py
+++ b/tests/test_mysql/test_mysql_connector_python.py
@@ -1,5 +1,4 @@
 import pytest
-from mysql.connector import ProgrammingError
 
 from pydapper import connect
 from pydapper import using
@@ -103,6 +102,8 @@ def test_connect_refuses_client_flags_that_asks_only_for_multi_statements(dsn):
 
 def test_a_raw_cursor_on_a_pydapper_connection_cannot_run_a_batch_for_any_client_flags(dsn):
     """The connect-time denial must hold for every input shape, not just the default one."""
+    from mysql.connector import ProgrammingError
+
     for caller_value in (None, 0, False, [], [MULTI_STATEMENTS], MULTI_STATEMENTS | 1):
         with connect(dsn, client_flags=caller_value) as commands:
             assert not commands.connection._client_flags & MULTI_STATEMENTS, caller_value
@@ -128,6 +129,8 @@ def test_using_keeps_the_callers_own_flags(server, database_name, db_port):
 
 
 def test_appended_statement_never_executes(dsn):
+    from mysql.connector import ProgrammingError
+
     victim_sql = "select 1 as a; drop table multi_statement_victim;"
 
     with connect(dsn) as setup:

--- a/tests/test_oracle/test_conformance.py
+++ b/tests/test_oracle/test_conformance.py
@@ -18,6 +18,17 @@ _CREATE = (
 )
 
 
+def _run_plsql_block(commands: Commands, block: str) -> None:
+    """Run an anonymous PL/SQL block on the DBAPI cursor.
+
+    A pydapper command executes exactly one statement, and the guard is lexical: the top-level ';'
+    inside a ``BEGIN ... END;`` block trips it. Driving the cursor directly is the documented escape
+    hatch for blocks and scripts, and this harness is the first-party demonstration of it.
+    """
+    with commands.connection.cursor() as cursor:
+        cursor.execute(block)
+
+
 class _OracledbConformanceHarness(SyncAdapterHarness):
     adapter_name = "oracledb"
     command_class = OracledbCommands
@@ -35,7 +46,7 @@ class _OracledbConformanceHarness(SyncAdapterHarness):
         import oracledb
 
         commands = OracledbCommands(oracledb.connect(password="pydapper", user="pydapper", dsn=self._oracle_dsn))
-        commands.execute(_DROP)
+        _run_plsql_block(commands, _DROP)
         commands.execute(_CREATE)
         seed_through_adapter(commands, self.table_name, supports_empty_strings=False)
         commands.connection.commit()
@@ -44,7 +55,7 @@ class _OracledbConformanceHarness(SyncAdapterHarness):
     def teardown_commands(self, commands: Commands) -> None:
         with suppress(Exception):
             commands.connection.rollback()
-            commands.execute(_DROP)
+            _run_plsql_block(commands, _DROP)
         commands.connection.close()
 
 

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -30,6 +30,7 @@ from pydapper.exceptions import DuplicateColumnException
 from pydapper.exceptions import InvalidParameterShapeException
 from pydapper.exceptions import MissingParameterException
 from pydapper.exceptions import MoreThanOneResultException
+from pydapper.exceptions import MultipleStatementsError
 from pydapper.exceptions import NoResultException
 from pydapper.exceptions import PyDapperException
 from pydapper.exceptions import RowMappingException
@@ -138,6 +139,7 @@ def public_exceptions() -> None:
     assert_type(MoreThanOneResultException(), MoreThanOneResultException)
     assert_type(MissingParameterException(), MissingParameterException)
     assert_type(InvalidParameterShapeException(), InvalidParameterShapeException)
+    assert_type(MultipleStatementsError("select 1; select 2", 9), MultipleStatementsError)
     assert_type(UnsupportedFeatureError(), UnsupportedFeatureError)
     assert_type(RowMappingException(), RowMappingException)
 


### PR DESCRIPTION
Closes #583.

## What changed and why

pydapper handed any string straight to the DBAPI, so multi-statement SQL did whatever the driver happened to do — and no adapter raised. `psycopg2` and `aiopg` returned the rows of the **last** statement, `psycopg` the rows of the **first**, `mysql-connector-python` executed every statement including appended DDL, and `sqlite3` raised a `sqlite3.Warning`, which is not a `sqlite3.Error` and so escaped `except sqlite3.Error`. There was no pydapper-owned behavior at all.

This settles one contract: **a pydapper command executes exactly one SQL statement**, and SQL containing more than one is refused before any driver work happens.

Detection is a lexical scan, not a parser. It reuses the placeholder scanner's existing quote- and comment-skipping, so a `;` inside a string literal or comment is ordinary text and there is one rulebook rather than two. `scan_placeholder_spans` is byte-for-byte unchanged.

MySQL additionally denies the capability at the protocol level: `mysql-connector-python` enables `CLIENT_MULTI_STATEMENTS` by default, so a command-time scan alone would leave it live on the wire.

## Before / after

```python
with pydapper.connect("postgresql+psycopg2://...") as db:
    db.query("select 1 as a; select 2 as b")
```

| Adapter | Before | After |
|---|---|---|
| `psycopg2`, `aiopg` | `[{'b': 2}]` | `MultipleStatementsError` |
| `psycopg` | `[{'a': 1}]` | `MultipleStatementsError` |
| `mysql` | `[{'a': 1}]`, appended `drop table` **executed** | `MultipleStatementsError`, and the flag is off on the wire |
| `sqlite3` | `sqlite3.Warning` (not a `sqlite3.Error`) | `MultipleStatementsError` |

Still accepted, unchanged: `db.query("select 1 as a;")`, `db.query("select ';' as a")`, `db.query("select 1 as a -- ; drop table t")`.

## A correction to the issue's spec

The issue's `client_flags` table says an `int` masking to `0` yields a driver `ProgrammingError`. **That premise is false** and implementing it as written ships a fail-open.

`MySQLConnectionAbstract.config` resolves the option as `config["client_flags"] or default` *before* the setter runs, and `ClientFlag.get_default()` has `MULTI_STATEMENTS` set. Any falsy value therefore skips validation and restores a default that re-enables the flag. Verified live: with `client_flags=ClientFlag.MULTI_STATEMENTS`, a raw cursor on a pydapper-opened connection ran `select 1 as a; drop table victim;` and **dropped the table**. This is not exotic — the driver's own `DEFAULT_CONFIGURATION["client_flags"]` is `0`.

The governing rule implemented instead is *never hand the driver a falsy value*:

| Caller value | Resolved to |
|---|---|
| absent, `None`, `0`, `False` | `[-ClientFlag.MULTI_STATEMENTS]` |
| `list` / `tuple` | `[*caller_value, -ClientFlag.MULTI_STATEMENTS]` |
| `int` with other bits set | `caller_value & ~ClientFlag.MULTI_STATEMENTS` |
| `int` masking to `0` | `ValueError` |
| any other falsy value | `ValueError` |
| any other truthy value | forwarded unchanged; the driver raises its own error |

Full detail in [this comment on #583](https://github.com/zschumacher/pydapper/issues/583#issuecomment-5161559060). A live `mysql`-marked test pins the upstream `or default` behavior this reasoning depends on, so a future driver release that changes it fails the suite instead of silently reopening the hole.

## Public API and typing impact

- New `MultipleStatementsError(PyDapperException)` in `pydapper/exceptions.py`, exposing `.sql` and `.separator_index`. It is deliberately **not** an `UnsupportedFeatureError`: #480 must distinguish "pydapper refused by policy" from "this adapter cannot", by type alone. Not exported from `pydapper/__init__.py`, which re-exports no exceptions.
- **The overload cost of this change is zero.** No command signature changed and the 192 `@overload` declarations in `pydapper/commands.py` are untouched.
- Pinned in `tests/type_tests.py`.
- No new dependency; `pyproject.toml` and `poetry.lock` are untouched.

## Conformance

Four new **mandatory core** cases (not a capability profile, no `AdapterCapability` member, `capability_profiles()` untouched). `core_sync_profile()` and `core_async_profile()` go 58 → **62** cases each, identical in id, order, kind, and description.

| Case id | Kind |
|---|---|
| `sql.multi-statement-rejected` | live |
| `sql.multi-statement-before-driver-work` | instrumented |
| `sql.trailing-semicolon-accepted` | instrumented |
| `sql.separator-in-text-accepted` | instrumented |

The two accept cases are instrumented rather than live on purpose: whether a *server* tolerates a trailing `;` is dialect-specific (Oracle rejects it), so they pin that pydapper does not refuse the SQL, never that the database accepts it.

All nine first-party `(adapter, mode)` pairs re-certified against the enlarged profiles.

## Breaking changes

Three, recorded in `docs/release_notes.md`:

1. Multi-statement SQL now raises on every adapter.
2. `mysql-connector-python` connections pydapper opens no longer negotiate `CLIENT_MULTI_STATEMENTS`, and two `client_flags` inputs now raise `ValueError`.
3. A top-level `;` inside a PostgreSQL dollar-quoted body or an Oracle anonymous PL/SQL block is now rejected. The guard is lexical and dialect-agnostic; a leading-keyword exemption would let `BEGIN; select 1; commit;` through on the default PostgreSQL adapter, which is exactly the shape it exists to stop. The escape hatch is the DBAPI cursor.

The Oracle conformance harness was itself a caller of (3) — it seeded via `commands.execute(_DROP)` with a PL/SQL block. It now drives the cursor directly and is the first-party demonstration of the documented workaround. The issue's claim that no first-party caller is affected was based on an AST scan of inline literals, which missed it because the SQL is a module constant; a corrected scan resolving constants across `tests/`, `docs_src/`, and `pydapper/` found no others.

## Two more holes the review found and this PR closes

**Non-`str` `sql` bypassed the guard entirely.** The scanner is a `str` lexer, so indexing `bytes` yields `int`s, every character comparison is `False`, and it returned "no separator". Verified live: `db.execute(b"insert into t values (1); drop table t")` on psycopg2 executed **both** statements. `sql` must now be a `str`; `bytes`/`bytearray`/`memoryview` raise `TypeError` before any driver work. `param` already runtime-rejected these types — `sql` was the inconsistency.

**`str.isspace()` was too wide, and it reintroduced the exact bug this ticket exists to fix.** The trailing-`;` continuation scan accepted 24 Unicode whitespace characters that SQLite treats as the start of a second statement — so `db.query("select 1 as a;\v")` sailed past the guard and produced the bare `sqlite3.Warning` again. Now a literal `" \t\n\r\f"` set, which is exactly SQLite's and PostgreSQL's. Pinned by a test that is exhaustive over all 1,114,112 code points against real `sqlite3`.

## Known gaps, filed as #590

The scanner's skip set is ANSI-only, and this change made that load-bearing. Adversarial review found seven dialect gaps, all confirmed against live servers:

**False negatives** (a real second statement gets through) — `select 'a\'; drop table t`, because `\` is treated as a string escape unconditionally, which is wrong for PostgreSQL, T-SQL, Oracle, and SQLite; MySQL `--` not requiring trailing whitespace (`select 1--1 as a; drop table t`); and BigQuery triple-quoted strings containing a `"`.

**False positives** (legal SQL refused) — a `;` inside a MySQL backtick identifier, a T-SQL bracket identifier, or a MySQL `#` comment; nested block comments, which both PostgreSQL and SQL Server support; `\r` inside a `--` comment on SQLite/MySQL; and Oracle `q'[...]'` whose body contains an apostrophe.

The backslash case is the serious one — it drops a real table through `query()` on the **default** PostgreSQL adapter. All are recorded under "Known limits" in the new docs fragment and tracked in #590, which makes the literal forms per-dialect while staying a lexer: no parser, no dependency.

Note the test suite deliberately **pins the backslash behavior as a known defect** rather than asserting it is correct, so #590's fix will flip a named test rather than silently changing behavior.

Also out of reach for any lexical guard, and now documented as such: SQL Server executes `select 1 as a insert into t values (1)` as two statements with no separator at all.

## Commands run

All seven markers, on this branch:

| Command | Result |
|---|---|
| `pytest -m core` | 1837 passed |
| `pytest -m sqlite` | 34 passed |
| `pytest -m postgresql` | 101 passed |
| `pytest -m mysql` | 37 passed |
| `pytest -m mssql` | 31 passed |
| `pytest -m oracle` | 25 passed |
| `pytest -m bigquery` | 26 passed |
| `mypy pydapper` | clean, 41 source files |
| `mypy tests/type_tests.py` | clean |
| `black --check .` / `isort --check .` | clean |
| `mkdocs build --strict` | clean, no new nav entry |
| `git diff --check` | clean |

**No driver suite was skipped** — Docker and every optional extra were available locally, so `postgresql`, `mssql`, `oracle`, and `bigquery` all ran live in addition to the required `mysql` suite.

A **17-mutation sweep** was also run against the implementation: dead guard, trailing-`;` rule removed, guard call deleted, both `execute` reorders reverted, four `client_flags` regressions, conformance case-id rename, kind flip, entry-point-table deletions in both modes, `_SQL_WHITESPACE` widened back to `str.isspace()`, the non-`str` check removed, `__reduce__` removed, and an entry point dropped from the interface-test sweep. **All 17 were caught, none survived**; the tree was restored byte-identical afterwards.

## Review rounds

Two adversarial review passes ran before this was pushed, with refute-style reviewers across distinct lenses (scanner correctness, guard bypass-proofness, MySQL `client_flags`, test quality via mutation, docs accuracy, ticket compliance), then a second pass verifying every fix and hunting for regressions the fixes introduced. Details in the PR comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
